### PR TITLE
Fixed function name

### DIFF
--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -43,8 +43,7 @@ int main(int argc, char *argv[])
     sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP); 
     //Set socket nonblocking
     #ifdef WIN32
-    //I think this works for windows
-    ioctl(sock, FIONBIO, &mode);
+    ioctlsocket(sock, FIONBIO, &mode);
     #else
     fcntl(sock, F_SETFL, O_NONBLOCK, 1);
     #endif


### PR DESCRIPTION
The `ioctl` is actually named `ioctlsocket` on Windows.
Here: http://msdn.microsoft.com/en-us/library/windows/desktop/ms738573(v=vs.85).aspx

Now everything compiles on Windows.
gcc 4.7.2 (MinGW)
