### PR TITLE
Fixed cmake and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,22 @@ compiler:
 before_script:
   - git clone git://github.com/jedisct1/libsodium.git
   - cd libsodium
+  - git checkout tags/0.4.2
   - ./autogen.sh
-  - ./configure && make -j 3 check
+  - ./configure && make -j3 check
+  - sudo make install
+  - sudo ldconfig
   - cd ..
 
 script:
-  #- cmake CMakeLists.txt
-  #- make -j3
-   - gcc -o test -Wall -Werror -Ilibsodium/src/libsodium/include/ core/*.c libsodium/src/libsodium/.libs/libsodium.a testing/Messenger_test.c
+  - cmake CMakeLists.txt
+  - make -j3
 
 notifications:
   email: false
-  
+
   irc: 
     channels:
       - "chat.freenode.net#InsertProjectNameHere"
     on_success: always
     on_failure: always
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,31 @@
 cmake_minimum_required(VERSION 2.6.0)
 project(TOX C)
- 
+
+set(exe_name toxMessengerTest)
+
 set(core_sources
         core/DHT.c
         core/network.c
         core/Lossless_UDP.c
         core/net_crypto.c
         core/Messenger.c)
-	
+
 set(test_sources
         testing/Messenger_test.c)
-	
-set(exe_name TOX-app)
-
 
 add_executable(${exe_name}
-	${core_sources}
-	${test_sources})
+        ${core_sources}
+        ${test_sources})
 
 if(WIN32)
-	target_link_libraries(${exe_name} ws2_32 libsodium)
-else(WIN32)
-        target_link_libraries(libsodium)
-endif(WIN32)
+        include_directories(${TOX_SOURCE_DIR}/sodium/include/)
+        target_link_libraries(${exe_name} ws2_32 
+                ${CMAKE_SOURCE_DIR}/sodium/lib/libsodium.a)
+else()
+        target_link_libraries(${exe_name} sodium)
+endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
-	message(STATUS "==== GCC detected - Adding compiler flags")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+        message(STATUS "==== GCC detected - Adding compiler flags ====")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
 endif()


### PR DESCRIPTION
Travis uses libsodium 0.4.2 instead of head of the master branch of [the git repository](https://github.com/jedisct1/libsodium), which may be unstable.

The Windows build assumes that the `sodium` folder from [libsodium 0.4.2](https://download.libsodium.org/libsodium/releases/libsodium-win32-0.4.2.tar.gz) is contained in the repository root.
