### PR TITLE
Implemented a faster algorithm for generating nonces

### DIFF
--- a/core/net_crypto.c
+++ b/core/net_crypto.c
@@ -144,8 +144,9 @@ void random_nonce(uint8_t * nonce)
     uint32_t i, j, r, m = crypto_box_NONCEBYTES / 3, ind = 0;
     for(i = 0; i < m; ++i)
     {
-        r = ranom_int();
-        for (j = 0; j < 3; j++) {
+        r = random_int();
+        for (j = 0; j < 3; j++) 
+        {
             nonce[ind] = r % 1000 % 256;
             r /= 1000;
             ++ind;


### PR DESCRIPTION
I have done a demo of an algorithm I thought up for generating random nonces in Python so I could generate  a graph with matplotlib to show performance comparisons. See it at: http://goput.it/puye.png
Basically works by cutting the number of random numbers generated down to a third of the original, and slices sections of the full 32-bit int generated to get the smaller single-byte values.
