### PR TITLE
Implemented a faster algorithm for generating nonces

### DIFF
--- a/core/net_crypto.c
+++ b/core/net_crypto.c
@@ -144,7 +144,7 @@ void random_nonce(uint8_t * nonce)
     uint32_t i, temp;
     for (i = 0; i < crypto_box_NONCEBYTES / 4; ++i) 
     {
-        uint32_t temp = random_int();
+        temp = random_int();
         memcpy(nonce + 4 * i, &temp, 4);
     }
 }


### PR DESCRIPTION
I have done a demo of an algorithm I thought up for generating random nonces in Python so I could generate a graph with matplotlib to show performance comparisons. See it at: http://goput.it/puye.png
Basically works by cutting the number of random numbers generated down to a third of the original, and slices sections of the full 32-bit int generated to get the smaller single-byte values.
