### PR TITLE
Refactoring Messenger to provide nicer interface

### DIFF
--- a/core/Messenger.c
+++ b/core/Messenger.c
@@ -2,7 +2,7 @@
 *
 * An implementation of a simple text chat only messenger on the tox network core.
 *
- 
+
     Copyright (C) 2013 Tox project All Rights Reserved.
 
     This file is part of Tox.
@@ -19,41 +19,11 @@
 
     You should have received a copy of the GNU General Public License
     along with Tox.  If not, see <http://www.gnu.org/licenses/>.
-    
+
 */
 
 #include "Messenger.h"
-#define MIN(a,b) (((a)<(b))?(a):(b))
- 
-typedef struct
-{
-    uint8_t client_id[CLIENT_ID_SIZE];
-    int crypt_connection_id;
-    int friend_request_id; /* id of the friend request corresponding to the current friend request to the current friend. */
-    uint8_t status; /* 0 if no friend, 1 if added, 2 if friend request sent, 3 if confirmed friend, 4 if online. */
-    uint8_t info[MAX_DATA_SIZE]; /* the data that is sent during the friend requests we do */
-    uint8_t name[MAX_NAME_LENGTH];
-    uint8_t name_sent; /* 0 if we didn't send our name to this friend 1 if we have. */
-    uint8_t *userstatus;
-    uint16_t userstatus_length;
-    uint8_t userstatus_sent;
-    uint16_t info_size; /* length of the info */
-}Friend;
- 
 
-
-uint8_t self_public_key[crypto_box_PUBLICKEYBYTES];
-
-static uint8_t self_name[MAX_NAME_LENGTH];
-static uint8_t *self_userstatus;
-static uint16_t self_userstatus_len;
-
-#define MAX_NUM_FRIENDS 256
-
-static Friend friendlist[MAX_NUM_FRIENDS];
-
-static uint32_t numfriends;
- 
 /* 1 if we are online
    0 if we are offline
    static uint8_t online; */
@@ -61,14 +31,14 @@ static uint32_t numfriends;
 
 /* return the friend id associated to that public key.
    return -1 if no such friend */
-int getfriend_id(uint8_t * client_id)
+int getfriend_id(Messenger *m, uint8_t * client_id)
 {
     uint32_t i;
-    for(i = 0; i < numfriends; ++i)
+    for(i = 0; i < m->numfriends; ++i)
     {
-        if(friendlist[i].status > 0)
+        if(m->friendlist[i].status > 0)
         {
-            if(memcmp(client_id, friendlist[i].client_id, crypto_box_PUBLICKEYBYTES) == 0)
+            if(memcmp(client_id, m->friendlist[i].client_id, crypto_box_PUBLICKEYBYTES) == 0)
             {
                 return i;
             }
@@ -82,16 +52,16 @@ int getfriend_id(uint8_t * client_id)
    make sure that client_id is of size CLIENT_ID_SIZE.
    return 0 if success
    return -1 if failure. */
-int getclient_id(int friend_id, uint8_t * client_id)
+int getclient_id(Messenger *m, int friend_id, uint8_t * client_id)
 {
-    if(friend_id >= numfriends || friend_id < 0)
+    if(friend_id >= m->numfriends || friend_id < 0)
     {
         return -1;
     }
 
-    if(friendlist[friend_id].status > 0)
+    if(m->friendlist[friend_id].status > 0)
     {
-        memcpy(client_id, friendlist[friend_id].client_id, CLIENT_ID_SIZE);
+        memcpy(client_id, m->friendlist[friend_id].client_id, CLIENT_ID_SIZE);
         return 0;
     }
     return -1;
@@ -104,7 +74,7 @@ int getclient_id(int friend_id, uint8_t * client_id)
    data is the data and length is the length
    returns the friend number if success
    return -1 if failure. */
-int m_addfriend(uint8_t * client_id, uint8_t * data, uint16_t length)
+int m_addfriend(Messenger *m, uint8_t * client_id, uint8_t * data, uint16_t length)
 {
     if(length == 0 || length >=
             (MAX_DATA_SIZE - crypto_box_PUBLICKEYBYTES - crypto_box_NONCEBYTES - crypto_box_BOXZEROBYTES + crypto_box_ZEROBYTES))
@@ -115,51 +85,51 @@ int m_addfriend(uint8_t * client_id, uint8_t * data, uint16_t length)
     {
         return -1;
     }
-    if(getfriend_id(client_id) != -1)
+    if(getfriend_id(m, client_id) != -1)
     {
         return -1;
     }
     uint32_t i;
-    for(i = 0; i <= numfriends; ++i)
+    for(i = 0; i <= m->numfriends; ++i)
     {
-        if(friendlist[i].status == 0)
+        if(m->friendlist[i].status == NO_ADDED)
         {
             DHT_addfriend(client_id);
-            friendlist[i].status = 1;
-            friendlist[i].crypt_connection_id = -1;
-            friendlist[i].friend_request_id = -1;
-            memcpy(friendlist[i].client_id, client_id, CLIENT_ID_SIZE);
-            friendlist[i].userstatus = calloc(1, 1);
-            friendlist[i].userstatus_length = 1;
-            memcpy(friendlist[i].info, data, length);
-            friendlist[i].info_size = length;
-            
-            ++numfriends;
+            m->friendlist[i].status = ADDED;
+            m->friendlist[i].crypt_connection_id = -1;
+            m->friendlist[i].friend_request_id = -1;
+            memcpy(m->friendlist[i].client_id, client_id, CLIENT_ID_SIZE);
+            m->friendlist[i].userstatus = calloc(1, 1);
+            m->friendlist[i].userstatus_length = 1;
+            memcpy(m->friendlist[i].info, data, length);
+            m->friendlist[i].info_size = length;
+
+            ++m->numfriends;
             return i;
         }
     }
     return -1;
 }
 
-int m_addfriend_norequest(uint8_t * client_id)
+int m_addfriend_norequest(Messenger *m, uint8_t * client_id)
 {
-    if(getfriend_id(client_id) != -1)
+    if(getfriend_id(m, client_id) != -1)
     {
         return -1;
     }
     uint32_t i;
-    for(i = 0; i <= numfriends; ++i)
+    for(i = 0; i <= m->numfriends; ++i)
     {
-        if(friendlist[i].status == 0)
+        if(m->friendlist[i].status == NO_ADDED)
         {
             DHT_addfriend(client_id);
-            friendlist[i].status = 2;
-            friendlist[i].crypt_connection_id = -1;
-            friendlist[i].friend_request_id = -1;
-            memcpy(friendlist[i].client_id, client_id, CLIENT_ID_SIZE);
-            friendlist[i].userstatus = calloc(1, 1);
-            friendlist[i].userstatus_length = 1;
-            numfriends++;
+            m->friendlist[i].status = REQUEST_SENT;
+            m->friendlist[i].crypt_connection_id = -1;
+            m->friendlist[i].friend_request_id = -1;
+            memcpy(m->friendlist[i].client_id, client_id, CLIENT_ID_SIZE);
+            m->friendlist[i].userstatus = calloc(1, 1);
+            m->friendlist[i].userstatus_length = 1;
+            ++m->numfriends;
             return i;
         }
     }
@@ -169,55 +139,50 @@ int m_addfriend_norequest(uint8_t * client_id)
 /* remove a friend
    return 0 if success
    return -1 if failure */
-int m_delfriend(int friendnumber)
+int m_delfriend(Messenger *m, int friendnumber)
 {
-    if(friendnumber >= numfriends || friendnumber < 0)
+    if(friendnumber >= m->numfriends || friendnumber < 0)
     {
         return -1;
     }
 
-    DHT_delfriend(friendlist[friendnumber].client_id);
-    crypto_kill(friendlist[friendnumber].crypt_connection_id);
-    free(friendlist[friendnumber].userstatus);
-    memset(&friendlist[friendnumber], 0, sizeof(Friend));
+    DHT_delfriend(m->friendlist[friendnumber].client_id);
+    crypto_kill(m->friendlist[friendnumber].crypt_connection_id);
+    free(m->friendlist[friendnumber].userstatus);
+    memset(&(m->friendlist[friendnumber]), 0, sizeof(Friend));
     uint32_t i;
-    for(i = numfriends; i != 0; --i)
+    for(i = m->numfriends; i != 0; --i)
     {
-        if(friendlist[i].status != 0)
+        if(m->friendlist[i].status != NO_ADDED)
         {
             break;
         }
     }
-    numfriends = i;
+    m->numfriends = i;
     return 0;
 }
 
 
-/* return 4 if friend is online
-   return 3 if friend is confirmed
-   return 2 if the friend request was sent
-   return 1 if the friend was added
-   return 0 if there is no friend with that number */
-int m_friendstatus(int friendnumber)
+Friend_status m_friendstatus(Messenger *m, int friendnumber)
 {
-    if(friendnumber < 0 || friendnumber >= MAX_NUM_FRIENDS)
+    if(friendnumber < 0 || friendnumber >= m->numfriends)
     {
         return 0;
     }
-    return friendlist[friendnumber].status;
+    return m->friendlist[friendnumber].status;
 }
 
 
 /* send a text chat message to an online friend
    return 1 if packet was successfully put into the send queue
    return 0 if it was not */
-int m_sendmessage(int friendnumber, uint8_t * message, uint32_t length)
+int m_sendmessage(Messenger *m, int friendnumber, uint8_t * message, uint32_t length)
 {
-    if(friendnumber < 0 || friendnumber >= MAX_NUM_FRIENDS)
+    if(friendnumber < 0 || friendnumber >= m->numfriends)
     {
         return 0;
     }
-    if(length >= MAX_DATA_SIZE || friendlist[friendnumber].status != 4)
+    if(length >= MAX_DATA_SIZE || m->friendlist[friendnumber].status != ONLINE)
     /* this does not mean the maximum message length is MAX_DATA_SIZE - 1, it is actually 17 bytes less. */
     {
         return 0;
@@ -225,29 +190,29 @@ int m_sendmessage(int friendnumber, uint8_t * message, uint32_t length)
     uint8_t temp[MAX_DATA_SIZE];
     temp[0] = PACKET_ID_MESSAGE;
     memcpy(temp + 1, message, length);
-    return write_cryptpacket(friendlist[friendnumber].crypt_connection_id, temp, length + 1);
+    return write_cryptpacket(m->friendlist[friendnumber].crypt_connection_id, temp, length + 1);
 }
 
 /* send a name packet to friendnumber */
-static int m_sendname(int friendnumber, uint8_t * name)
+static int m_sendname(Messenger *m, int friendnumber, uint8_t * name)
 {
     uint8_t temp[MAX_NAME_LENGTH + 1];
     memcpy(temp + 1, name, MAX_NAME_LENGTH);
     temp[0] = PACKET_ID_NICKNAME;
-    return write_cryptpacket(friendlist[friendnumber].crypt_connection_id, temp, MAX_NAME_LENGTH + 1);
+    return write_cryptpacket(m->friendlist[friendnumber].crypt_connection_id, temp, MAX_NAME_LENGTH + 1);
 }
 
 /* set the name of a friend
    return 0 if success
    return -1 if failure */
 
-static int setfriendname(int friendnumber, uint8_t * name)
+static int setfriendname(Messenger *m, int friendnumber, uint8_t * name)
 {
-    if(friendnumber >= numfriends || friendnumber < 0)
+    if(friendnumber >= m->numfriends || friendnumber < 0)
     {
         return -1;
     }
-    memcpy(friendlist[friendnumber].name, name, MAX_NAME_LENGTH);
+    memcpy(m->friendlist[friendnumber].name, name, MAX_NAME_LENGTH);
     return 0;
 }
 
@@ -256,17 +221,17 @@ static int setfriendname(int friendnumber, uint8_t * name)
    name must be a string of maximum MAX_NAME_LENGTH length.
    return 0 if success
    return -1 if failure */
-int setname(uint8_t * name, uint16_t length)
+int setname(Messenger *m, uint8_t * name, uint16_t length)
 {
     if(length > MAX_NAME_LENGTH)
     {
         return -1;
     }
-    memcpy(self_name, name, length);
+    memcpy(m->self_name, name, length);
     uint32_t i;
-    for(i = 0; i < numfriends; ++i)
+    for(i = 0; i < m->numfriends; ++i)
     {
-        friendlist[i].name_sent = 0;
+        m->friendlist[i].name_sent = 0;
     }
     return 0;
 }
@@ -276,17 +241,17 @@ int setname(uint8_t * name, uint16_t length)
    name needs to be a valid memory location with a size of at least MAX_NAME_LENGTH bytes.
    return 0 if success
    return -1 if failure */
-int getname(int friendnumber, uint8_t * name)
+int getname(Messenger *m, int friendnumber, uint8_t * name)
 {
-    if(friendnumber >= numfriends || friendnumber < 0)
+    if(friendnumber >= m->numfriends || friendnumber < 0)
     {
         return -1;
     }
-    memcpy(name, friendlist[friendnumber].name, MAX_NAME_LENGTH);
+    memcpy(name, m->friendlist[friendnumber].name, MAX_NAME_LENGTH);
     return 0;
 }
 
-int m_set_userstatus(uint8_t *status, uint16_t length)
+int m_set_userstatus(Messenger *m, uint8_t *status, uint16_t length)
 {
     if(length > MAX_USERSTATUS_LENGTH)
     {
@@ -294,201 +259,198 @@ int m_set_userstatus(uint8_t *status, uint16_t length)
     }
     uint8_t *newstatus = calloc(length, 1);
     memcpy(newstatus, status, length);
-    free(self_userstatus);
-    self_userstatus = newstatus;
-    self_userstatus_len = length;
+    free(m->self_userstatus);
+    m->self_userstatus = newstatus;
+    m->self_userstatus_len = length;
 
     uint32_t i;
-    for(i = 0; i < numfriends; ++i)
+    for(i = 0; i < m->numfriends; ++i)
     {
-        friendlist[i].userstatus_sent = 0;
+        m->friendlist[i].userstatus_sent = 0;
     }
     return 0;
 }
 
 /*  return the size of friendnumber's user status
     guaranteed to be at most MAX_USERSTATUS_LENGTH */
-int m_get_userstatus_size(int friendnumber)
+int m_get_userstatus_size(Messenger *m, int friendnumber)
 {
-    if(friendnumber >= numfriends || friendnumber < 0)
+    if(friendnumber >= m->numfriends || friendnumber < 0)
     {
         return -1;
     }
-    return friendlist[friendnumber].userstatus_length;
+    return m->friendlist[friendnumber].userstatus_length;
 }
 
 /*  copy the user status of friendnumber into buf, truncating if needed to maxlen
     bytes, use m_get_userstatus_size to find out how much you need to allocate */
-int m_copy_userstatus(int friendnumber, uint8_t * buf, uint32_t maxlen)
+int m_copy_userstatus(Messenger *m, int friendnumber, uint8_t * buf, uint32_t maxlen)
 {
-    if(friendnumber >= numfriends || friendnumber < 0)
+    if(friendnumber >= m->numfriends || friendnumber < 0)
     {
         return -1;
     }
     memset(buf, 0, maxlen);
-    memcpy(buf, friendlist[friendnumber].userstatus, MIN(maxlen, MAX_USERSTATUS_LENGTH) - 1);
+    memcpy(buf, m->friendlist[friendnumber].userstatus, MIN(maxlen, MAX_USERSTATUS_LENGTH) - 1);
     return 0;
 }
 
-static int send_userstatus(int friendnumber, uint8_t * status, uint16_t length)
+static int send_userstatus(Messenger *m, int friendnumber, uint8_t * status, uint16_t length)
 {
     uint8_t *thepacket = malloc(length + 1);
     memcpy(thepacket + 1, status, length);
     thepacket[0] = PACKET_ID_USERSTATUS;
-    int written = write_cryptpacket(friendlist[friendnumber].crypt_connection_id, thepacket, length + 1);
+    int written = write_cryptpacket(m->friendlist[friendnumber].crypt_connection_id, thepacket, length + 1);
     free(thepacket);
     return written;
 }
 
-static int set_friend_userstatus(int friendnumber, uint8_t * status, uint16_t length)
+static int set_friend_userstatus(Messenger *m, int friendnumber, uint8_t * status, uint16_t length)
 {
-    if(friendnumber >= numfriends || friendnumber < 0)
+    if(friendnumber >= m->numfriends || friendnumber < 0)
     {
         return -1;
     }
     uint8_t *newstatus = calloc(length, 1);
     memcpy(newstatus, status, length);
-    free(friendlist[friendnumber].userstatus);
-    friendlist[friendnumber].userstatus = newstatus;
-    friendlist[friendnumber].userstatus_length = length;
+    free(m->friendlist[friendnumber].userstatus);
+    m->friendlist[friendnumber].userstatus = newstatus;
+    m->friendlist[friendnumber].userstatus_length = length;
     return 0;
 }
 
-static void (*friend_request)(uint8_t *, uint8_t *, uint16_t);
-static uint8_t friend_request_isset = 0;
-
 /* set the function that will be executed when a friend request is received. */
-void m_callback_friendrequest(void (*function)(uint8_t *, uint8_t *, uint16_t))
+void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *, uint8_t *, uint8_t *, uint16_t))
 {
-    friend_request = function;
-    friend_request_isset = 1;
+    m->friend_request = function;
+    m->friend_request_isset = 1;
 }
-
-
-static void (*friend_message)(int, uint8_t *, uint16_t);
-static uint8_t friend_message_isset = 0;
 
 /* set the function that will be executed when a message from a friend is received. */
-void m_callback_friendmessage(void (*function)(int, uint8_t *, uint16_t))
+void m_callback_friendmessage(Messenger *m, void (*function)(Messenger *, int, uint8_t *, uint16_t))
 {
-    friend_message = function;
-    friend_message_isset = 1;
+    m->friend_message = function;
+    m->friend_message_isset = 1;
 }
 
-
-static void (*friend_namechange)(int, uint8_t *, uint16_t);
-static uint8_t friend_namechange_isset = 0;
-void m_callback_namechange(void (*function)(int, uint8_t *, uint16_t))
+void m_callback_namechange(Messenger *m, void (*function)(Messenger *, int, uint8_t *, uint16_t))
 {
-    friend_namechange = function;
-    friend_namechange_isset = 1;
+    m->friend_namechange = function;
+    m->friend_namechange_isset = 1;
 }
 
-static void (*friend_statuschange)(int, uint8_t *, uint16_t);
-static uint8_t friend_statuschange_isset = 0;
-void m_callback_userstatus(void (*function)(int, uint8_t *, uint16_t))
+void m_callback_userstatus(Messenger *m, void (*function)(Messenger *, int, uint8_t *, uint16_t))
 {
-    friend_statuschange = function;
-    friend_statuschange_isset = 1;
+    m->friend_statuschange = function;
+    m->friend_statuschange_isset = 1;
 }
 
-#define PORT 33445
 /* run this at startup */
-void initMessenger()
+Messenger * initMessenger()
 {
+	Messenger *m = calloc(1, sizeof(Messenger));
+	if( !m ) /* FIXME panic */
+		return 0;
+	m->friendlist = calloc(256, sizeof(Friend));
+	if( !m ) /* FIXME panic */
+		return 0;
+	m->size = 256; /* FIXME make dynamic later on, requires logic change */
+
     new_keys();
-    m_set_userstatus((uint8_t*)"Online", sizeof("Online"));
+    m_set_userstatus(m, (uint8_t*)"Online", sizeof("Online"));
     initNetCrypto();
     IP ip;
     ip.i = 0;
-    init_networking(ip, PORT);
+    init_networking(ip, MESSENGER_PORT);
+
+	return m;
 }
 
-static void doFriends()
+static void doFriends(Messenger *m)
 {/* TODO: add incoming connections and some other stuff. */
     uint32_t i;
     int len;
     uint8_t temp[MAX_DATA_SIZE];
-    for(i = 0; i < numfriends; ++i)
+    for(i = 0; i < m->numfriends; ++i)
     {
-        if(friendlist[i].status == 1)
+        if(m->friendlist[i].status == 1)
         {
-             IP_Port friendip = DHT_getfriendip(friendlist[i].client_id);
-             int request = check_friendrequest(friendlist[i].friend_request_id);
+             IP_Port friendip = DHT_getfriendip(m->friendlist[i].client_id);
+             int request = check_friendrequest(m->friendlist[i].friend_request_id);
              /* printf("\n%u %u %u\n", friendip.ip.i, request, friendlist[i].friend_request_id); */
              if(friendip.ip.i > 1 && request == -1)
              {
-                  friendlist[i].friend_request_id = send_friendrequest(friendlist[i].client_id,
-                                               friendip, friendlist[i].info, friendlist[i].info_size);
-                  friendlist[i].status = 2;
+                  m->friendlist[i].friend_request_id = send_friendrequest(m->friendlist[i].client_id,
+                                               friendip, m->friendlist[i].info, m->friendlist[i].info_size);
+                  m->friendlist[i].status = 2;
              }
         }
-        if(friendlist[i].status == 2 || friendlist[i].status == 3) /* friend is not online */
+        if(m->friendlist[i].status == REQUEST_SENT || m->friendlist[i].status == CONFIRMED_FRIEND) /* friend is not online */
         {
-            check_friendrequest(friendlist[i].friend_request_id); /* for now this is used to kill the friend request */
-            IP_Port friendip = DHT_getfriendip(friendlist[i].client_id);
-            switch(is_cryptoconnected(friendlist[i].crypt_connection_id))
+            check_friendrequest(m->friendlist[i].friend_request_id); /* for now this is used to kill the friend request */
+            IP_Port friendip = DHT_getfriendip(m->friendlist[i].client_id);
+            switch(is_cryptoconnected(m->friendlist[i].crypt_connection_id))
             {
                 case 0:
                     if (friendip.ip.i > 1)
-                        friendlist[i].crypt_connection_id = crypto_connect(friendlist[i].client_id, friendip);
+                        m->friendlist[i].crypt_connection_id = crypto_connect(m->friendlist[i].client_id, friendip);
                     break;
                 case 3: /*  Connection is established */
-                    friendlist[i].status = 4;
+                    m->friendlist[i].status = 4;
                     break;
                 case 4:
-                    crypto_kill(friendlist[i].crypt_connection_id);
-                    friendlist[i].crypt_connection_id = -1;
+                    crypto_kill(m->friendlist[i].crypt_connection_id);
+                    m->friendlist[i].crypt_connection_id = -1;
                     break;
                 default:
                     break;
             }
         }
-        while(friendlist[i].status == 4) /* friend is online */
+        while(m->friendlist[i].status == 4) /* friend is online */
         {
-            if(friendlist[i].name_sent == 0)
+            if(m->friendlist[i].name_sent == 0)
             {
-                if(m_sendname(i, self_name))
+                if(m_sendname(m, i, m->self_name))
                 {
-                    friendlist[i].name_sent = 1;
+                    m->friendlist[i].name_sent = 1;
                 }
             }
-            if(friendlist[i].userstatus_sent == 0)
+            if(m->friendlist[i].userstatus_sent == 0)
             {
-                if(send_userstatus(i, self_userstatus, self_userstatus_len))
+                if(send_userstatus(m, i, m->self_userstatus, m->self_userstatus_len))
                 {
-                    friendlist[i].userstatus_sent = 1;
+                    m->friendlist[i].userstatus_sent = 1;
                 }
             }
-            len = read_cryptpacket(friendlist[i].crypt_connection_id, temp);
+            len = read_cryptpacket(m->friendlist[i].crypt_connection_id, temp);
             if(len > 0)
             {
                 switch(temp[0]) {
                     case PACKET_ID_NICKNAME: {
                         if (len != MAX_NAME_LENGTH + 1) break;
-                        if(friend_namechange_isset)
+                        if(m->friend_namechange_isset)
                         {
-                            friend_namechange(i, temp + 1, MAX_NAME_LENGTH); /* TODO: use the actual length */
+                            m->friend_namechange(m, i, temp + 1, MAX_NAME_LENGTH); /* TODO: use the actual length */
                         }
-                        memcpy(friendlist[i].name, temp + 1, MAX_NAME_LENGTH);
-                        friendlist[i].name[MAX_NAME_LENGTH - 1] = 0; /* make sure the NULL terminator is present. */
+                        memcpy(m->friendlist[i].name, temp + 1, MAX_NAME_LENGTH);
+                        m->friendlist[i].name[MAX_NAME_LENGTH - 1] = 0; /* make sure the NULL terminator is present. */
                         break;
                     }
                     case PACKET_ID_USERSTATUS: {
                         uint8_t *status = calloc(MIN(len - 1, MAX_USERSTATUS_LENGTH), 1);
                         memcpy(status, temp + 1, MIN(len - 1, MAX_USERSTATUS_LENGTH));
-                        if(friend_statuschange_isset)
+                        if(m->friend_statuschange_isset)
                         {
-                            friend_statuschange(i, status, MIN(len - 1, MAX_USERSTATUS_LENGTH));
+                            m->friend_statuschange(m, i, status, MIN(len - 1, MAX_USERSTATUS_LENGTH));
                         }
-                        set_friend_userstatus(i, status, MIN(len - 1, MAX_USERSTATUS_LENGTH));
+                        set_friend_userstatus(m, i, status, MIN(len - 1, MAX_USERSTATUS_LENGTH));
                         free(status);
                         break;
                     }
                     case PACKET_ID_MESSAGE: {
-                        if(friend_message_isset)
+                        if(m->friend_message_isset)
                         {
-                            (*friend_message)(i, temp + 1, len - 1);
+                            (*m->friend_message)(m, i, temp + 1, len - 1);
                         }
                         break;
                     }
@@ -496,11 +458,11 @@ static void doFriends()
             }
             else
             {
-                 if(is_cryptoconnected(friendlist[i].crypt_connection_id) == 4) /* if the connection timed out, kill it */
+                 if(is_cryptoconnected(m->friendlist[i].crypt_connection_id) == 4) /* if the connection timed out, kill it */
                  {
-                         crypto_kill(friendlist[i].crypt_connection_id);
-                         friendlist[i].crypt_connection_id = -1;
-                         friendlist[i].status = 3;
+                         crypto_kill(m->friendlist[i].crypt_connection_id);
+                         m->friendlist[i].crypt_connection_id = -1;
+                         m->friendlist[i].status = 3;
                  }
                  break;
             }
@@ -508,24 +470,24 @@ static void doFriends()
     }
 }
 
-static void doFriendRequest()
+static void doFriendRequest(Messenger *m)
 {
     uint8_t public_key[crypto_box_PUBLICKEYBYTES];
     uint8_t temp[MAX_DATA_SIZE];
-    
+
     int len = handle_friendrequest(public_key, temp);
     if(len >= 0)
     {
-        if(friend_request_isset)
+        if(m->friend_request_isset)
         {
-            (*friend_request)(public_key, temp, len);
+            (*(m->friend_request))(m, public_key, temp, len);
         }
     }
 }
 
 
 
-static void doInbound()
+static void doInbound(Messenger *m)
 {
     uint8_t secret_nonce[crypto_box_NONCEBYTES];
     uint8_t public_key[crypto_box_PUBLICKEYBYTES];
@@ -533,20 +495,20 @@ static void doInbound()
     int inconnection = crypto_inbound(public_key, secret_nonce, session_key);
     if(inconnection != -1)
     {
-        int friend_id = getfriend_id(public_key);
+        int friend_id = getfriend_id(m, public_key);
         if(friend_id != -1)
         {
-             crypto_kill(friendlist[friend_id].crypt_connection_id);
-             friendlist[friend_id].crypt_connection_id =
+             crypto_kill(m->friendlist[friend_id].crypt_connection_id);
+             m->friendlist[friend_id].crypt_connection_id =
              accept_crypto_inbound(inconnection, public_key, secret_nonce, session_key);
-             
-             friendlist[friend_id].status = 3;
+
+             m->friendlist[friend_id].status = 3;
         }
     }
 }
 
 /* the main loop that needs to be run at least 200 times per second. */
-void doMessenger()
+void doMessenger(Messenger *m)
 {
     IP_Port ip_port;
     uint8_t data[MAX_UDP_PACKET_SIZE];
@@ -576,20 +538,20 @@ void doMessenger()
     doDHT();
     doLossless_UDP();
     doNetCrypto();
-    doInbound();
-    doFriendRequest();
-    doFriends();
+    doInbound(m);
+    doFriendRequest(m);
+    doFriends(m);
 }
 
 /* returns the size of the messenger data (for saving) */
-uint32_t Messenger_size()
+uint32_t Messenger_size(Messenger *m)
 {
     return crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES
-                                     + sizeof(uint32_t) + DHT_size() + sizeof(uint32_t) + sizeof(Friend) * numfriends;
+                                     + sizeof(uint32_t) + DHT_size() + sizeof(uint32_t) + sizeof(Friend) * m->numfriends;
 }
 
 /* save the messenger in data of size Messenger_size() */
-void Messenger_save(uint8_t * data)
+void Messenger_save(Messenger *m, uint8_t * data)
 {
     save_keys(data);
     data += crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES;
@@ -598,14 +560,14 @@ void Messenger_save(uint8_t * data)
     data += sizeof(size);
     DHT_save(data);
     data += size;
-    size = sizeof(Friend) * numfriends;
+    size = sizeof(Friend) * m->numfriends;
     memcpy(data, &size, sizeof(size));
     data += sizeof(size);
-    memcpy(data, friendlist, sizeof(Friend) * numfriends);
+    memcpy(data, m->friendlist, sizeof(Friend) * m->numfriends);
 }
 
 /* load the messenger from data of size length. */
-int Messenger_load(uint8_t * data, uint32_t length)
+int Messenger_load(Messenger *m, uint8_t * data, uint32_t length)
 {
     if(length == ~0)
     {
@@ -621,7 +583,7 @@ int Messenger_load(uint8_t * data, uint32_t length)
     uint32_t size;
     memcpy(&size, data, sizeof(size));
     data += sizeof(size);
-    
+
     if(length < size)
     {
         return -1;
@@ -638,19 +600,19 @@ int Messenger_load(uint8_t * data, uint32_t length)
     {
         return -1;
     }
-    
+
     Friend * temp = malloc(size);
     memcpy(temp, data, size);
-    
+
     uint16_t num = size / sizeof(Friend);
-    
+
     uint32_t i;
     for(i = 0; i < num; ++i)
     {
         if(temp[i].status != 0)
         {
-            int fnum = m_addfriend_norequest(temp[i].client_id);
-            setfriendname(fnum, temp[i].name);
+            int fnum = m_addfriend_norequest(m, temp[i].client_id);
+            setfriendname(m, fnum, temp[i].name);
             /* set_friend_userstatus(fnum, temp[i].userstatus, temp[i].userstatus_length); */
         }
     }

--- a/core/Messenger.h
+++ b/core/Messenger.h
@@ -3,7 +3,7 @@
 * An implementation of a simple text chat only messenger on the tox network core.
 *
 * NOTE: All the text in the messages must be encoded using UTF-8
- 
+
     Copyright (C) 2013 Tox project All Rights Reserved.
 
     This file is part of Tox.
@@ -20,10 +20,10 @@
 
     You should have received a copy of the GNU General Public License
     along with Tox.  If not, see <http://www.gnu.org/licenses/>.
-    
+
 */
- 
- 
+
+
 #ifndef MESSENGER_H
 #define MESSENGER_H
 
@@ -37,6 +37,55 @@
 #define PACKET_ID_USERSTATUS 49
 #define PACKET_ID_MESSAGE 64
 
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
+#define MESSENGER_PORT 33445
+
+typedef enum Friend_status {
+	NO_ADDED, /* was 0, no friend here */
+	ADDED, /* was 1, friend has been added */
+	REQUEST_SENT, /* was 2, friend request sent */
+	CONFIRMED_FRIEND, /* was 3, friend request confirmed */
+	ONLINE /* was 4, friend is online */
+} Friend_status;
+
+typedef struct Friend {
+    uint8_t client_id[CLIENT_ID_SIZE];
+    int crypt_connection_id;
+    int friend_request_id; /* id of the friend request corresponding to the current friend request to the current friend. */
+    Friend_status status;
+    uint8_t info[MAX_DATA_SIZE]; /* the data that is sent during the friend requests we do */
+    uint8_t name[MAX_NAME_LENGTH];
+    uint8_t name_sent; /* 0 if we didn't send our name to this friend 1 if we have. */
+    uint8_t *userstatus;
+    uint16_t userstatus_length;
+    uint8_t userstatus_sent;
+    uint16_t info_size; /* length of the info */
+} Friend;
+
+typedef struct Messenger {
+	/* FIXME eventually friendlist will be a dynamically growing array */
+	int numfriends; /* number of elements in use in friendlist */
+	int size; /* number of elements allocated for friendlist */
+	Friend *friendlist;
+
+	uint8_t self_public_key[crypto_box_PUBLICKEYBYTES];
+
+	uint8_t self_name[MAX_NAME_LENGTH];
+	uint8_t *self_userstatus;
+	uint16_t self_userstatus_len;
+
+	/* callback functions */
+	void (*friend_request)(struct Messenger *, uint8_t *, uint8_t *, uint16_t);
+	uint8_t friend_request_isset;
+	void (*friend_message)(struct Messenger *, int, uint8_t *, uint16_t);
+	uint8_t friend_message_isset;
+	void (*friend_namechange)(struct Messenger *, int, uint8_t *, uint16_t);
+	uint8_t friend_namechange_isset;
+	void (*friend_statuschange)(struct Messenger *, int, uint8_t *, uint16_t);
+	uint8_t friend_statuschange_isset;
+} Messenger;
+
 /* don't assume MAX_USERSTATUS_LENGTH will stay at 128, it may be increased
    to an absurdly large number later */
 
@@ -46,45 +95,40 @@
    data is the data and length is the length
    returns the friend number if success
    return -1 if failure. */
-int m_addfriend(uint8_t * client_id, uint8_t * data, uint16_t length);
+int m_addfriend(Messenger *m, uint8_t * client_id, uint8_t * data, uint16_t length);
 
 
 /* add a friend without sending a friendrequest.
    returns the friend number if success
    return -1 if failure. */
-int m_addfriend_norequest(uint8_t * client_id);
+int m_addfriend_norequest(Messenger *m, uint8_t * client_id);
 
 /* return the friend id associated to that client id.
    return -1 if no such friend */
-int getfriend_id(uint8_t * client_id);
+int getfriend_id(Messenger *m, uint8_t * client_id);
 
 /* copies the public key associated to that friend id into client_id buffer.
    make sure that client_id is of size CLIENT_ID_SIZE.
    return 0 if success
    return -1 if failure */
-int getclient_id(int friend_id, uint8_t * client_id);
+int getclient_id(Messenger *m, int friend_id, uint8_t * client_id);
 
 /* remove a friend */
-int m_delfriend(int friendnumber);
+int m_delfriend(Messenger *m, int friendnumber);
 
-/* return 4 if friend is online
-   return 3 if friend is confirmed
-   return 2 if the friend request was sent
-   return 1 if the friend was added
-   return 0 if there is no friend with that number */
-int m_friendstatus(int friendnumber);
+Friend_status m_friendstatus(Messenger *m, int friendnumber);
 
 
 /* send a text chat message to an online friend
    returns 1 if packet was successfully put into the send queue
    return 0 if it was not */
-int m_sendmessage(int friendnumber, uint8_t * message, uint32_t length);
+int m_sendmessage(Messenger *m, int friendnumber, uint8_t * message, uint32_t length);
 
 /* Set our nickname
    name must be a string of maximum MAX_NAME_LENGTH length.
    return 0 if success
    return -1 if failure */
-int setname(uint8_t * name, uint16_t length);
+int setname(Messenger *m, uint8_t * name, uint16_t length);
 
 
 /* get name of friendnumber
@@ -92,58 +136,57 @@ int setname(uint8_t * name, uint16_t length);
    name needs to be a valid memory location with a size of at least MAX_NAME_LENGTH (128) bytes.
    return 0 if success
    return -1 if failure */
-int getname(int friendnumber, uint8_t * name);
+int getname(Messenger *m, int friendnumber, uint8_t * name);
 
 /* set our user status
    you are responsible for freeing status after
    returns 0 on success, -1 on failure */
-int m_set_userstatus(uint8_t *status, uint16_t length);
+int m_set_userstatus(Messenger *m, uint8_t *status, uint16_t length);
 
 /* return the length of friendnumber's user status,
    including null
    pass it into malloc */
-int m_get_userstatus_size(int friendnumber);
+int m_get_userstatus_size(Messenger *m, int friendnumber);
 
 /* copy friendnumber's userstatus into buf, truncating if size is over maxlen
    get the size you need to allocate from m_get_userstatus_size */
-int m_copy_userstatus(int friendnumber, uint8_t * buf, uint32_t maxlen);
+int m_copy_userstatus(Messenger *m, int friendnumber, uint8_t * buf, uint32_t maxlen);
 
 /* set the function that will be executed when a friend request is received.
    function format is function(uint8_t * public_key, uint8_t * data, uint16_t length) */
-void m_callback_friendrequest(void (*function)(uint8_t *, uint8_t *, uint16_t));
+void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *, uint8_t *, uint8_t *, uint16_t));
 
 
 /* set the function that will be executed when a message from a friend is received.
    function format is: function(int friendnumber, uint8_t * message, uint32_t length) */
-void m_callback_friendmessage(void (*function)(int, uint8_t *, uint16_t));
+void m_callback_friendmessage(Messenger *m, void (*function)(Messenger *, int, uint8_t *, uint16_t));
 
 /* set the callback for name changes
    function(int friendnumber, uint8_t *newname, uint16_t length)
    you are not responsible for freeing newname */
-void m_callback_namechange(void (*function)(int, uint8_t *, uint16_t));
+void m_callback_namechange(Messenger *m, void (*function)(Messenger *, int, uint8_t *, uint16_t));
 
 /* set the callback for user status changes
    function(int friendnumber, uint8_t *newstatus, uint16_t length)
    you are not responsible for freeing newstatus */
-void m_callback_userstatus(void (*function)(int, uint8_t *, uint16_t));
+void m_callback_userstatus(Messenger *m, void (*function)(Messenger *, int, uint8_t *, uint16_t));
 
 /* run this at startup */
-void initMessenger();
-
+Messenger * initMessenger();
 
 /* the main loop that needs to be run at least 200 times per second */
-void doMessenger();
+void doMessenger(Messenger *m);
 
 
 /* SAVING AND LOADING FUNCTIONS: */
 
 /* returns the size of the messenger data (for saving) */
-uint32_t Messenger_size();
+uint32_t Messenger_size(Messenger *m);
 
 /* save the messenger in data (must be allocated memory of size Messenger_size()) */
-void Messenger_save(uint8_t * data);
+void Messenger_save(Messenger *m, uint8_t * data);
 
 /* load the messenger from data of size length */
-int Messenger_load(uint8_t * data, uint32_t length);
+int Messenger_load(Messenger *m, uint8_t * data, uint32_t length);
 
 #endif

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -7,6 +7,7 @@
 #define c_sleep(x) usleep(1000*x)
 #endif
 
+Messenger *messenger;
 char lines[HISTORY][STRING_LENGTH];
 char line[STRING_LENGTH];
 int x,y;
@@ -48,13 +49,13 @@ void line_eval(char lines[HISTORY][STRING_LENGTH], char *line)
             for (i=0; i<128; i++) {
                 temp_id[i] = line[i+3];
             }
-            int num = m_addfriend(hex_string_to_bin(temp_id), (uint8_t*)"Install Gentoo", sizeof("Install Gentoo"));
+            int num = m_addfriend(messenger, hex_string_to_bin(temp_id), (uint8_t*)"Install Gentoo", sizeof("Install Gentoo"));
             char numstring[100];
             sprintf(numstring, "[i] added friend %d", num);
             new_lines(numstring);
             do_refresh();
         } else if (line[1] == 'd') {
-            doMessenger();
+            doMessenger(messenger);
         } else if (line[1] == 'm') { //message command: /m friendnumber messsage
             int i;
             int len = strlen(line);
@@ -72,7 +73,7 @@ void line_eval(char lines[HISTORY][STRING_LENGTH], char *line)
                 }
             }
             int num = atoi(numstring);
-            m_sendmessage(num, (uint8_t*) message, sizeof(message));
+            m_sendmessage(messenger, num, (uint8_t*) message, sizeof(message));
         } else if (line[1] == 'n') {
             uint8_t name[MAX_NAME_LENGTH];
             int i = 0;
@@ -81,7 +82,7 @@ void line_eval(char lines[HISTORY][STRING_LENGTH], char *line)
                 name[i - 3] = line[i];
             }
             name[i - 3] = 0;
-            setname(name, i);
+            setname(messenger, name, i);
             char numstring[100];
             sprintf(numstring, "[i] changed nick to %s", (char*)name);
             new_lines(numstring);
@@ -93,7 +94,7 @@ void line_eval(char lines[HISTORY][STRING_LENGTH], char *line)
                 status[i - 3] = line[i];
             }
             status[i - 3] = 0;
-            m_set_userstatus(status, strlen((char*)status));
+            m_set_userstatus(messenger, status, strlen((char*)status));
             char numstring[100];
             sprintf(numstring, "[i] changed status to %s", (char*)status);
             new_lines(numstring);
@@ -166,7 +167,7 @@ void do_refresh()
     clrtoeol();
     refresh();
 }
-void print_request(uint8_t * public_key, uint8_t * data, uint16_t length)
+void print_request(Messenger *m, uint8_t * public_key, uint8_t * data, uint16_t length)
 {
     new_lines("Friend request");
     do_refresh();
@@ -175,32 +176,32 @@ void print_request(uint8_t * public_key, uint8_t * data, uint16_t length)
     {
         new_lines("[i] friend request accepted.");
         do_refresh();
-        int num = m_addfriend_norequest(public_key);
+        int num = m_addfriend_norequest(messenger, public_key);
         char numchar[100];
         sprintf(numchar, "[i] added friendnumber %d", num);
         new_lines(numchar);
     }
 }
-void print_message(int friendnumber, uint8_t * string, uint16_t length)
+void print_message(Messenger *m, int friendnumber, uint8_t * string, uint16_t length)
 {
     char *name = malloc(MAX_NAME_LENGTH);
-    getname(friendnumber, (uint8_t*)name);
+    getname(messenger, friendnumber, (uint8_t*)name);
     char msg[100+length+strlen(name)+1];
     sprintf(msg, "[%d] <%s> %s", friendnumber, name, string);
     free(name);
     new_lines(msg);
 }
-void print_nickchange(int friendnumber, uint8_t *string, uint16_t length) {
+void print_nickchange(Messenger *m, int friendnumber, uint8_t *string, uint16_t length) {
     char *name = malloc(MAX_NAME_LENGTH);
-    getname(friendnumber, (uint8_t*)name);
+    getname(messenger, friendnumber, (uint8_t*)name);
     char msg[100+length];
     sprintf(msg, "[i] [%d] %s is now known as %s.", friendnumber, name, string);
     free(name);
     new_lines(msg);
 }
-void print_statuschange(int friendnumber, uint8_t *string, uint16_t length) {
+void print_statuschange(Messenger *m, int friendnumber, uint8_t *string, uint16_t length) {
     char *name = malloc(MAX_NAME_LENGTH);
-    getname(friendnumber, (uint8_t*)name);
+    getname(messenger, friendnumber, (uint8_t*)name);
     char msg[100+length+strlen(name)+1];
     sprintf(msg, "[i] [%d] %s's status changed to %s.", friendnumber, name, string);
     free(name);
@@ -214,11 +215,11 @@ int main(int argc, char *argv[])
     }
     int c;
     int on = 0;
-    initMessenger();
-    m_callback_friendrequest(print_request);
-    m_callback_friendmessage(print_message);
-    m_callback_namechange(print_nickchange);
-    m_callback_userstatus(print_statuschange);
+    messenger = initMessenger();
+    m_callback_friendrequest(messenger, print_request);
+    m_callback_friendmessage(messenger, print_message);
+    m_callback_namechange(messenger, print_nickchange);
+    m_callback_userstatus(messenger, print_statuschange);
     char idstring0[200];
     char idstring1[32][5];
     char idstring2[32][5];
@@ -277,7 +278,7 @@ int main(int argc, char *argv[])
                 on = 1;
             }
         }
-        doMessenger();
+        doMessenger(messenger);
         c_sleep(1);
         do_refresh();
     }


### PR DESCRIPTION
This refactor also includes:
- some mild trailing whitespace removal
- removing of friend status constants and replacing with a Friend_status
  enum
- changing Messenger_test.c to match the new interface provided by
  Messenger.h/.c
- changing nTox.c to match the new interface

NB: This refactor tries to avoid changing any logic, in theory it
should'nt have introduced many errors
