### PR TITLE
Updated INSTALL.md to add dependencies for OSX

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,8 +42,8 @@ make
 ###OSX:
 
 Much the same as above, remember to install the latest XCode and the developer tools (Preferences -> Downloads -> Command Line Tools).
-Users running Mountain Lion and the latest version of XCode (4.6.3) will also need to install libtool
-Libtool is easy enough to install, grab it from http://www.gnu.org/software/libtool/ and:
+Users running Mountain Lion and the latest version of XCode (4.6.3) will also need to install libtool, automake and autoconf.
+They are easy enough to install, grab them from http://www.gnu.org/software/libtool/, http://www.gnu.org/software/autoconf/ and http://www.gnu.org/software/automake/, then follow these steps for each:
 
 ```bash
 ./configure
@@ -51,7 +51,7 @@ make
 sudo make install
 ```
 
-Do not install it from macports (or any dependencies for that matter) as they get shoved in the wrong directory
+Do not install them from macports (or any dependencies for that matter) as they get shoved in the wrong directory
 and make your life more annoying.
 
 Another thing you may want to install is the latest gcc, this caused me a few problems as XCode from 4.3


### PR DESCRIPTION
Besides libtool one needs automake and autoconf for libsodium to compile successfully. Added links and adapted instructions accordingly.
