### PR TITLE
Emacs + Vim coding standard directives

### DIFF
--- a/core/DHT.c
+++ b/core/DHT.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* DHT.c
  *
  * An implementation of the DHT as seen in docs/DHT.txt
@@ -1102,3 +1103,5 @@ int DHT_isconnected()
             return 1;
     return 0;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/DHT.h
+++ b/core/DHT.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* DHT.h
  *
  * An implementation of the DHT as seen in docs/DHT.txt
@@ -109,3 +110,5 @@ int DHT_isconnected();
 #endif
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/LAN_discovery.c
+++ b/core/LAN_discovery.c
@@ -1,4 +1,6 @@
-/*  LAN_discovery.c
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ *  LAN_discovery.c
  *
  *  LAN discovery implementation.
  *
@@ -77,3 +79,5 @@ int LANdiscovery_handlepacket(uint8_t *packet, uint32_t length, IP_Port source)
         return handle_LANdiscovery(packet, length, source);
     return 1;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/LAN_discovery.h
+++ b/core/LAN_discovery.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /*  LAN_discovery.h
  *
  *  LAN discovery implementation.
@@ -48,3 +49,5 @@ int LANdiscovery_handlepacket(uint8_t *packet, uint32_t length, IP_Port source);
 #endif
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/Lossless_UDP.c
+++ b/core/Lossless_UDP.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* Lossless_UDP.c
  *
  * An implementation of the Lossless_UDP protocol as seen in docs/Lossless_UDP.txt
@@ -747,3 +748,5 @@ void doLossless_UDP()
     doData();
     adjustRates();
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/Lossless_UDP.h
+++ b/core/Lossless_UDP.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* Lossless_UDP.h
  *
  * An implementation of the Lossless_UDP protocol as seen in docs/Lossless_UDP.txt
@@ -104,3 +105,5 @@ int LosslessUDP_handlepacket(uint8_t *packet, uint32_t length, IP_Port source);
 #endif
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/Messenger.c
+++ b/core/Messenger.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* Messenger.c
  *
  * An implementation of a simple text chat only messenger on the tox network core.
@@ -573,3 +574,5 @@ int Messenger_load(uint8_t * data, uint32_t length)
     free(temp);
     return 0;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/Messenger.h
+++ b/core/Messenger.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* Messenger.h
  *
  * An implementation of a simple text chat only messenger on the tox network core.
@@ -155,3 +156,5 @@ int Messenger_load(uint8_t *data, uint32_t length);
 #endif
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/friend_requests.c
+++ b/core/friend_requests.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* friend_requests.c
  *
  * Handle friend requests.
@@ -129,3 +130,5 @@ int friendreq_handlepacket(uint8_t * packet, uint32_t length, IP_Port source)
     }
     return 1;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/friend_requests.h
+++ b/core/friend_requests.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* friend_requests.h
  *
  * Handle friend requests.
@@ -49,3 +50,5 @@ int friendreq_handlepacket(uint8_t *packet, uint32_t length, IP_Port source);
 #endif
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/net_crypto.c
+++ b/core/net_crypto.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* net_crypto.c
  *
  * Functions for the core network crypto.
@@ -562,3 +563,5 @@ void doNetCrypto()
     receive_crypto();
     killTimedout();
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/net_crypto.h
+++ b/core/net_crypto.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* net_crypto.h
  *
  * Functions for the core network crypto.
@@ -132,3 +133,5 @@ void doNetCrypto();
 #endif
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/network.c
+++ b/core/network.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* network.h
  *
  * Functions for the core networking.
@@ -186,3 +187,5 @@ int resolve_addr(char *address)
     freeaddrinfo(server);
     return resolved;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/core/network.h
+++ b/core/network.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* network.h
  *
  * Datatypes, functions and includes for the core networking.
@@ -132,3 +133,5 @@ int resolve_addr(char *address);
 #endif
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* DHT boostrap
  *
  * A simple DHT boostrap server for tox.
@@ -129,3 +130,5 @@ int main(int argc, char *argv[])
     shutdown_networking();
     return 0;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/other/bootstrap_serverdaemon/DHT_bootstrap_daemon.c
+++ b/other/bootstrap_serverdaemon/DHT_bootstrap_daemon.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* DHT boostrap
  *
  * A simple DHT boostrap server for tox - daemon edition.
@@ -418,3 +419,5 @@ int main(int argc, char *argv[]) {
     shutdown_networking();
     exit(EXIT_SUCCESS);
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/DHT_cryptosendfiletest.c
+++ b/testing/DHT_cryptosendfiletest.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* DHT cryptosendfiletest
  * 
  * This program sends or recieves a friend request.
@@ -226,3 +227,5 @@ int main(int argc, char *argv[])
     shutdown_networking();
     return 0;   
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/DHT_sendfiletest.c
+++ b/testing/DHT_sendfiletest.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* DHT sendfiletest
  * 
  * Sends the data from a file to another client.
@@ -174,3 +175,5 @@ int main(int argc, char *argv[])
     shutdown_networking();
     return 0;   
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* DHT test
  * A file with a main that runs our DHT for testing.
  * 
@@ -178,3 +179,5 @@ int main(int argc, char *argv[])
     shutdown_networking();
     return 0;   
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/Lossless_UDP_testclient.c
+++ b/testing/Lossless_UDP_testclient.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* Lossless_UDP testclient
  * A program that connects and sends a file using our lossless UDP algorithm.
  * NOTE: this program simulates a 33% packet loss.
@@ -212,3 +213,5 @@ int main(int argc, char *argv[])
         
     return 0;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/Lossless_UDP_testserver.c
+++ b/testing/Lossless_UDP_testserver.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* Lossless_UDP testserver
  * A program that waits for a lossless UDP connection and then saves all the data recieved to a file.
  * NOTE: this program simulates a 33% packet loss.
@@ -199,3 +200,5 @@ int main(int argc, char *argv[])
         
     return 0;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* Messenger test
  * 
  * This program adds a friend and accepts all friend requests with the proper message.
@@ -143,3 +144,5 @@ int main(int argc, char *argv[])
         fclose(file);
     }  
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/misc_tools.c
+++ b/testing/misc_tools.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* misc_tools.c
  * 
  * Miscellaneous functions and data structures for doing random things.
@@ -38,3 +39,5 @@ unsigned char * hex_string_to_bin(char hex_string[])
         sscanf(pos,"%2hhx",&val[i]);
     return val;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/misc_tools.h
+++ b/testing/misc_tools.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* misc_tools.h
  * 
  * Miscellaneous functions and data structures for doing random things.
@@ -27,3 +28,5 @@
 unsigned char * hex_string_to_bin(char hex_string[]);
  
 #endif // MISC_TOOLS_H
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* nTox.c
  *
  * Textual frontend for Tox.
@@ -353,3 +354,5 @@ int main(int argc, char *argv[])
     endwin();
     return 0;
 }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/testing/nTox.h
+++ b/testing/nTox.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /* nTox.h
  * 
  *Textual frontend for Tox.
@@ -48,3 +49,5 @@ char *appender(char *str, const char c);
 void do_refresh();
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Just to make it easier for everyone to follow coding standards, these are directives to Emacs and Vim to automatically set modes/settings up when the file is opened. Sets tab width to 4 and tab-with-spaces. I followed Libreoffice/OOo's standards when adding them. 
