### PR TITLE
nacl compiling option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,22 @@
 cmake_minimum_required(VERSION 2.6.0)
 
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+if(NOT WIN32)
+	option(USE_NACL "Use NaCl library instead of libsodium")
+endif()
+
+if(NOT USE_NACL)
+	set(LINK_CRYPTO_LIBRARY "sodium")
+else()
+	find_package(NaCl REQUIRED)
+
+	include_directories(${NACL_INCLUDE_DIR})
+	add_definitions(-DVANILLA_NACL)
+
+	set(LINK_CRYPTO_LIBRARY ${NACL_LIBRARIES})
+endif()
+
 #MinGW prints more warnings for -Wall than gcc does, thus causing build to fail
 if(NOT WIN32)
 	if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
@@ -17,7 +34,7 @@ macro(linkCoreLibraries exe_name)
 			ws2_32)
 	else()
 		target_link_libraries(${exe_name} core
-			sodium)
+			${LINK_CRYPTO_LIBRARY})
 	endif()
 endmacro()
 

--- a/cmake/FindNaCl.cmake
+++ b/cmake/FindNaCl.cmake
@@ -1,0 +1,17 @@
+find_path(NACL_INCLUDE_DIR crypto_box.h
+	$ENV{NACL_INCLUDE_DIR} /usr/include/nacl/
+	DOC "Directory which contain NaCl headers")
+
+find_path(NACL_LIBRARY_DIR libnacl.a
+	$ENV{NACL_LIBRARY_DIR} /usr/lib/nacl
+	DOC "Directory which contain libnacl.a, cpucycles.o, and randombytes.o")
+
+if(NACL_LIBRARY_DIR)
+	set(NACL_LIBRARIES
+		"${NACL_LIBRARY_DIR}/cpucycles.o"
+		"${NACL_LIBRARY_DIR}/libnacl.a"
+		"${NACL_LIBRARY_DIR}/randombytes.o")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NaCl DEFAULT_MSG NACL_INCLUDE_DIR NACL_LIBRARY_DIR NACL_LIBRARIES)

--- a/core/network.h
+++ b/core/network.h
@@ -56,11 +56,7 @@
 /* we use libsodium by default */
 #include <sodium.h>
 #else
-
-/* TODO: Including stuff like this is bad. This needs fixing.
-   We keep support for the original NaCl for now. */
-#include "../nacl/build/Linux/include/amd64/crypto_box.h"
-
+#include <crypto_box.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Cmake support for `USE_NACL` option

```
cmake -DUSE_NACL=ON ..
```

You can specify custom paths using

```
-DNACL_LIBRARY_DIR=/path/to/your/nacl/build/lib/
-DNACL_INCLUDE_DIR=/path/to/your/nacl/build/include/
```
