### PR TITLE
travis: use apt-get -y option and fix builds randomly timing out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - cd ..
 # installing libconfig, needed for DHT_bootstrap_daemon
   - sudo sed -i 's/precise/quantal/' /etc/apt/sources.list # needed for libconfig-dev
-  - sudo apt-get update -qq
+  - sudo apt-get update -q
   - sudo apt-get -y install libconfig-dev
 
 script:


### PR DESCRIPTION
The Advanced Packaging Tool has an option to automatically assume Yes to all queries. We don't
need to use GNU yes for this.

Additionally, I've changed .travis.yml to use apt-get -q update instead of -qq. This should fix long apt-get updates timing out because they're producing no output.
