### PR TITLE
touch up docs to link to eachother

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,17 @@
+#Install Instructions
+
+- [Installation](#installation)
+    - [Linux](#linux)
+    - [OS X](#osx)
+      - [Homebrew](#homebrew)
+      - [Non-Homebrew](#non-homebrew)
+    - [Windows](#windows)
+- [Usage](#usage)
+
+<a name="installation" />
 ##Installation
 
+<a name="linux" />
 ###Linux:
 
 Build dependencies:
@@ -40,8 +52,10 @@ Or you could just build everything that is supported on your platform by running
 make
 ```
 
-###OSX:
+<a name="osx" />
+###OS X:
 
+<a name="homebrew" />
 ####Homebrew:
 ```
 brew install libtool automake autoconf libconfig libsodium
@@ -50,6 +64,7 @@ make
 sudo make install
 ```
 
+<a name="non-homebrew" />
 ####Non-homebrew:
 
 Much the same as Linux, remember to install the latest XCode and the developer tools (Preferences -> Downloads -> Command Line Tools).
@@ -69,6 +84,7 @@ Another thing you may want to install is the latest gcc, this caused me a few pr
 no longer includes gcc and instead uses LLVM-GCC, a nice install guide can be found at
 http://caiustheory.com/install-gcc-421-apple-build-56663-with-xcode-42
 
+<a name="windows" />
 ###Windows:
 
 You should install:
@@ -100,3 +116,8 @@ Or you could just build everything that is supported on your platform by running
 ```bash
 mingw32-make
 ```
+
+<a name="usage" />
+## Usage
+
+- [Start Guide](start_guide.md)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Keep everything really simple.
 
 ## Roadmap:
 - [x] Get our DHT working perfectly. (Done, needs large scale testing though)
-- [x] Reliable connection (See Lossless UDP protocol) to other peers according to client ID. (Done, see DHT_sendfiletest.c for an example)
+- [x] Reliable connection (See Lossless UDP protocol) to other peers according to client ID. (Done, see `DHT_sendfiletest.c` for an example)
 - [x] Encryption. (Done)
 - [  ] Get a simple text only IM client working perfectly. (This is where we are)
 - [  ] Streaming media
@@ -45,7 +45,8 @@ configure for the normal user or suffer from being way too centralized.
 
 ### Documentation:
 
-[DHT Protocol](https://github.com/irungentoo/ProjectTox-Core/wiki/DHT)<br />
-[Lossless UDP Protocol](https://github.com/irungentoo/ProjectTox-Core/wiki/Lossless-UDP)<br />
-[Crypto](https://github.com/irungentoo/ProjectTox-Core/wiki/Crypto)<br />
-[Ideas](https://github.com/irungentoo/ProjectTox-Core/wiki/Ideas)
+- [Installation](/INSTALL.md)
+- [DHT Protocol](https://github.com/irungentoo/ProjectTox-Core/wiki/DHT)<br />
+- [Lossless UDP Protocol](https://github.com/irungentoo/ProjectTox-Core/wiki/Lossless-UDP)<br />
+- [Crypto](https://github.com/irungentoo/ProjectTox-Core/wiki/Crypto)<br />
+- [Ideas](https://github.com/irungentoo/ProjectTox-Core/wiki/Ideas)

--- a/start_guide.md
+++ b/start_guide.md
@@ -1,5 +1,5 @@
 # Using Tox
-1. Build Tox
+1. [Build Tox](/INSTALL.md)
 2. Fix errors
 3. Consult IRC for help
 4. Go on debugging journy for devs
@@ -13,25 +13,25 @@ Tox. Here's a user-friendly attempt at it.
 1. Connect to the network!
     + You need to connect to a bootstrapping server, to give you a public key.
     + Where can I find a public server? Right here, as of now:
-      (the help message from running nTox with no args will help)
-        + 198.46.136.167 33445 728925473812C7AAC482BE7250BCCAD0B8CB9F737BF3D42ABD34459C1768F854
-        + 192.81.133.111 33445 8CD5A9BF0A6CE358BA36F7A653F99FA6B258FF756E490F52C1F98CC420F78858
-        + 66.175.223.88 33445  AC4112C975240CAD260BB2FCD134266521FAAF0A5D159C5FD3201196191E4F5D
-        + 192.184.81.118 33445 5CD7EB176C19A2FD840406CD56177BB8E75587BB366F7BB3004B19E3EDC04143
+      (the help message from running `nTox` with no args will help)
+        + `198.46.136.167 33445 728925473812C7AAC482BE7250BCCAD0B8CB9F737BF3D42ABD34459C1768F854`
+        + `192.81.133.111 33445 8CD5A9BF0A6CE358BA36F7A653F99FA6B258FF756E490F52C1F98CC420F78858`
+        + `66.175.223.88 33445  AC4112C975240CAD260BB2FCD134266521FAAF0A5D159C5FD3201196191E4F5D`
+        + `192.184.81.118 33445 5CD7EB176C19A2FD840406CD56177BB8E75587BB366F7BB3004B19E3EDC04143`
 2. Find a friend!
     + Now that you're on the network, you need a friend. To get one of those,
        you need to to send or receive a request. What's a request, you ask?
        It's like a friend request, but we use really scary and cryptic numbers
-       instead of names. When nTox starts, it shows your _your_ long, scary number,
+       instead of names. When `nTox` starts, it shows your _your_ long, scary number,
        called your *public key*. Give that to people, and they can add you as
-       as "friend". Or, you can add someone else, with the */f* command, if you like.
+       as "friend". Or, you can add someone else, with the `/f` command, if you like.
 3. Chat it up!
-    + Now use the */m* command to send a message to someone. Wow, you're chatting!
+    + Now use the `/m` command to send a message to someone. Wow, you're chatting!
 4. But something broke!
     + Yeah, pre-alpha-alpha software tends to do that. We're working on it.
-    + Please report all crashes to either the github page, or #tox-dev on freenode.
-5. Nothing broke, but what does */f* mean?
-    + nTox parses text as a command if the first character is a forward-slash ('/').
+    + Please report all crashes to either the [github](/) page, or `#tox-dev` on freenode.
+5. Nothing broke, but what does `/f` mean?
+    + `nTox` parses text as a command if the first character is a forward-slash (`/`).
       You can check all commands in commands.md.
 6. Use and support Tox!
     + Code for us, debug for us, document for us, translate for us, even just talk about us!


### PR DESCRIPTION
# summary

I've toched up the documentation to correctly link to each other and use markdown syntax where appropriate.  This way, a user can start from the top of the readme, and end up at the end of the start guide without having to comb through the source tree for the relevant documentation.
# demo

You can see how the documentation will look on my forked repo https://github.com/bahamas10/ProjectTox-Core/tree/dave-touchup-docs ... scroll to the bottom to see the link to `Installation`  
