### PR TITLE
fixed friend add bugs and gave no message its own error

### DIFF
--- a/core/Messenger.c
+++ b/core/Messenger.c
@@ -94,25 +94,31 @@ int getclient_id(int friend_id, uint8_t *client_id)
     return -1;
 }
 
-/* add a friend
-   set the data that will be sent along with friend request
-   client_id is the client id of the friend
-   data is the data and length is the length
-   returns the friend number if success
-   return -1 if message length is too long
-   return -2 if user's own key
-   return -3 if already a friend
-   return -4 for other*/
+/*
+ * add a friend
+ * set the data that will be sent along with friend request
+ * client_id is the client id of the friend
+ * data is the data and length is the length
+ * returns the friend number if success
+ * return -1 if message length is too long
+ * return -2 if no message (message length must be >= 1 byte)
+ * return -3 if user's own key
+ * return -4 if friend request already sent or already a friend
+ * return -5 for unknown error 
+ */
 int m_addfriend(uint8_t *client_id, uint8_t *data, uint16_t length)
 {
     if (length >= (MAX_DATA_SIZE - crypto_box_PUBLICKEYBYTES 
                          - crypto_box_NONCEBYTES - crypto_box_BOXZEROBYTES 
                          + crypto_box_ZEROBYTES))
         return -1;
-    if (memcmp(client_id, self_public_key, crypto_box_PUBLICKEYBYTES) == 0)
+    if (length < 1)
         return -2;
-    if (getfriend_id(client_id) != -1)
+    if (memcmp(client_id, self_public_key, crypto_box_PUBLICKEYBYTES) == 0)
         return -3;
+    if (getfriend_id(client_id) != -1)
+        return -4;
+
     uint32_t i;
     for (i = 0; i <= numfriends; ++i) { /*TODO: dynamic memory allocation, this will segfault if there are more than MAX_NUM_FRIENDS*/
         if(friendlist[i].status == 0) {
@@ -130,7 +136,7 @@ int m_addfriend(uint8_t *client_id, uint8_t *data, uint16_t length)
             return i;
         }
     }
-    return -4;
+    return -5;
 }
 
 int m_addfriend_norequest(uint8_t * client_id)

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -106,24 +106,28 @@ void line_eval(char lines[HISTORY][STRING_LENGTH], char *line)
             char temp_id[128];
             for (i = 0; i < 128; i++) 
                 temp_id[i] = line[i+prompt_offset];
+
             int num = m_addfriend(hex_string_to_bin(temp_id), (uint8_t*)"Install Gentoo", sizeof("Install Gentoo"));
             char numstring[100];
             switch (num) {
-                case -1:
-                    sprintf(numstring, "[i] Incorrect key length");
-                    break;
-                case -2:
-                    sprintf(numstring, "[i] That appears to be your own key");
-                    break;
-                case -3:
-                    sprintf(numstring, "[i] Friend request already sent");
-                    break;
-                case -4:
-                    sprintf(numstring, "[i] Could not add friend");
-                    break;
-                default:
-                    sprintf(numstring, "[i] Added friend %d", num);
-                    break;
+            case -1:
+                sprintf(numstring, "[i] Message is too long.");
+                break;
+            case -2:
+                sprintf(numstring, "[i] Please add a message to your request.");
+                break;
+            case -3:
+                sprintf(numstring, "[i] That appears to be your own ID.");
+                break;
+            case -4:
+                sprintf(numstring, "[i] Friend request already sent.");
+                break;
+            case -5:
+                sprintf(numstring, "[i] Undefined error when adding friend.");
+                break;
+            default:
+                sprintf(numstring, "[i] Added friend as %d.", num);
+                break;
             }
             new_lines(numstring);
             do_refresh();

--- a/testing/nTox_win32.c
+++ b/testing/nTox_win32.c
@@ -132,13 +132,15 @@ void line_eval(char* line)
                 printf(numstring);
             }
             else if (num == -1) 
-                printf("\nWrong key size\n\n");
+                printf("\n[i] Message is too long.\n\n");
             else if (num == -2)
-                printf("\nYou can't add yourself\n\n");
+                printf("\n[i] Please add a message to your friend request.\n\n");
             else if (num == -3)
-                printf("\nYou already have this person added\n\n");
+                printf("\n[i] That appears to be your own ID.\n\n");
             else if (num == -4)
-                printf("\nUndefined error when adding friend");
+                printf("\n[i] Friend request already sent.\n\n");
+            else if (num == -5)
+                printf("\n[i] Undefined error when adding friend\n\n");
         }
 
         else if (inpt_command == 'r') {

--- a/testing/toxic/prompt.c
+++ b/testing/toxic/prompt.c
@@ -138,13 +138,15 @@ static void execute(ToxWindow* self, char* cmd) {
       wprintw(self->window, "Message is too long.\n");
       break;
     case -2:
+      wprintw(self->window, "Please add a message to your request.\n");
+    case -3:
       wprintw(self->window, "That appears to be your own ID.\n");
       break;
-    case -3:
+    case -4:
       wprintw(self->window, "Friend request already sent.\n");
       break;
-    case -4:
-      wprintw(self->window, "Invalid ID.\n");
+    case -5:
+      wprintw(self->window, "[i] Undefined error when adding friend.\n");
       break; 
     default:
       wprintw(self->window, "Friend added as %d.\n", num);


### PR DESCRIPTION
The if (length == 0) condition was doing nothing, and if there is going to be a forced message for friend adds, it should have its own error code/message. But a default message is a better solution imo.
