### PR TITLE
OSX Homebrew Install Doc Fix

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,7 @@ make
 <a name="homebrew" />
 ####Homebrew:
 ```
-brew install libtool automake autoconf libconfig libsodium
+brew install libtool automake autoconf libconfig libsodium cmake
 cmake .
 make
 sudo make install


### PR DESCRIPTION
OSX: 10.8.4
XCode: 4.6.3

Needed to install cmake using homebrew. 

Also `sudo make install` did not work (No rule to make target 'install') but was able to compile nTox successfully.
