### PR TITLE
Changed CMake options to compile the core as a shared library instead of static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,15 +33,15 @@ if(NOT USE_NACL)
 endif()
 
 macro(linkCoreLibraries exe_name)
-	add_dependencies(${exe_name} core)
+	add_dependencies(${exe_name} toxcore)
 	if(WIN32)
 		include_directories(${CMAKE_HOME_DIRECTORY}/sodium/include/)
-		target_link_libraries(${exe_name} core
+		target_link_libraries(${exe_name} toxcore
 		${CMAKE_SOURCE_DIR}/sodium/lib/libsodium.a
 			ws2_32)
 	else()
 		include_directories(${SODIUM_INCLUDE_DIR})
-		target_link_libraries(${exe_name} core
+		target_link_libraries(${exe_name} toxcore
 			${LINK_CRYPTO_LIBRARY})
 
 	endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.6.0)
-project(core C)
+project(toxcore C)
 
 if(WIN32)
 	include_directories(${CMAKE_HOME_DIRECTORY}/sodium/include/)
@@ -16,4 +16,4 @@ set(core_sources
 	LAN_discovery.c
 	Messenger.c)
 
-add_library(core ${core_sources})
+add_library(toxcore SHARED ${core_sources})


### PR DESCRIPTION
It is now compiled under 'toxcore' instead of just 'core' to be able to be installed globally without conflicts.

The primary reason why this should be done is that so it can be wrapped in Python, Mono and many other managed languages without having to recompile it as a shared library, something that could lead to increased fragmentation (which might be a big issue if a security issue is found).

Works and compiles perfectly fine.
