### PR TITLE
Fixed 2 Null pointer derefrences in both nTox and toxic

### DIFF
--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -428,7 +428,9 @@ int main(int argc, char *argv[])
     }
 
     for(i = 0; i < argc; i++) {
-        if(argv[i][0] == '-') {
+      if (argv[i] == NULL){
+        break;
+      } else if(argv[i][0] == '-') {
             if(argv[i][1] == 'h') {
                 print_help();
                 exit(0);

--- a/testing/toxic/main.c
+++ b/testing/toxic/main.c
@@ -288,7 +288,9 @@ int main(int argc, char* argv[]) {
   ToxWindow* a;
 
     for(i = 0; i < argc; i++) {
-        if(argv[i][0] == '-') {
+      if (argv[i] == NULL){
+        break; 
+      } else if(argv[i][0] == '-') {
             if(argv[i][1] == 'f') {
                 if(argv[i + 1] != NULL)
                     filename = argv[i + 1];


### PR DESCRIPTION
This resulted in holes while loading data files in nTox and toxic that could be exploited, possibly allowing arbitrary code to be ran when loading data files.

Tested by charmlesscoin.
