### PR TITLE
Use void for functions with no parameters

### DIFF
--- a/core/DHT.c
+++ b/core/DHT.c
@@ -873,7 +873,7 @@ IP_Port DHT_getfriendip(uint8_t * client_id)
 /* Ping each client in the "friends" list every 60 seconds. Send a get nodes request
  * every 20 seconds to a random good node for each "friend" in our "friends" list. 
  */
-void doDHTFriends()
+static void doDHTFriends(void)
 {
     uint32_t i, j;
     uint64_t temp_time = unix_time();
@@ -912,7 +912,7 @@ static uint64_t close_lastgetnodes;
 /* Ping each client in the close nodes list every 60 seconds.
  * Send a get nodes request every 20 seconds to a random good node in the list.
  */
-void doClose()
+static void doClose(void)
 {
     uint32_t i;
     uint64_t temp_time = unix_time();
@@ -1211,7 +1211,7 @@ static void punch_holes(IP ip, uint16_t * port_list, uint16_t numports, uint16_t
     friends_list[friend_num].punching_index = i;
 }
 
-static void doNAT()
+static void doNAT(void)
 {
     uint32_t i;
     uint64_t temp_time = unix_time();
@@ -1275,7 +1275,7 @@ int DHT_handlepacket(uint8_t * packet, uint32_t length, IP_Port source)
     return 0;
 }
 
-void doDHT()
+void doDHT(void)
 {
     doClose();
     doDHTFriends();
@@ -1283,7 +1283,7 @@ void doDHT()
 }
 
 /* get the size of the DHT (for saving) */
-uint32_t DHT_size()
+uint32_t DHT_size(void)
 {
     return sizeof(close_clientlist) + sizeof(Friend) * num_friends;
 }
@@ -1341,7 +1341,7 @@ int DHT_load(uint8_t * data, uint32_t size)
 /* returns 0 if we are not connected to the DHT
  * returns 1 if we are 
  */
-int DHT_isconnected()
+int DHT_isconnected(void)
 {
     uint32_t i;
     uint64_t temp_time = unix_time();

--- a/core/DHT.h
+++ b/core/DHT.h
@@ -58,7 +58,7 @@ int DHT_delfriend(uint8_t *client_id);
 IP_Port DHT_getfriendip(uint8_t *client_id);
 
 /* Run this function at least a couple times per second (It's the main loop) */
-void doDHT();
+void doDHT(void);
 
 /* if we receive a DHT packet we call this function so it can be handled.
     return 0 if packet is handled correctly.
@@ -90,7 +90,7 @@ int friend_ips(IP_Port *ip_portlist, uint8_t *friend_id);
 /* SAVE/LOAD functions */
 
 /* get the size of the DHT (for saving) */
-uint32_t DHT_size();
+uint32_t DHT_size(void);
 
 /* save the DHT in data where data is an array of size DHT_size() */
 void DHT_save(uint8_t *data);

--- a/core/LAN_discovery.c
+++ b/core/LAN_discovery.c
@@ -76,7 +76,7 @@ static uint32_t get_broadcast(void)
 #endif
 
 /* Return the broadcast ip */
-static IP broadcast_ip()
+static IP broadcast_ip(void)
 {
     IP ip;
     #ifdef __linux

--- a/core/Lossless_UDP.c
+++ b/core/Lossless_UDP.c
@@ -284,7 +284,7 @@ static int new_inconnection(IP_Port ip_port)
  * Returns an integer corresponding to the next connection in our incoming connection list.
  * Return -1 if there are no new incoming connections in the list.
  */
-int incoming_connection()
+int incoming_connection(void)
 {
     uint32_t i;
     for (i = 0; i < MAX_CONNECTIONS; ++i) {
@@ -298,7 +298,7 @@ int incoming_connection()
 }
 
 /* Try to free some memory from the connections array. */
-static void free_connections()
+static void free_connections(void)
 {
     uint32_t i;
     for(i = connections_length; i != 0; --i)
@@ -793,7 +793,7 @@ int LosslessUDP_handlepacket(uint8_t *packet, uint32_t length, IP_Port source)
  * Send handshake requests
  * handshake packets are sent at the same rate as SYNC packets
  */
-static void doNew()
+static void doNew(void)
 {
     uint32_t i;
     uint64_t temp_time = current_time();
@@ -817,7 +817,7 @@ static void doNew()
     }
 }
 
-static void doSYNC()
+static void doSYNC(void)
 {
     uint32_t i;
     uint64_t temp_time = current_time();
@@ -830,7 +830,7 @@ static void doSYNC()
     }
 }
 
-static void doData()
+static void doData(void)
 {
     uint32_t i;
     uint64_t j;
@@ -851,7 +851,7 @@ static void doData()
  *
  * TODO: flow control.
  */
-static void adjustRates()
+static void adjustRates(void)
 {
     uint32_t i;
     uint64_t temp_time = current_time();
@@ -871,7 +871,7 @@ static void adjustRates()
 }
 
 /* Call this function a couple times per second It's the main loop. */
-void doLossless_UDP()
+void doLossless_UDP(void)
 {
     doNew();
     doSYNC();

--- a/core/Lossless_UDP.h
+++ b/core/Lossless_UDP.h
@@ -52,7 +52,7 @@ int getconnection_id(IP_Port ip_port);
  * Returns an int corresponding to the next connection in our imcoming connection list
  * Return -1 if there are no new incoming connections in the list.
  */
-int incoming_connection();
+int incoming_connection(void);
 
 /* 
  * Return -1 if it could not kill the connection.
@@ -110,7 +110,7 @@ uint32_t recvqueue(int connection_id);
 int is_connected(int connection_id);
 
 /* Call this function a couple times per second It's the main loop. */
-void doLossless_UDP();
+void doLossless_UDP(void);
 
 /* 
  * If we receive a Lossless_UDP packet, call this function so it can be handled.

--- a/core/Messenger.c
+++ b/core/Messenger.c
@@ -363,7 +363,7 @@ void m_callback_userstatus(void (*function)(int, uint8_t *, uint16_t))
 
 #define PORT 33445
 /* run this at startup */
-int initMessenger()
+int initMessenger(void)
 {
     new_keys();
     m_set_userstatus((uint8_t*)"Online", sizeof("Online"));
@@ -378,7 +378,7 @@ int initMessenger()
 }
 
 //TODO: make this function not suck.
-static void doFriends()
+static void doFriends(void)
 {
     /* TODO: add incoming connections and some other stuff. */
     uint32_t i;
@@ -464,7 +464,7 @@ static void doFriends()
     }
 }
 
-static void doInbound()
+static void doInbound(void)
 {
     uint8_t secret_nonce[crypto_box_NONCEBYTES];
     uint8_t public_key[crypto_box_PUBLICKEYBYTES];
@@ -488,7 +488,7 @@ static void doInbound()
 static uint64_t last_LANdiscovery;
 
 /*Send a LAN discovery packet every LAN_DISCOVERY_INTERVAL seconds*/
-static void LANdiscovery()
+static void LANdiscovery(void)
 {
     if (last_LANdiscovery + LAN_DISCOVERY_INTERVAL < unix_time()) {
         send_LANdiscovery(htons(PORT));
@@ -498,7 +498,7 @@ static void LANdiscovery()
 
 
 /* the main loop that needs to be run at least 200 times per second. */
-void doMessenger()
+void doMessenger(void)
 {
     IP_Port ip_port;
     uint8_t data[MAX_UDP_PACKET_SIZE];
@@ -532,7 +532,7 @@ void doMessenger()
 }
 
 /* returns the size of the messenger data (for saving) */
-uint32_t Messenger_size()
+uint32_t Messenger_size(void)
 {
     return crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES
            + sizeof(uint32_t) + DHT_size() + sizeof(uint32_t) + sizeof(Friend) * numfriends;

--- a/core/Messenger.h
+++ b/core/Messenger.h
@@ -160,15 +160,15 @@ void m_callback_userstatus(void (*function)(int, uint8_t *, uint16_t));
 /* run this at startup
     returns 0 if no connection problems
     returns -1 if there are problems */
-int initMessenger();
+int initMessenger(void);
 
 /* the main loop that needs to be run at least 200 times per second */
-void doMessenger();
+void doMessenger(void);
 
 /* SAVING AND LOADING FUNCTIONS: */
 
 /* returns the size of the messenger data (for saving) */
-uint32_t Messenger_size();
+uint32_t Messenger_size(void);
 
 /* save the messenger in data (must be allocated memory of size Messenger_size()) */
 void Messenger_save(uint8_t *data);

--- a/core/net_crypto.c
+++ b/core/net_crypto.c
@@ -440,7 +440,7 @@ int is_cryptoconnected(int crypt_connection_id)
 
 /* Generate our public and private keys
    Only call this function the first time the program starts. */
-void new_keys()
+void new_keys(void)
 {
     crypto_box_keypair(self_public_key,self_secret_key);
 }
@@ -479,7 +479,7 @@ static int new_incoming(int id)
 
 /* TODO: optimize this
    handle all new incoming connections. */
-static void handle_incomings()
+static void handle_incomings(void)
 {
     int income;
     while (1) {
@@ -490,7 +490,7 @@ static void handle_incomings()
 }
 
 /* handle received packets for not yet established crypto connections. */
-static void receive_crypto()
+static void receive_crypto(void)
 {
     uint32_t i;
     for (i = 0; i < MAX_CRYPTO_CONNECTIONS; ++i) {
@@ -547,7 +547,7 @@ static void receive_crypto()
 
 /* run this to (re)initialize net_crypto
    sets all the global connection variables to their default values. */
-void initNetCrypto()
+void initNetCrypto(void)
 {
     memset(crypto_connections, 0 ,sizeof(crypto_connections));
     memset(incoming_connections, -1 ,sizeof(incoming_connections));
@@ -556,7 +556,7 @@ void initNetCrypto()
         crypto_connections[i].number = ~0;
 }
 
-static void killTimedout()
+static void killTimedout(void)
 {
     uint32_t i;
     for (i = 0; i < MAX_CRYPTO_CONNECTIONS; ++i) {
@@ -570,7 +570,7 @@ static void killTimedout()
 }
 
 /* main loop */
-void doNetCrypto()
+void doNetCrypto(void)
 {
     /* TODO:check if friend requests were sent correctly
        handle new incoming connections

--- a/core/net_crypto.h
+++ b/core/net_crypto.h
@@ -110,7 +110,7 @@ int is_cryptoconnected(int crypt_connection_id);
 
 /* Generate our public and private keys
     Only call this function the first time the program starts. */
-void new_keys();
+void new_keys(void);
 
 /* save the public and private keys to the keys array
     Length must be crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES */
@@ -122,10 +122,10 @@ void load_keys(uint8_t * keys);
 
 /* run this to (re)initialize net_crypto
     sets all the global connection variables to their default values. */
-void initNetCrypto();
+void initNetCrypto(void);
 
 /* main loop */
-void doNetCrypto();
+void doNetCrypto(void);
 
 #ifdef __cplusplus
 }

--- a/core/network.c
+++ b/core/network.c
@@ -24,7 +24,7 @@
 #include "network.h"
 
 /* returns current UNIX time in microseconds (us). */
-uint64_t current_time()
+uint64_t current_time(void)
 {
     uint64_t time;
 #ifdef WIN32
@@ -46,7 +46,7 @@ uint64_t current_time()
 
 /* return a random number
    NOTE: this function should probably not be used where cryptographic randomness is absolutely necessary */
-uint32_t random_int()
+uint32_t random_int(void)
 {
 #ifndef VANILLA_NACL
     //NOTE: this function comes from libsodium
@@ -153,7 +153,7 @@ int init_networking(IP ip, uint16_t port)
 }
 
 /* function to cleanup networking stuff */
-void shutdown_networking()
+void shutdown_networking(void)
 {
 #ifdef WIN32
     closesocket(sock);

--- a/core/network.h
+++ b/core/network.h
@@ -90,11 +90,11 @@ typedef struct {
 } ADDR;
 
 /* returns current time in milleseconds since the epoch. */
-uint64_t current_time();
+uint64_t current_time(void);
 
 /* return a random number
     NOTE: this function should probably not be used where cryptographic randomness is absolutely necessary */
-uint32_t random_int();
+uint32_t random_int(void);
 
 /* Basic network functions: */
 
@@ -115,7 +115,7 @@ int receivepacket(IP_Port *ip_port, uint8_t *data, uint32_t *length);
 int init_networking(IP ip, uint16_t port);
 
 /* function to cleanup networking stuff(doesn't do much right now) */
-void shutdown_networking();
+void shutdown_networking(void);
 
 /*
   resolve_addr():


### PR DESCRIPTION
Use (void) instead of () for functions with no parameters.
