### PR TITLE
refactor the friend list to use a linked list instead of a static array

### DIFF
--- a/core/Messenger.c
+++ b/core/Messenger.c
@@ -57,7 +57,7 @@ static uint32_t numfriends = 0;
    static uint8_t online; */
 
 /* find friend #friendnumber in the friend list */
-Friend *seektofriend(uint32_t friendnumber)
+static Friend *seektofriend(int friendnumber)
 {
     uint32_t i;
     Friend *f;


### PR DESCRIPTION
Previously the friend list was stored in a static array with a maximum size of 256 friends. This change refactors the friend list to use a linked list structure instead. This allows it to grow and shrink as needed; there is no maximum number of friends a user can have (it also reduces memory usage, but that's not a big concern). 

The disadvantage of this approach is that linked lists are slightly trickier to work with than simple arrays, and this change may introduce some bugs. Toxic appears to be working though.

Some static functions were modified to take a `Friend *` as an argument instead of an array index for easier processing. Global functions that take an array index were left alone to avoid breaking anything; these functions now use the new function `seektofriend` to simulate array indexing in a linked list.
