### PR TITLE
Fixed toxic friends list flicker

### DIFF
--- a/testing/toxic/friendlist.c
+++ b/testing/toxic/friendlist.c
@@ -116,7 +116,7 @@ static void friendlist_onDraw(ToxWindow* self) {
   curs_set(0);
   size_t i;
 
-  wclear(self->window);
+  werase(self->window);
 
   if(num_friends == 0) {
     wprintw(self->window, "Empty. Add some friends! :-)\n");


### PR DESCRIPTION
Using wclear makes the window clear again on the next call to wrefresh, which was making the friends list flicker (using rxvt-unicode). I changed this to werase, which fixed the issue.
