### PR TITLE
On UNIX, if pkg-config is available, use it to find the location of libconfig's headers.

### DIFF
--- a/cmake/FindLIBCONFIG.cmake
+++ b/cmake/FindLIBCONFIG.cmake
@@ -5,7 +5,12 @@
 # LIBCONFIG_FOUND
 #
 
-FIND_PATH(LIBCONFIG_INCLUDE_DIR NAMES libconfig.h)
+if (UNIX)
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(_LIBCONFIG QUIET libconfig)
+endif ()
+
+FIND_PATH(LIBCONFIG_INCLUDE_DIR NAMES libconfig.h HINTS ${_LIBCONFIG_INCLUDEDIR})
 
 FIND_LIBRARY(LIBCONFIG_LIBRARY NAMES config)
 


### PR DESCRIPTION
On UNIX, if pkg-config is available, use it to find the location of libconfig's headers.

```
modified:   cmake/FindLIBCONFIG.cmake
```
