### PR TITLE
Tox didn't want to build until I added this.

### DIFF
--- a/auto_tests/cmake/messenger_test.cmake
+++ b/auto_tests/cmake/messenger_test.cmake
@@ -5,6 +5,8 @@ set(exe_name messenger_test)
 add_executable(${exe_name}
     messenger_test.c)
 
+set(EXTRA_LIBS m rt pthread)
+
 linkCoreLibraries(${exe_name})
 add_dependencies(${exe_name} Check)
-target_link_libraries(${exe_name} check)
+target_link_libraries(${exe_name} check ${EXTRA_LIBS})


### PR DESCRIPTION
I had problems building Tox on Ubuntu 12.10 x64_86 (see issue #419) and this seems to fix it.

You should probably not merge this unless someone else has the same problems because I am not sure if this is needed for other platforms. Also, I don't know much CMake, so I could've done something incorrectly.
