### PR TITLE
Fixed m_sendmessage to return the ID of the message sent

### DIFF
--- a/core/Messenger.c
+++ b/core/Messenger.c
@@ -231,7 +231,11 @@ uint32_t m_sendmessage(int friendnumber, uint8_t *message, uint32_t length)
     uint32_t msgid = ++friendlist[friendnumber].message_id;
     if (msgid == 0)
         msgid = 1; /* otherwise, false error */
-    return m_sendmessage_withid(friendnumber, msgid, message, length);
+    if(m_sendmessage_withid(friendnumber, msgid, message, length)) {
+        return msgid;
+    }
+    
+    return 0;
 }
 
 uint32_t m_sendmessage_withid(int friendnumber, uint32_t theid, uint8_t *message, uint32_t length)


### PR DESCRIPTION
Hi,

  the m_sendmessage function is supposed to return the ID of the message sent, however it ends up only ever returning 0 (failed) or 1.

Daniel
