### PR TITLE
Fixed warnings on Windows

### DIFF
--- a/core/network.h
+++ b/core/network.h
@@ -31,8 +31,10 @@
 #include <time.h>
 
 #ifdef WIN32 /* Put win32 includes here */
+#ifndef WINVER
 //Windows XP
 #define WINVER 0x0501
+#endif
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>

--- a/testing/crypto_speed_test.c
+++ b/testing/crypto_speed_test.c
@@ -1,6 +1,9 @@
 // Hi-resolution timer
 #ifdef WIN32
-
+#ifndef WINVER
+//Windows XP
+#define WINVER 0x0501
+#endif
 #include <windows.h>
 double get_time()
 {


### PR DESCRIPTION
Target version of Windows API should be defined before including `windows.h`
