### PR TITLE
Replaced friendstatus with connectionstatus

### DIFF
--- a/core/Messenger.h
+++ b/core/Messenger.h
@@ -211,9 +211,15 @@ void m_callback_userstatus(void (*function)(int, USERSTATUS));
     in that case, you should discard it. */
 void m_callback_read_receipt(void (*function)(int, uint32_t));
 
-/* set the callback for friend status changes
-    function(int friendnumber, uint8_t status) */
-void m_callback_friendstatus(void (*function)(int, uint8_t));
+/* set the callback for conenction status changes
+    function(int friendnumber, uint8_t status)
+    status:
+      0 -- friend went offline after being previously online
+      1 -- friend went online
+    note that this callback is not called when adding friends, thus the "after
+    being previously online" part. it's assumed that when adding friends,
+    their connection status is offline. */
+void m_callback_connectionstatus(void (*function)(int, uint8_t));
 
 /* run this at startup
     returns 0 if no connection problems


### PR DESCRIPTION
`friendstatus` callback was returning `friendnumber` in the middle of `m_addfriend*` functions, thus without client getting the `friendnumber` from `m_addfriend*` functions yet. Here is a commit made by @Alek900 that fixed one of `m_addfriend` functions 851c52571f5024000ee17b7b41fb5ce69960104a .

The fix basically made so that the `friendstatus` callback won't ever return `FRIEND_ADDED` value. So I found it appropriate to restrict return values of the callback to only [Online, Offline] and accordingly rename the callback.
