### PR TITLE
make connection more robust for toxic

### DIFF
--- a/testing/toxic/main.c
+++ b/testing/toxic/main.c
@@ -247,12 +247,11 @@ static void init_windows()
 
 static void do_tox()
 {
-  static int conn_try = 1;
+  static int conn_try = 0;
   static bool dht_on = false;
-  if (!dht_on && !DHT_isconnected()) {
+  if (!dht_on && !DHT_isconnected() && !(conn_try++ % 100)) {
     init_connection();
-    if (!(conn_try++ % 100))
-      wprintw(prompt->window, "\nAttempting to connect...\n");
+    wprintw(prompt->window, "\nEstablishing connection...\n");
   }
   else if (!dht_on && DHT_isconnected()) {
     dht_on = true;


### PR DESCRIPTION
Instead of making one connection attempt at startup, it keeps trying to connect until a connection is established, and also tries to reconnect after a DC.
