### PR TITLE
Messenger refactor - redid work from pull request 79

### DIFF
--- a/core/Messenger.c
+++ b/core/Messenger.c
@@ -24,40 +24,8 @@
 #include "Messenger.h"
 #define MIN(a,b) (((a)<(b))?(a):(b))
 
-typedef struct {
-    uint8_t client_id[CLIENT_ID_SIZE];
-    int crypt_connection_id;
-    uint64_t friend_request_id; /* id of the friend request corresponding to the current friend request to the current friend. */
-    uint8_t status; /* 0 if no friend, 1 if added, 2 if friend request sent, 3 if confirmed friend, 4 if online. */
-    uint8_t info[MAX_DATA_SIZE]; /* the data that is sent during the friend requests we do */
-    uint8_t name[MAX_NAME_LENGTH];
-    uint8_t name_sent; /* 0 if we didn't send our name to this friend 1 if we have. */
-    uint8_t *statusmessage;
-    uint16_t statusmessage_length;
-    uint8_t statusmessage_sent;
-    USERSTATUS userstatus;
-    uint8_t userstatus_sent;
-    uint16_t info_size; /* length of the info */
-    uint32_t message_id; /* a semi-unique id used in read receipts */
-    uint8_t receives_read_receipts; /* shall we send read receipts to this person? */
-} Friend;
-
-uint8_t self_public_key[crypto_box_PUBLICKEYBYTES];
-
-static uint8_t self_name[MAX_NAME_LENGTH];
-static uint16_t self_name_length;
-
-static uint8_t self_statusmessage[MAX_STATUSMESSAGE_LENGTH];
-static uint16_t self_statusmessage_length;
-
-static USERSTATUS self_userstatus;
-
-static Friend *friendlist;
-static uint32_t numfriends;
-
-
-static void set_friend_status(int friendnumber, uint8_t status);
-static int write_cryptpacket_id(int friendnumber, uint8_t packet_id, uint8_t *data, uint32_t length);
+static void set_friend_status(Messenger *m, int friendnumber, uint8_t status);
+static int write_cryptpacket_id(Messenger *m, int friendnumber, uint8_t packet_id, uint8_t *data, uint32_t length);
 
 /* 1 if we are online
    0 if we are offline
@@ -65,24 +33,24 @@ static int write_cryptpacket_id(int friendnumber, uint8_t packet_id, uint8_t *da
 
 /* set the size of the friend list to numfriends
    return -1 if realloc fails */
-int realloc_friendlist(uint32_t num) {
-    Friend *newfriendlist = realloc(friendlist, num*sizeof(Friend));
+int realloc_friendlist(Messenger *m, uint32_t num) {
+    Friend *newfriendlist = realloc(m->friendlist, num*sizeof(Friend));
     if (newfriendlist == NULL)
         return -1;
     memset(&newfriendlist[num-1], 0, sizeof(Friend));
-    friendlist = newfriendlist;
+    m->friendlist = newfriendlist;
     return 0;
 }
 
 /* return the friend id associated to that public key.
    return -1 if no such friend */
-int getfriend_id(uint8_t *client_id)
+int getfriend_id(Messenger *m, uint8_t *client_id)
 {
     uint32_t i;
 
-    for (i = 0; i < numfriends; ++i) {
-        if (friendlist[i].status > 0)
-            if (memcmp(client_id, friendlist[i].client_id, crypto_box_PUBLICKEYBYTES) == 0)
+    for (i = 0; i < m->numfriends; ++i) {
+        if (m->friendlist[i].status > 0)
+            if (memcmp(client_id, m->friendlist[i].client_id, crypto_box_PUBLICKEYBYTES) == 0)
                 return i;
     }
 
@@ -93,13 +61,13 @@ int getfriend_id(uint8_t *client_id)
    make sure that client_id is of size CLIENT_ID_SIZE.
    return 0 if success
    return -1 if failure. */
-int getclient_id(int friend_id, uint8_t *client_id)
+int getclient_id(Messenger *m, int friend_id, uint8_t *client_id)
 {
-    if (friend_id >= numfriends || friend_id < 0)
+    if (friend_id >= m->numfriends || friend_id < 0)
         return -1;
 
-    if (friendlist[friend_id].status > 0) {
-        memcpy(client_id, friendlist[friend_id].client_id, CLIENT_ID_SIZE);
+    if (m->friendlist[friend_id].status > 0) {
+        memcpy(client_id, m->friendlist[friend_id].client_id, CLIENT_ID_SIZE);
         return 0;
     }
 
@@ -118,7 +86,7 @@ int getclient_id(int friend_id, uint8_t *client_id)
  * return FAERR_ALREADYSENT if friend request already sent or already a friend
  * return FAERR_UNKNOWN for unknown error
  */
-int m_addfriend(uint8_t *client_id, uint8_t *data, uint16_t length)
+int m_addfriend(Messenger *m, uint8_t *client_id, uint8_t *data, uint16_t length)
 {
     if (length >= (MAX_DATA_SIZE - crypto_box_PUBLICKEYBYTES
                          - crypto_box_NONCEBYTES - crypto_box_BOXZEROBYTES
@@ -128,57 +96,57 @@ int m_addfriend(uint8_t *client_id, uint8_t *data, uint16_t length)
         return FAERR_NOMESSAGE;
     if (memcmp(client_id, self_public_key, crypto_box_PUBLICKEYBYTES) == 0)
         return FAERR_OWNKEY;
-    if (getfriend_id(client_id) != -1)
+    if (getfriend_id(m, client_id) != -1)
         return FAERR_ALREADYSENT;
 
     /* resize the friend list if necessary */
-    realloc_friendlist(numfriends + 1);
+    realloc_friendlist(m, m->numfriends + 1);
 
     uint32_t i;
-    for (i = 0; i <= numfriends; ++i)  {
-        if (friendlist[i].status == NOFRIEND) {
+    for (i = 0; i <= m->numfriends; ++i)  {
+        if (m->friendlist[i].status == NOFRIEND) {
             DHT_addfriend(client_id);
-            friendlist[i].status = FRIEND_ADDED;
-            friendlist[i].crypt_connection_id = -1;
-            friendlist[i].friend_request_id = -1;
-            memcpy(friendlist[i].client_id, client_id, CLIENT_ID_SIZE);
-            friendlist[i].statusmessage = calloc(1, 1);
-            friendlist[i].statusmessage_length = 1;
-            friendlist[i].userstatus = USERSTATUS_NONE;
-            memcpy(friendlist[i].info, data, length);
-            friendlist[i].info_size = length;
-            friendlist[i].message_id = 0;
-            friendlist[i].receives_read_receipts = 1; /* default: YES */
+            m->friendlist[i].status = FRIEND_ADDED;
+            m->friendlist[i].crypt_connection_id = -1;
+            m->friendlist[i].friend_request_id = -1;
+            memcpy(m->friendlist[i].client_id, client_id, CLIENT_ID_SIZE);
+            m->friendlist[i].statusmessage = calloc(1, 1);
+            m->friendlist[i].statusmessage_length = 1;
+            m->friendlist[i].userstatus = USERSTATUS_NONE;
+            memcpy(m->friendlist[i].info, data, length);
+            m->friendlist[i].info_size = length;
+            m->friendlist[i].message_id = 0;
+            m->friendlist[i].receives_read_receipts = 1; /* default: YES */
 
-            ++numfriends;
+            ++ m->numfriends;
             return i;
         }
     }
     return FAERR_UNKNOWN;
 }
 
-int m_addfriend_norequest(uint8_t * client_id)
+int m_addfriend_norequest(Messenger *m, uint8_t * client_id)
 {
-    if (getfriend_id(client_id) != -1)
+    if (getfriend_id(m, client_id) != -1)
         return -1;
 
     /* resize the friend list if necessary */
-    realloc_friendlist(numfriends + 1);
+    realloc_friendlist(m, m->numfriends + 1);
 
     uint32_t i;
-    for (i = 0; i <= numfriends; ++i) {
-        if(friendlist[i].status == NOFRIEND) {
+    for (i = 0; i <= m->numfriends; ++i) {
+        if(m->friendlist[i].status == NOFRIEND) {
             DHT_addfriend(client_id);
-            friendlist[i].status = FRIEND_REQUESTED;
-            friendlist[i].crypt_connection_id = -1;
-            friendlist[i].friend_request_id = -1;
-            memcpy(friendlist[i].client_id, client_id, CLIENT_ID_SIZE);
-            friendlist[i].statusmessage = calloc(1, 1);
-            friendlist[i].statusmessage_length = 1;
-            friendlist[i].userstatus = USERSTATUS_NONE;
-            friendlist[i].message_id = 0;
-            friendlist[i].receives_read_receipts = 1; /* default: YES */
-            ++numfriends;
+            m->friendlist[i].status = FRIEND_REQUESTED;
+            m->friendlist[i].crypt_connection_id = -1;
+            m->friendlist[i].friend_request_id = -1;
+            memcpy(m->friendlist[i].client_id, client_id, CLIENT_ID_SIZE);
+            m->friendlist[i].statusmessage = calloc(1, 1);
+            m->friendlist[i].statusmessage_length = 1;
+            m->friendlist[i].userstatus = USERSTATUS_NONE;
+            m->friendlist[i].message_id = 0;
+            m->friendlist[i].receives_read_receipts = 1; /* default: YES */
+            ++ m->numfriends;
             return i;
         }
     }
@@ -188,23 +156,23 @@ int m_addfriend_norequest(uint8_t * client_id)
 /* remove a friend
    return 0 if success
    return -1 if failure */
-int m_delfriend(int friendnumber)
+int m_delfriend(Messenger *m, int friendnumber)
 {
-    if (friendnumber >= numfriends || friendnumber < 0)
+    if (friendnumber >= m->numfriends || friendnumber < 0)
         return -1;
 
-    DHT_delfriend(friendlist[friendnumber].client_id);
-    crypto_kill(friendlist[friendnumber].crypt_connection_id);
-    free(friendlist[friendnumber].statusmessage);
-    memset(&friendlist[friendnumber], 0, sizeof(Friend));
+    DHT_delfriend(m->friendlist[friendnumber].client_id);
+    crypto_kill(m->friendlist[friendnumber].crypt_connection_id);
+    free(m->friendlist[friendnumber].statusmessage);
+    memset(&(m->friendlist[friendnumber]), 0, sizeof(Friend));
     uint32_t i;
 
-    for (i = numfriends; i != 0; --i) {
-        if (friendlist[i-1].status != NOFRIEND)
+    for (i = m->numfriends; i != 0; --i) {
+        if (m->friendlist[i-1].status != NOFRIEND)
             break;
     }
-    numfriends = i;
-    realloc_friendlist(numfriends + 1);
+    m->numfriends = i;
+    realloc_friendlist(m, m->numfriends + 1);
 
     return 0;
 }
@@ -214,31 +182,31 @@ int m_delfriend(int friendnumber)
    return FRIEND_REQUESTED if the friend request was sent
    return FRIEND_ADDED if the friend was added
    return NOFRIEND if there is no friend with that number */
-int m_friendstatus(int friendnumber)
+int m_friendstatus(Messenger *m, int friendnumber)
 {
-    if (friendnumber < 0 || friendnumber >= numfriends)
+    if (friendnumber < 0 || friendnumber >= m->numfriends)
         return NOFRIEND;
-    return friendlist[friendnumber].status;
+    return m->friendlist[friendnumber].status;
 }
 
 /* send a text chat message to an online friend
    return the message id if packet was successfully put into the send queue
    return 0 if it was not */
-uint32_t m_sendmessage(int friendnumber, uint8_t *message, uint32_t length)
+uint32_t m_sendmessage(Messenger *m, int friendnumber, uint8_t *message, uint32_t length)
 {
-    if (friendnumber < 0 || friendnumber >= numfriends)
+    if (friendnumber < 0 || friendnumber >= m->numfriends)
         return 0;
-    uint32_t msgid = ++friendlist[friendnumber].message_id;
+    uint32_t msgid = ++m->friendlist[friendnumber].message_id;
     if (msgid == 0)
         msgid = 1; /* otherwise, false error */
-    if(m_sendmessage_withid(friendnumber, msgid, message, length)) {
+    if(m_sendmessage_withid(m, friendnumber, msgid, message, length)) {
         return msgid;
     }
-    
+
     return 0;
 }
 
-uint32_t m_sendmessage_withid(int friendnumber, uint32_t theid, uint8_t *message, uint32_t length)
+uint32_t m_sendmessage_withid(Messenger *m, int friendnumber, uint32_t theid, uint8_t *message, uint32_t length)
 {
     if (length >= (MAX_DATA_SIZE - sizeof(theid)))
         return 0;
@@ -246,34 +214,34 @@ uint32_t m_sendmessage_withid(int friendnumber, uint32_t theid, uint8_t *message
     theid = htonl(theid);
     memcpy(temp, &theid, sizeof(theid));
     memcpy(temp + sizeof(theid), message, length);
-    return write_cryptpacket_id(friendnumber, PACKET_ID_MESSAGE, temp, length + sizeof(theid));
+    return write_cryptpacket_id(m, friendnumber, PACKET_ID_MESSAGE, temp, length + sizeof(theid));
 }
 
 /* send an action to an online friend
    return 1 if packet was successfully put into the send queue
    return 0 if it was not */
-int m_sendaction(int friendnumber, uint8_t *action, uint32_t length)
+int m_sendaction(Messenger *m, int friendnumber, uint8_t *action, uint32_t length)
 {
-    return write_cryptpacket_id(friendnumber, PACKET_ID_ACTION, action, length);
+    return write_cryptpacket_id(m, friendnumber, PACKET_ID_ACTION, action, length);
 }
 
 /* send a name packet to friendnumber
    length is the length with the NULL terminator*/
-static int m_sendname(int friendnumber, uint8_t * name, uint16_t length)
+static int m_sendname(Messenger *m, int friendnumber, uint8_t * name, uint16_t length)
 {
     if(length > MAX_NAME_LENGTH || length == 0)
         return 0;
-    return write_cryptpacket_id(friendnumber, PACKET_ID_NICKNAME, name, length);
+    return write_cryptpacket_id(m, friendnumber, PACKET_ID_NICKNAME, name, length);
 }
 
 /* set the name of a friend
    return 0 if success
    return -1 if failure */
-static int setfriendname(int friendnumber, uint8_t * name)
+static int setfriendname(Messenger *m, int friendnumber, uint8_t * name)
 {
-    if (friendnumber >= numfriends || friendnumber < 0)
+    if (friendnumber >= m->numfriends || friendnumber < 0)
         return -1;
-    memcpy(friendlist[friendnumber].name, name, MAX_NAME_LENGTH);
+    memcpy(m->friendlist[friendnumber].name, name, MAX_NAME_LENGTH);
     return 0;
 }
 
@@ -283,15 +251,15 @@ static int setfriendname(int friendnumber, uint8_t * name)
    length is the length of name with the NULL terminator
    return 0 if success
    return -1 if failure */
-int setname(uint8_t * name, uint16_t length)
+int setname(Messenger *m, uint8_t * name, uint16_t length)
 {
     if (length > MAX_NAME_LENGTH || length == 0)
         return -1;
-    memcpy(self_name, name, length);
-    self_name_length = length;
+    memcpy(m->name, name, length);
+    m->name_length = length;
     uint32_t i;
-    for (i = 0; i < numfriends; ++i)
-        friendlist[i].name_sent = 0;
+    for (i = 0; i < m->numfriends; ++i)
+        m->friendlist[i].name_sent = 0;
     return 0;
 }
 
@@ -299,10 +267,10 @@ int setname(uint8_t * name, uint16_t length)
    put it in name
    name needs to be a valid memory location with a size of at least MAX_NAME_LENGTH bytes.
    return the length of the name */
-uint16_t getself_name(uint8_t *name)
+uint16_t getself_name(Messenger *m, uint8_t *name)
 {
-    memcpy(name, self_name, self_name_length);
-    return self_name_length;
+    memcpy(name, m->name, m->name_length);
+    return m->name_length;
 }
 
 /* get name of friendnumber
@@ -310,293 +278,288 @@ uint16_t getself_name(uint8_t *name)
    name needs to be a valid memory location with a size of at least MAX_NAME_LENGTH bytes.
    return 0 if success
    return -1 if failure */
-int getname(int friendnumber, uint8_t * name)
+int getname(Messenger *m, int friendnumber, uint8_t * name)
 {
-    if (friendnumber >= numfriends || friendnumber < 0)
+    if (friendnumber >= m->numfriends || friendnumber < 0)
         return -1;
-    memcpy(name, friendlist[friendnumber].name, MAX_NAME_LENGTH);
+    memcpy(name, m->friendlist[friendnumber].name, MAX_NAME_LENGTH);
     return 0;
 }
 
-int m_set_statusmessage(uint8_t *status, uint16_t length)
+int m_set_statusmessage(Messenger *m, uint8_t *status, uint16_t length)
 {
     if (length > MAX_STATUSMESSAGE_LENGTH)
         return -1;
-    memcpy(self_statusmessage, status, length);
-    self_statusmessage_length = length;
+    memcpy(m->statusmessage, status, length);
+    m->statusmessage_length = length;
 
     uint32_t i;
-    for (i = 0; i < numfriends; ++i)
-        friendlist[i].statusmessage_sent = 0;
+    for (i = 0; i < m->numfriends; ++i)
+        m->friendlist[i].statusmessage_sent = 0;
     return 0;
 }
 
-int m_set_userstatus(USERSTATUS status)
+int m_set_userstatus(Messenger *m, USERSTATUS status)
 {
     if (status >= USERSTATUS_INVALID) {
         return -1;
     }
-    self_userstatus = status;
+    m->userstatus = status;
     uint32_t i;
-    for (i = 0; i < numfriends; ++i)
-        friendlist[i].userstatus_sent = 0;
+    for (i = 0; i < m->numfriends; ++i)
+        m->friendlist[i].userstatus_sent = 0;
     return 0;
 }
 
 /*  return the size of friendnumber's user status
     guaranteed to be at most MAX_STATUSMESSAGE_LENGTH */
-int m_get_statusmessage_size(int friendnumber)
+int m_get_statusmessage_size(Messenger *m, int friendnumber)
 {
-    if (friendnumber >= numfriends || friendnumber < 0)
+    if (friendnumber >= m->numfriends || friendnumber < 0)
         return -1;
-    return friendlist[friendnumber].statusmessage_length;
+    return m->friendlist[friendnumber].statusmessage_length;
 }
 
 /*  copy the user status of friendnumber into buf, truncating if needed to maxlen
     bytes, use m_get_statusmessage_size to find out how much you need to allocate */
-int m_copy_statusmessage(int friendnumber, uint8_t * buf, uint32_t maxlen)
+int m_copy_statusmessage(Messenger *m, int friendnumber, uint8_t * buf, uint32_t maxlen)
 {
-    if (friendnumber >= numfriends || friendnumber < 0)
+    if (friendnumber >= m->numfriends || friendnumber < 0)
         return -1;
     memset(buf, 0, maxlen);
-    memcpy(buf, friendlist[friendnumber].statusmessage, MIN(maxlen, MAX_STATUSMESSAGE_LENGTH) - 1);
+    memcpy(buf, m->friendlist[friendnumber].statusmessage, MIN(maxlen, MAX_STATUSMESSAGE_LENGTH) - 1);
     return 0;
 }
 
-int m_copy_self_statusmessage(uint8_t * buf, uint32_t maxlen)
+int m_copy_self_statusmessage(Messenger *m, uint8_t * buf, uint32_t maxlen)
 {
     memset(buf, 0, maxlen);
-    memcpy(buf, self_statusmessage, MIN(maxlen, MAX_STATUSMESSAGE_LENGTH) - 1);
+    memcpy(buf, m->statusmessage, MIN(maxlen, MAX_STATUSMESSAGE_LENGTH) - 1);
     return 0;
 }
 
-USERSTATUS m_get_userstatus(int friendnumber)
+USERSTATUS m_get_userstatus(Messenger *m, int friendnumber)
 {
-    if (friendnumber >= numfriends || friendnumber < 0)
+    if (friendnumber >= m->numfriends || friendnumber < 0)
         return USERSTATUS_INVALID;
-    USERSTATUS status = friendlist[friendnumber].userstatus;
+    USERSTATUS status = m->friendlist[friendnumber].userstatus;
     if (status >= USERSTATUS_INVALID) {
         status = USERSTATUS_NONE;
     }
     return status;
 }
 
-USERSTATUS m_get_self_userstatus(void)
+USERSTATUS m_get_self_userstatus(Messenger *m)
 {
-    return self_userstatus;
+    return m->userstatus;
 }
 
-static int send_statusmessage(int friendnumber, uint8_t * status, uint16_t length)
+static int send_statusmessage(Messenger *m, int friendnumber, uint8_t * status, uint16_t length)
 {
-    return write_cryptpacket_id(friendnumber, PACKET_ID_STATUSMESSAGE, status, length);
+    return write_cryptpacket_id(m, friendnumber, PACKET_ID_STATUSMESSAGE, status, length);
 }
 
-static int send_userstatus(int friendnumber, USERSTATUS status)
+static int send_userstatus(Messenger *m, int friendnumber, USERSTATUS status)
 {
     uint8_t stat = status;
-    return write_cryptpacket_id(friendnumber, PACKET_ID_USERSTATUS, &stat, sizeof(stat));
+    return write_cryptpacket_id(m, friendnumber, PACKET_ID_USERSTATUS, &stat, sizeof(stat));
 }
 
-static int set_friend_statusmessage(int friendnumber, uint8_t * status, uint16_t length)
+static int set_friend_statusmessage(Messenger *m, int friendnumber, uint8_t * status, uint16_t length)
 {
-    if (friendnumber >= numfriends || friendnumber < 0)
+    if (friendnumber >= m->numfriends || friendnumber < 0)
         return -1;
     uint8_t *newstatus = calloc(length, 1);
     memcpy(newstatus, status, length);
-    free(friendlist[friendnumber].statusmessage);
-    friendlist[friendnumber].statusmessage = newstatus;
-    friendlist[friendnumber].statusmessage_length = length;
+    free(m->friendlist[friendnumber].statusmessage);
+    m->friendlist[friendnumber].statusmessage = newstatus;
+    m->friendlist[friendnumber].statusmessage_length = length;
     return 0;
 }
 
-static void set_friend_userstatus(int friendnumber, USERSTATUS status)
+static void set_friend_userstatus(Messenger *m, int friendnumber, USERSTATUS status)
 {
-    friendlist[friendnumber].userstatus = status;
+    m->friendlist[friendnumber].userstatus = status;
 }
 
 /* Sets whether we send read receipts for friendnumber. */
-void m_set_sends_receipts(int friendnumber, int yesno)
+void m_set_sends_receipts(Messenger *m, int friendnumber, int yesno)
 {
     if (yesno != 0 || yesno != 1)
         return;
-    if (friendnumber >= numfriends || friendnumber < 0)
+    if (friendnumber >= m->numfriends || friendnumber < 0)
         return;
-    friendlist[friendnumber].receives_read_receipts = yesno;
+    m->friendlist[friendnumber].receives_read_receipts = yesno;
 }
 
 /* static void (*friend_request)(uint8_t *, uint8_t *, uint16_t);
 static uint8_t friend_request_isset = 0; */
 /* set the function that will be executed when a friend request is received. */
-void m_callback_friendrequest(void (*function)(uint8_t *, uint8_t *, uint16_t))
+void m_callback_friendrequest(Messenger *m, void (*function)(uint8_t *, uint8_t *, uint16_t))
 {
     callback_friendrequest(function);
 }
 
-static void (*friend_message)(int, uint8_t *, uint16_t);
-static uint8_t friend_message_isset = 0;
-
 /* set the function that will be executed when a message from a friend is received. */
-void m_callback_friendmessage(void (*function)(int, uint8_t *, uint16_t))
+void m_callback_friendmessage(Messenger *m, void (*function)(Messenger *m, int, uint8_t *, uint16_t))
 {
-    friend_message = function;
-    friend_message_isset = 1;
+    m->friend_message = function;
+    m->friend_message_isset = 1;
 }
 
-static void (*friend_action)(int, uint8_t *, uint16_t);
-static uint8_t friend_action_isset = 0;
-void m_callback_action(void (*function)(int, uint8_t *, uint16_t))
+void m_callback_action(Messenger *m, void (*function)(Messenger *m, int, uint8_t *, uint16_t))
 {
-    friend_action = function;
-    friend_action_isset = 1;
+    m->friend_action = function;
+    m->friend_action_isset = 1;
 }
 
-static void (*friend_namechange)(int, uint8_t *, uint16_t);
-static uint8_t friend_namechange_isset = 0;
-void m_callback_namechange(void (*function)(int, uint8_t *, uint16_t))
+void m_callback_namechange(Messenger *m, void (*function)(Messenger *m, int, uint8_t *, uint16_t))
 {
-    friend_namechange = function;
-    friend_namechange_isset = 1;
+    m->friend_namechange = function;
+    m->friend_namechange_isset = 1;
 }
 
-static void (*friend_statusmessagechange)(int, uint8_t *, uint16_t);
-static uint8_t friend_statusmessagechange_isset = 0;
-void m_callback_statusmessage(void (*function)(int, uint8_t *, uint16_t))
+void m_callback_statusmessage(Messenger *m, void (*function)(Messenger *m, int, uint8_t *, uint16_t))
 {
-    friend_statusmessagechange = function;
-    friend_statusmessagechange_isset = 1;
+    m->friend_statusmessagechange = function;
+    m->friend_statusmessagechange_isset = 1;
 }
 
-static void (*friend_userstatuschange)(int, USERSTATUS);
-static uint8_t friend_userstatuschange_isset = 0;
-void m_callback_userstatus(void (*function)(int, USERSTATUS))
+void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, int, USERSTATUS))
 {
-    friend_userstatuschange = function;
-    friend_userstatuschange_isset = 1;
+    m->friend_userstatuschange = function;
+    m->friend_userstatuschange_isset = 1;
 }
 
-static void (*read_receipt)(int, uint32_t);
-static uint8_t read_receipt_isset = 0;
-void m_callback_read_receipt(void (*function)(int, uint32_t))
+void m_callback_read_receipt(Messenger *m, void (*function)(Messenger *m, int, uint32_t))
 {
-    read_receipt = function;
-    read_receipt_isset = 1;
+    m->read_receipt = function;
+    m->read_receipt_isset = 1;
 }
 
-static void (*friend_connectionstatuschange)(int, uint8_t);
-static uint8_t friend_connectionstatuschange_isset = 0;
-void m_callback_connectionstatus(void (*function)(int, uint8_t))
+void m_callback_connectionstatus(Messenger *m, void (*function)(Messenger *m, int, uint8_t))
 {
-    friend_connectionstatuschange = function;
-    friend_connectionstatuschange_isset = 1;
+    m->friend_connectionstatuschange = function;
+    m->friend_connectionstatuschange_isset = 1;
 }
 
-static void check_friend_connectionstatus(int friendnumber, uint8_t status)
+static void check_friend_connectionstatus(Messenger *m, int friendnumber, uint8_t status)
 {
-    if (!friend_connectionstatuschange_isset)
+    if (!m->friend_connectionstatuschange_isset)
         return;
     if (status == NOFRIEND)
         return;
-    const uint8_t was_connected = friendlist[friendnumber].status == FRIEND_ONLINE;
+    const uint8_t was_connected = m->friendlist[friendnumber].status == FRIEND_ONLINE;
     const uint8_t is_connected = status == FRIEND_ONLINE;
     if (is_connected != was_connected)
-        friend_connectionstatuschange(friendnumber, is_connected);
+        m->friend_connectionstatuschange(m, friendnumber, is_connected);
 }
 
-static void set_friend_status(int friendnumber, uint8_t status)
+void set_friend_status(Messenger *m, int friendnumber, uint8_t status)
 {
-    check_friend_connectionstatus(friendnumber, status);
-    friendlist[friendnumber].status = status;
+    check_friend_connectionstatus(m, friendnumber, status);
+    m->friendlist[friendnumber].status = status;
 }
 
-static int write_cryptpacket_id(int friendnumber, uint8_t packet_id, uint8_t *data, uint32_t length)
+int write_cryptpacket_id(Messenger *m, int friendnumber, uint8_t packet_id, uint8_t *data, uint32_t length)
 {
-    if (friendnumber < 0 || friendnumber >= numfriends)
+    if (friendnumber < 0 || friendnumber >= m->numfriends)
         return 0;
-    if (length >= MAX_DATA_SIZE || friendlist[friendnumber].status != FRIEND_ONLINE)
+    if (length >= MAX_DATA_SIZE || m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return 0;
     uint8_t packet[length + 1];
     packet[0] = packet_id;
     memcpy(packet + 1, data, length);
-    return write_cryptpacket(friendlist[friendnumber].crypt_connection_id, packet, length + 1);
+    return write_cryptpacket(m->friendlist[friendnumber].crypt_connection_id, packet, length + 1);
 }
 
 #define PORT 33445
 /* run this at startup */
-int initMessenger(void)
+Messenger * initMessenger(void)
 {
+    Messenger *m = calloc(1, sizeof(Messenger));
+    if( ! m )
+        return 0;
+
     new_keys();
-    m_set_statusmessage((uint8_t*)"Online", sizeof("Online"));
+    m_set_statusmessage(m, (uint8_t*)"Online", sizeof("Online"));
     initNetCrypto();
     IP ip;
     ip.i = 0;
 
     if(init_networking(ip,PORT) == -1)
-        return -1;
+        return 0;
 
     DHT_init();
     LosslessUDP_init();
     friendreq_init();
     LANdiscovery_init();
 
-    return 0;
+    return m;
+}
+
+/* run this before closing shop */
+void cleanupMessenger(Messenger *m){
+    /* FIXME TODO it seems no one frees friendlist or all the elements status */
+    free(m);
 }
 
 //TODO: make this function not suck.
-static void doFriends(void)
+void doFriends(Messenger *m)
 {
     /* TODO: add incoming connections and some other stuff. */
     uint32_t i;
     int len;
     uint8_t temp[MAX_DATA_SIZE];
-    for (i = 0; i < numfriends; ++i) {
-        if (friendlist[i].status == FRIEND_ADDED) {
-            int fr = send_friendrequest(friendlist[i].client_id, friendlist[i].info, friendlist[i].info_size);
+    for (i = 0; i < m->numfriends; ++i) {
+        if (m->friendlist[i].status == FRIEND_ADDED) {
+            int fr = send_friendrequest(m->friendlist[i].client_id, m->friendlist[i].info, m->friendlist[i].info_size);
             if (fr == 0) /* TODO: This needs to be fixed so that it sends the friend requests a couple of times in case of packet loss */
-                set_friend_status(i, FRIEND_REQUESTED);
+                set_friend_status(m, i, FRIEND_REQUESTED);
             else if (fr > 0)
-                set_friend_status(i, FRIEND_REQUESTED);
+                set_friend_status(m, i, FRIEND_REQUESTED);
         }
-        if (friendlist[i].status == FRIEND_REQUESTED || friendlist[i].status == FRIEND_CONFIRMED) { /* friend is not online */
-            if (friendlist[i].status == FRIEND_REQUESTED) {
-                if (friendlist[i].friend_request_id + 10 < unix_time()) { /*I know this is hackish but it should work.*/
-                    send_friendrequest(friendlist[i].client_id, friendlist[i].info, friendlist[i].info_size);
-                    friendlist[i].friend_request_id = unix_time();
+        if (m->friendlist[i].status == FRIEND_REQUESTED || m->friendlist[i].status == FRIEND_CONFIRMED) { /* friend is not online */
+            if (m->friendlist[i].status == FRIEND_REQUESTED) {
+                if (m->friendlist[i].friend_request_id + 10 < unix_time()) { /*I know this is hackish but it should work.*/
+                    send_friendrequest(m->friendlist[i].client_id, m->friendlist[i].info, m->friendlist[i].info_size);
+                    m->friendlist[i].friend_request_id = unix_time();
                 }
             }
-            IP_Port friendip = DHT_getfriendip(friendlist[i].client_id);
-            switch (is_cryptoconnected(friendlist[i].crypt_connection_id)) {
+            IP_Port friendip = DHT_getfriendip(m->friendlist[i].client_id);
+            switch (is_cryptoconnected(m->friendlist[i].crypt_connection_id)) {
             case 0:
                 if (friendip.ip.i > 1)
-                    friendlist[i].crypt_connection_id = crypto_connect(friendlist[i].client_id, friendip);
+                    m->friendlist[i].crypt_connection_id = crypto_connect(m->friendlist[i].client_id, friendip);
                 break;
             case 3: /*  Connection is established */
-                set_friend_status(i, FRIEND_ONLINE);
-                friendlist[i].name_sent = 0;
-                friendlist[i].userstatus_sent = 0;
-                friendlist[i].statusmessage_sent = 0;
+                set_friend_status(m, i, FRIEND_ONLINE);
+                m->friendlist[i].name_sent = 0;
+                m->friendlist[i].userstatus_sent = 0;
+                m->friendlist[i].statusmessage_sent = 0;
                 break;
             case 4:
-                crypto_kill(friendlist[i].crypt_connection_id);
-                friendlist[i].crypt_connection_id = -1;
+                crypto_kill(m->friendlist[i].crypt_connection_id);
+                m->friendlist[i].crypt_connection_id = -1;
                 break;
             default:
                 break;
             }
         }
-        while (friendlist[i].status == FRIEND_ONLINE) { /* friend is online */
-            if (friendlist[i].name_sent == 0) {
-                if (m_sendname(i, self_name, self_name_length))
-                    friendlist[i].name_sent = 1;
+        while (m->friendlist[i].status == FRIEND_ONLINE) { /* friend is online */
+            if (m->friendlist[i].name_sent == 0) {
+                if (m_sendname(m, i, m->name, m->name_length))
+                    m->friendlist[i].name_sent = 1;
             }
-            if (friendlist[i].statusmessage_sent == 0) {
-                if (send_statusmessage(i, self_statusmessage, self_statusmessage_length))
-                    friendlist[i].statusmessage_sent = 1;
+            if (m->friendlist[i].statusmessage_sent == 0) {
+                if (send_statusmessage(m, i, m->statusmessage, m->statusmessage_length))
+                    m->friendlist[i].statusmessage_sent = 1;
             }
-            if (friendlist[i].userstatus_sent == 0) {
-                if (send_userstatus(i, self_userstatus))
-                    friendlist[i].userstatus_sent = 1;
+            if (m->friendlist[i].userstatus_sent == 0) {
+                if (send_userstatus(m, i, m->userstatus))
+                    m->friendlist[i].userstatus_sent = 1;
             }
-            len = read_cryptpacket(friendlist[i].crypt_connection_id, temp);
+            len = read_cryptpacket(m->friendlist[i].crypt_connection_id, temp);
             uint8_t packet_id = temp[0];
             uint8_t* data = temp + 1;
             int data_length = len - 1;
@@ -605,10 +568,10 @@ static void doFriends(void)
                 case PACKET_ID_NICKNAME: {
                     if (data_length >= MAX_NAME_LENGTH || data_length == 0)
                         break;
-                    if(friend_namechange_isset)
-                        friend_namechange(i, data, data_length);
-                    memcpy(friendlist[i].name, data, data_length);
-                    friendlist[i].name[data_length - 1] = 0; /* make sure the NULL terminator is present. */
+                    if(m->friend_namechange_isset)
+                        m->friend_namechange(m, i, data, data_length);
+                    memcpy(m->friendlist[i].name, data, data_length);
+                    m->friendlist[i].name[data_length - 1] = 0; /* make sure the NULL terminator is present. */
                     break;
                 }
                 case PACKET_ID_STATUSMESSAGE: {
@@ -616,9 +579,9 @@ static void doFriends(void)
                         break;
                     uint8_t *status = calloc(MIN(data_length, MAX_STATUSMESSAGE_LENGTH), 1);
                     memcpy(status, data, MIN(data_length, MAX_STATUSMESSAGE_LENGTH));
-                    if (friend_statusmessagechange_isset)
-                        friend_statusmessagechange(i, status, MIN(data_length, MAX_STATUSMESSAGE_LENGTH));
-                    set_friend_statusmessage(i, status, MIN(data_length, MAX_STATUSMESSAGE_LENGTH));
+                    if (m->friend_statusmessagechange_isset)
+                        m->friend_statusmessagechange(m, i, status, MIN(data_length, MAX_STATUSMESSAGE_LENGTH));
+                    set_friend_statusmessage(m, i, status, MIN(data_length, MAX_STATUSMESSAGE_LENGTH));
                     free(status);
                     break;
                 }
@@ -626,9 +589,9 @@ static void doFriends(void)
                     if (data_length != 1)
                         break;
                     USERSTATUS status = data[0];
-                    if (friend_userstatuschange_isset)
-                        friend_userstatuschange(i, status);
-                    set_friend_userstatus(i, status);
+                    if (m->friend_userstatuschange_isset)
+                        m->friend_userstatuschange(m, i, status);
+                    set_friend_userstatus(m, i, status);
                     break;
                 }
                 case PACKET_ID_MESSAGE: {
@@ -636,16 +599,16 @@ static void doFriends(void)
                     uint8_t message_id_length = 4;
                     uint8_t *message = data + message_id_length;
                     uint16_t message_length = data_length - message_id_length;
-                    if (friendlist[i].receives_read_receipts) {
-                        write_cryptpacket_id(i, PACKET_ID_RECEIPT, message_id, message_id_length);
+                    if (m->friendlist[i].receives_read_receipts) {
+                        write_cryptpacket_id(m, i, PACKET_ID_RECEIPT, message_id, message_id_length);
                     }
-                    if (friend_message_isset)
-                        (*friend_message)(i, message, message_length);
+                    if (m->friend_message_isset)
+                        (*m->friend_message)(m, i, message, message_length);
                     break;
                 }
                 case PACKET_ID_ACTION: {
-                    if (friend_action_isset)
-                        (*friend_action)(i, data, data_length);
+                    if (m->friend_action_isset)
+                        (*m->friend_action)(m, i, data, data_length);
                     break;
                 }
                 case PACKET_ID_RECEIPT: {
@@ -654,16 +617,16 @@ static void doFriends(void)
                         break;
                     memcpy(&msgid, data, sizeof(msgid));
                     msgid = ntohl(msgid);
-                    if (read_receipt_isset)
-                        (*read_receipt)(i, msgid);
+                    if (m->read_receipt_isset)
+                        (*m->read_receipt)(m, i, msgid);
                     break;
                 }
                 }
             } else {
-                if (is_cryptoconnected(friendlist[i].crypt_connection_id) == 4) { /* if the connection timed out, kill it */
-                    crypto_kill(friendlist[i].crypt_connection_id);
-                    friendlist[i].crypt_connection_id = -1;
-                    set_friend_status(i, FRIEND_CONFIRMED);
+                if (is_cryptoconnected(m->friendlist[i].crypt_connection_id) == 4) { /* if the connection timed out, kill it */
+                    crypto_kill(m->friendlist[i].crypt_connection_id);
+                    m->friendlist[i].crypt_connection_id = -1;
+                    set_friend_status(m, i, FRIEND_CONFIRMED);
                 }
                 break;
             }
@@ -671,20 +634,20 @@ static void doFriends(void)
     }
 }
 
-static void doInbound(void)
+void doInbound(Messenger *m)
 {
     uint8_t secret_nonce[crypto_box_NONCEBYTES];
     uint8_t public_key[crypto_box_PUBLICKEYBYTES];
     uint8_t session_key[crypto_box_PUBLICKEYBYTES];
     int inconnection = crypto_inbound(public_key, secret_nonce, session_key);
     if (inconnection != -1) {
-        int friend_id = getfriend_id(public_key);
+        int friend_id = getfriend_id(m, public_key);
         if (friend_id != -1) {
-            crypto_kill(friendlist[friend_id].crypt_connection_id);
-            friendlist[friend_id].crypt_connection_id =
+            crypto_kill(m->friendlist[friend_id].crypt_connection_id);
+            m->friendlist[friend_id].crypt_connection_id =
                 accept_crypto_inbound(inconnection, public_key, secret_nonce, session_key);
 
-            set_friend_status(friend_id, FRIEND_CONFIRMED);
+            set_friend_status(m, friend_id, FRIEND_CONFIRMED);
         }
     }
 }
@@ -695,7 +658,7 @@ static void doInbound(void)
 static uint64_t last_LANdiscovery;
 
 /*Send a LAN discovery packet every LAN_DISCOVERY_INTERVAL seconds*/
-static void LANdiscovery(void)
+void LANdiscovery(Messenger *m)
 {
     if (last_LANdiscovery + LAN_DISCOVERY_INTERVAL < unix_time()) {
         send_LANdiscovery(htons(PORT));
@@ -705,27 +668,27 @@ static void LANdiscovery(void)
 
 
 /* the main loop that needs to be run at least 200 times per second. */
-void doMessenger(void)
+void doMessenger(Messenger *m)
 {
     networking_poll();
-	
+
     doDHT();
     doLossless_UDP();
     doNetCrypto();
-    doInbound();
-    doFriends();
-    LANdiscovery();
+    doInbound(m);
+    doFriends(m);
+    LANdiscovery(m);
 }
 
 /* returns the size of the messenger data (for saving) */
-uint32_t Messenger_size(void)
+uint32_t Messenger_size(Messenger *m)
 {
     return crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES
-           + sizeof(uint32_t) + DHT_size() + sizeof(uint32_t) + sizeof(Friend) * numfriends;
+           + sizeof(uint32_t) + DHT_size() + sizeof(uint32_t) + sizeof(Friend) * m->numfriends;
 }
 
 /* save the messenger in data of size Messenger_size() */
-void Messenger_save(uint8_t *data)
+void Messenger_save(Messenger *m, uint8_t *data)
 {
     save_keys(data);
     data += crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES;
@@ -734,14 +697,14 @@ void Messenger_save(uint8_t *data)
     data += sizeof(size);
     DHT_save(data);
     data += size;
-    size = sizeof(Friend) * numfriends;
+    size = sizeof(Friend) * m->numfriends;
     memcpy(data, &size, sizeof(size));
     data += sizeof(size);
-    memcpy(data, friendlist, sizeof(Friend) * numfriends);
+    memcpy(data, m->friendlist, sizeof(Friend) * m->numfriends);
 }
 
 /* load the messenger from data of size length. */
-int Messenger_load(uint8_t * data, uint32_t length)
+int Messenger_load(Messenger *m, uint8_t * data, uint32_t length)
 {
     if (length == ~0)
         return -1;
@@ -773,11 +736,12 @@ int Messenger_load(uint8_t * data, uint32_t length)
     uint32_t i;
     for (i = 0; i < num; ++i) {
         if(temp[i].status != 0) {
-            int fnum = m_addfriend_norequest(temp[i].client_id);
-            setfriendname(fnum, temp[i].name);
+            int fnum = m_addfriend_norequest(m, temp[i].client_id);
+            setfriendname(m, fnum, temp[i].name);
             /* set_friend_statusmessage(fnum, temp[i].statusmessage, temp[i].statusmessage_length); */
         }
     }
     free(temp);
     return 0;
 }
+

--- a/core/Messenger.h
+++ b/core/Messenger.h
@@ -73,6 +73,58 @@ typedef enum {
     USERSTATUS_INVALID
 } USERSTATUS;
 
+typedef struct {
+    uint8_t client_id[CLIENT_ID_SIZE];
+    int crypt_connection_id;
+    uint64_t friend_request_id; /* id of the friend request corresponding to the current friend request to the current friend. */
+    uint8_t status; /* 0 if no friend, 1 if added, 2 if friend request sent, 3 if confirmed friend, 4 if online. */
+    uint8_t info[MAX_DATA_SIZE]; /* the data that is sent during the friend requests we do */
+    uint8_t name[MAX_NAME_LENGTH];
+    uint8_t name_sent; /* 0 if we didn't send our name to this friend 1 if we have. */
+    uint8_t *statusmessage;
+    uint16_t statusmessage_length;
+    uint8_t statusmessage_sent;
+    USERSTATUS userstatus;
+    uint8_t userstatus_sent;
+    uint16_t info_size; /* length of the info */
+    uint32_t message_id; /* a semi-unique id used in read receipts */
+    uint8_t receives_read_receipts; /* shall we send read receipts to this person? */
+} Friend;
+
+typedef struct Messenger {
+    uint8_t public_key[crypto_box_PUBLICKEYBYTES];
+
+    uint8_t name[MAX_NAME_LENGTH];
+    uint16_t name_length;
+
+    uint8_t statusmessage[MAX_STATUSMESSAGE_LENGTH];
+    uint16_t statusmessage_length;
+
+    USERSTATUS userstatus;
+
+    Friend *friendlist;
+    uint32_t numfriends;
+
+    void (*friend_message)(struct Messenger *m, int, uint8_t *, uint16_t);
+    uint8_t friend_message_isset;
+    void (*friend_action)(struct Messenger *m, int, uint8_t *, uint16_t);
+    uint8_t friend_action_isset;
+    void (*friend_namechange)(struct Messenger *m, int, uint8_t *, uint16_t);
+    uint8_t friend_namechange_isset;
+    void (*friend_statusmessagechange)(struct Messenger *m, int, uint8_t *, uint16_t);
+    uint8_t friend_statusmessagechange_isset;
+    void (*friend_userstatuschange)(struct Messenger *m, int, USERSTATUS);
+    uint8_t friend_userstatuschange_isset;
+    void (*read_receipt)(struct Messenger *m, int, uint32_t);
+    uint8_t read_receipt_isset;
+    void (*friend_statuschange)(struct Messenger *m, int, uint8_t);
+    uint8_t friend_statuschange_isset;
+    void (*friend_connectionstatuschange)(struct Messenger *m, int, uint8_t);
+    uint8_t friend_connectionstatuschange_isset;
+
+
+} Messenger;
+
 /*
  * add a friend
  * set the data that will be sent along with friend request
@@ -85,33 +137,33 @@ typedef enum {
  * return -4 if friend request already sent or already a friend
  * return -5 for unknown error
  */
-int m_addfriend(uint8_t *client_id, uint8_t *data, uint16_t length);
+int m_addfriend(Messenger *m, uint8_t *client_id, uint8_t *data, uint16_t length);
 
 
 /* add a friend without sending a friendrequest.
     returns the friend number if success
     return -1 if failure. */
-int m_addfriend_norequest(uint8_t *client_id);
+int m_addfriend_norequest(Messenger *m, uint8_t *client_id);
 
 /* return the friend id associated to that client id.
     return -1 if no such friend */
-int getfriend_id(uint8_t *client_id);
+int getfriend_id(Messenger *m, uint8_t *client_id);
 
 /* copies the public key associated to that friend id into client_id buffer.
     make sure that client_id is of size CLIENT_ID_SIZE.
     return 0 if success
     return -1 if failure */
-int getclient_id(int friend_id, uint8_t *client_id);
+int getclient_id(Messenger *m, int friend_id, uint8_t *client_id);
 
 /* remove a friend */
-int m_delfriend(int friendnumber);
+int m_delfriend(Messenger *m, int friendnumber);
 
 /* return 4 if friend is online
     return 3 if friend is confirmed
     return 2 if the friend request was sent
     return 1 if the friend was added
     return 0 if there is no friend with that number */
-int m_friendstatus(int friendnumber);
+int m_friendstatus(Messenger *m, int friendnumber);
 
 /* send a text chat message to an online friend
     returns the message id if packet was successfully put into the send queue
@@ -120,13 +172,13 @@ int m_friendstatus(int friendnumber);
     if one is received.
     m_sendmessage_withid will send a message with the id of your choosing,
     however we can generate an id for you by calling plain m_sendmessage. */
-uint32_t m_sendmessage(int friendnumber, uint8_t *message, uint32_t length);
-uint32_t m_sendmessage_withid(int friendnumber, uint32_t theid, uint8_t *message, uint32_t length);
+uint32_t m_sendmessage(Messenger *m, int friendnumber, uint8_t *message, uint32_t length);
+uint32_t m_sendmessage_withid(Messenger *m, int friendnumber, uint32_t theid, uint8_t *message, uint32_t length);
 
 /* send an action to an online friend
     returns 1 if packet was successfully put into the send queue
     return 0 if it was not */
-int m_sendaction(int friendnumber, uint8_t *action, uint32_t length);
+int m_sendaction(Messenger *m, int friendnumber, uint8_t *action, uint32_t length);
 
 /* Set our nickname
    name must be a string of maximum MAX_NAME_LENGTH length.
@@ -134,73 +186,73 @@ int m_sendaction(int friendnumber, uint8_t *action, uint32_t length);
    length is the length of name with the NULL terminator
    return 0 if success
    return -1 if failure */
-int setname(uint8_t *name, uint16_t length);
+int setname(Messenger *m, uint8_t *name, uint16_t length);
 
 /* get our nickname
    put it in name
    return the length of the name*/
-uint16_t getself_name(uint8_t *name);
+uint16_t getself_name(Messenger *m, uint8_t *name);
 
 /* get name of friendnumber
     put it in name
     name needs to be a valid memory location with a size of at least MAX_NAME_LENGTH (128) bytes.
     return 0 if success
     return -1 if failure */
-int getname(int friendnumber, uint8_t *name);
+int getname(Messenger *m, int friendnumber, uint8_t *name);
 
 /* set our user status
     you are responsible for freeing status after
     returns 0 on success, -1 on failure */
-int m_set_statusmessage(uint8_t *status, uint16_t length);
-int m_set_userstatus(USERSTATUS status);
+int m_set_statusmessage(Messenger *m, uint8_t *status, uint16_t length);
+int m_set_userstatus(Messenger *m, USERSTATUS status);
 
 /* return the length of friendnumber's status message,
     including null
     pass it into malloc */
-int m_get_statusmessage_size(int friendnumber);
+int m_get_statusmessage_size(Messenger *m, int friendnumber);
 
 /* copy friendnumber's status message into buf, truncating if size is over maxlen
     get the size you need to allocate from m_get_statusmessage_size
     The self variant will copy our own status message. */
-int m_copy_statusmessage(int friendnumber, uint8_t *buf, uint32_t maxlen);
-int m_copy_self_statusmessage(uint8_t *buf, uint32_t maxlen);
+int m_copy_statusmessage(Messenger *m, int friendnumber, uint8_t *buf, uint32_t maxlen);
+int m_copy_self_statusmessage(Messenger *m, uint8_t *buf, uint32_t maxlen);
 
 /* Return one of USERSTATUS values.
  * Values unknown to your application should be represented as USERSTATUS_NONE.
  * As above, the self variant will return our own USERSTATUS.
  * If friendnumber is invalid, this shall return USERSTATUS_INVALID. */
-USERSTATUS m_get_userstatus(int friendnumber);
-USERSTATUS m_get_self_userstatus(void);
+USERSTATUS m_get_userstatus(Messenger *m, int friendnumber);
+USERSTATUS m_get_self_userstatus(Messenger *m);
 
 /* Sets whether we send read receipts for friendnumber.
  * This function is not lazy, and it will fail if yesno is not (0 or 1).*/
-void m_set_sends_receipts(int friendnumber, int yesno);
+void m_set_sends_receipts(Messenger *m, int friendnumber, int yesno);
 
 /* set the function that will be executed when a friend request is received.
     function format is function(uint8_t * public_key, uint8_t * data, uint16_t length) */
-void m_callback_friendrequest(void (*function)(uint8_t *, uint8_t *, uint16_t));
+void m_callback_friendrequest(Messenger *m, void (*function)(uint8_t *, uint8_t *, uint16_t));
 
 /* set the function that will be executed when a message from a friend is received.
     function format is: function(int friendnumber, uint8_t * message, uint32_t length) */
-void m_callback_friendmessage(void (*function)(int, uint8_t *, uint16_t));
+void m_callback_friendmessage(Messenger *m, void (*function)(Messenger *m, int, uint8_t *, uint16_t));
 
 /* set the function that will be executed when an action from a friend is received.
     function format is: function(int friendnumber, uint8_t * action, uint32_t length) */
-void m_callback_action(void (*function)(int, uint8_t *, uint16_t));
+void m_callback_action(Messenger *m, void (*function)(Messenger *m, int, uint8_t *, uint16_t));
 
 /* set the callback for name changes
     function(int friendnumber, uint8_t *newname, uint16_t length)
     you are not responsible for freeing newname */
-void m_callback_namechange(void (*function)(int, uint8_t *, uint16_t));
+void m_callback_namechange(Messenger *m, void (*function)(Messenger *m, int, uint8_t *, uint16_t));
 
 /* set the callback for status message changes
     function(int friendnumber, uint8_t *newstatus, uint16_t length)
     you are not responsible for freeing newstatus */
-void m_callback_statusmessage(void (*function)(int, uint8_t *, uint16_t));
+void m_callback_statusmessage(Messenger *m, void (*function)(Messenger *m, int, uint8_t *, uint16_t));
 
 /* set the callback for status type changes
     function(int friendnumber, USERSTATUS kind) */
-void m_callback_userstatus(void (*function)(int, USERSTATUS));
+void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, int, USERSTATUS));
 
 /* set the callback for read receipts
     function(int friendnumber, uint32_t receipt)
@@ -209,7 +261,7 @@ void m_callback_userstatus(void (*function)(int, USERSTATUS));
     has been received on the other side. since core doesn't
     track ids for you, receipt may not correspond to any message
     in that case, you should discard it. */
-void m_callback_read_receipt(void (*function)(int, uint32_t));
+void m_callback_read_receipt(Messenger *m, void (*function)(Messenger *m, int, uint32_t));
 
 /* set the callback for connection status changes
     function(int friendnumber, uint8_t status)
@@ -219,26 +271,30 @@ void m_callback_read_receipt(void (*function)(int, uint32_t));
     note that this callback is not called when adding friends, thus the "after
     being previously online" part. it's assumed that when adding friends,
     their connection status is offline. */
-void m_callback_connectionstatus(void (*function)(int, uint8_t));
+void m_callback_connectionstatus(Messenger *m, void (*function)(Messenger *m, int, uint8_t));
 
 /* run this at startup
-    returns 0 if no connection problems
-    returns -1 if there are problems */
-int initMessenger(void);
+ *  returns allocated instance of Messenger on success
+ *  returns 0 if there are problems */
+Messenger * initMessenger(void);
+
+/* run this before closing shop
+ * free all datastructures */
+void cleanupMessenger(Messenger *M);
 
 /* the main loop that needs to be run at least 200 times per second */
-void doMessenger(void);
+void doMessenger(Messenger *m);
 
 /* SAVING AND LOADING FUNCTIONS: */
 
 /* returns the size of the messenger data (for saving) */
-uint32_t Messenger_size(void);
+uint32_t Messenger_size(Messenger *m);
 
 /* save the messenger in data (must be allocated memory of size Messenger_size()) */
-void Messenger_save(uint8_t *data);
+void Messenger_save(Messenger *m, uint8_t *data);
 
 /* load the messenger from data of size length */
-int Messenger_load(uint8_t *data, uint32_t length);
+int Messenger_load(Messenger *m, uint8_t *data, uint32_t length);
 
 #ifdef __cplusplus
 }

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -1,21 +1,21 @@
 /* Messenger test
- * 
+ *
  * This program adds a friend and accepts all friend requests with the proper message.
- * 
+ *
  * It tries sending a message to the added friend.
- * 
+ *
  * If it receives a message from a friend it replies back.
- * 
- * 
+ *
+ *
  * This is how I compile it: gcc -O2 -Wall -D VANILLA_NACL -o test ../core/Lossless_UDP.c ../core/network.c ../core/net_crypto.c ../core/Messenger.c ../core/DHT.c ../nacl/build/${HOSTNAME%.*}/lib/amd64/{cpucycles.o,libnacl.a,randombytes.o} Messenger_test.c
  *
- * 
+ *
  * Command line arguments are the ip, port and public_key of a node (for bootstrapping).
- * 
+ *
  * EX: ./test 127.0.0.1 33445 CDCFD319CE3460824B33BE58FD86B8941C9585181D8FBD7C79C5721D7C2E9F7C
- * 
+ *
  * Or the argument can be the path to the save file.
- * 
+ *
  * EX: ./test Save.bak
  *
  *  Copyright (C) 2013 Tox project All Rights Reserved.
@@ -34,7 +34,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with Tox.  If not, see <http://www.gnu.org/licenses/>.
- *  
+ *
  */
 
 #include "../core/Messenger.h"
@@ -51,6 +51,10 @@
 
 #endif
 
+/* FIXME needed as print_request has to match the interface expected by
+ * networking_requesthandler and so cannot take a Messenger * */
+static Messenger *m;
+
 void print_request(uint8_t * public_key, uint8_t * data, uint16_t length)
 {
     printf("Friend request received from: \n");
@@ -63,7 +67,7 @@ void print_request(uint8_t * public_key, uint8_t * data, uint16_t length)
         printf("%hhX", public_key[j]);
     }
     printf("\nOf length: %u with data: %s \n", length, data);
-    
+
     if(length != sizeof("Install Gentoo"))
     {
         return;
@@ -72,14 +76,14 @@ void print_request(uint8_t * public_key, uint8_t * data, uint16_t length)
     //if the request contained the message of peace the person is obviously a friend so we add him.
     {
         printf("Friend request accepted.\n");
-        m_addfriend_norequest(public_key);
+        m_addfriend_norequest(m, public_key);
     }
 }
 
-void print_message(int friendnumber, uint8_t * string, uint16_t length)
+void print_message(Messenger *m, int friendnumber, uint8_t * string, uint16_t length)
 {
     printf("Message with length %u received from %u: %s \n", length, friendnumber, string);
-    m_sendmessage(friendnumber, (uint8_t*)"Test1", 6);
+    m_sendmessage(m, friendnumber, (uint8_t*)"Test1", 6);
 }
 
 int main(int argc, char *argv[])
@@ -88,7 +92,13 @@ int main(int argc, char *argv[])
         printf("usage %s ip port public_key (of the DHT bootstrap node)\n or\n %s Save.bak\n", argv[0], argv[0]);
         exit(0);
     }
-    initMessenger();
+
+    m = initMessenger();
+    if( !m ){
+        fputs("Failed to allocate messenger datastructure\n", stderr);
+        exit(0);
+    }
+
     if(argc > 3) {
         IP_Port bootstrap_ip_port;
         bootstrap_ip_port.port = htons(atoi(argv[2]));
@@ -100,13 +110,13 @@ int main(int argc, char *argv[])
         int read;
         uint8_t buffer[128000];
         read = fread(buffer, 1, 128000, file);
-        printf("Messenger loaded: %i\n", Messenger_load(buffer, read));
+        printf("Messenger loaded: %i\n", Messenger_load(m, buffer, read));
         fclose(file);
-        
+
     }
-    m_callback_friendrequest(print_request);
-    m_callback_friendmessage(print_message);
-    
+    m_callback_friendrequest(m, print_request);
+    m_callback_friendmessage(m, print_message);
+
     printf("OUR ID: ");
     uint32_t i;
     for(i = 0; i < 32; i++) {
@@ -114,33 +124,34 @@ int main(int argc, char *argv[])
             printf("0");
         printf("%hhX",self_public_key[i]);
     }
-    
-    setname((uint8_t *)"Anon", 5);
-    
+
+    setname(m, (uint8_t *)"Anon", 5);
+
     char temp_id[128];
     printf("\nEnter the client_id of the friend you wish to add (32 bytes HEX format):\n");
     if(scanf("%s", temp_id) != 1) {
         return 1;
     }
-    int num = m_addfriend(hex_string_to_bin(temp_id), (uint8_t*)"Install Gentoo", sizeof("Install Gentoo"));
-    
+    int num = m_addfriend(m, hex_string_to_bin(temp_id), (uint8_t*)"Install Gentoo", sizeof("Install Gentoo"));
+
     perror("Initialization");
 
     while(1) {
         uint8_t name[128];
-        getname(num, name);
+        getname(m, num, name);
         printf("%s\n", name);
-        
-        m_sendmessage(num, (uint8_t*)"Test", 5);
-        doMessenger();
+
+        m_sendmessage(m, num, (uint8_t*)"Test", 5);
+        doMessenger(m);
         c_sleep(30);
         FILE *file = fopen("Save.bak", "wb");
         if ( file==NULL ){return 1;}
-        uint8_t * buffer = malloc(Messenger_size());
-        Messenger_save(buffer);
-        size_t write_result = fwrite(buffer, 1, Messenger_size(), file);
-        if (write_result < Messenger_size()) {return 1;}
+        uint8_t * buffer = malloc(Messenger_size(m));
+        Messenger_save(m, buffer);
+        size_t write_result = fwrite(buffer, 1, Messenger_size(m), file);
+        if (write_result < Messenger_size(m)) {return 1;}
         free(buffer);
         fclose(file);
-    }  
+    }
+    cleanupMessenger(m);
 }

--- a/testing/nTox.h
+++ b/testing/nTox.h
@@ -1,5 +1,5 @@
 /* nTox.h
- * 
+ *
  *Textual frontend for Tox.
  *
  *  Copyright (C) 2013 Tox project All Rights Reserved.
@@ -18,7 +18,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with Tox.  If not, see <http://www.gnu.org/licenses/>.
- *  
+ *
  */
 
 #ifndef NTOX_H
@@ -43,7 +43,7 @@
 #define PUB_KEY_BYTES 32
 
 void new_lines(char *line);
-void line_eval(char *line);
+void line_eval(Messenger *m, char *line);
 void wrap(char output[STRING_LENGTH], char input[STRING_LENGTH], int line_width) ;
 int count_lines(char *string) ;
 char *appender(char *str, const char c);

--- a/testing/toxic/friendlist.c
+++ b/testing/toxic/friendlist.c
@@ -14,7 +14,7 @@
 
 extern char WINDOW_STATUS[TOXWINDOWS_MAX_NUM];
 extern int add_window(ToxWindow w, int n);
-extern ToxWindow new_chat(int friendnum);
+extern ToxWindow new_chat(Messenger *m, int friendnum);
 
 extern int active_window;
 
@@ -42,7 +42,7 @@ void fix_name(uint8_t *name)
   *q = 0;
 }
 
-void friendlist_onMessage(ToxWindow *self, int num, uint8_t *str, uint16_t len)
+void friendlist_onMessage(ToxWindow *self, Messenger *m, int num, uint8_t *str, uint16_t len)
 {
   if (num >= num_friends)
     return;
@@ -54,7 +54,7 @@ void friendlist_onMessage(ToxWindow *self, int num, uint8_t *str, uint16_t len)
     for (i = N_DEFAULT_WINS; i < MAX_WINDOW_SLOTS; ++i) {
       if (WINDOW_STATUS[i] == -1) {
         WINDOW_STATUS[i] = num;
-        add_window(new_chat(num), i);
+        add_window(new_chat(m, num), i);
         active_window = i;
         break;
       }
@@ -82,20 +82,20 @@ void friendlist_onStatusChange(ToxWindow *self, int num, uint8_t *str, uint16_t 
   fix_name(friends[num].status);
 }
 
-int friendlist_onFriendAdded(int num)
+int friendlist_onFriendAdded(Messenger *m, int num)
 {
   if (num_friends == MAX_FRIENDS_NUM)
     return -1;
 
   friends[num_friends].num = num;
-  getname(num, friends[num_friends].name);
+  getname(m, num, friends[num_friends].name);
   strcpy((char*) friends[num_friends].name, "unknown");
   strcpy((char*) friends[num_friends].status, "unknown");
   friends[num_friends++].chatwin = -1;
   return 0;
 }
 
-static void friendlist_onKey(ToxWindow *self, int key)
+static void friendlist_onKey(ToxWindow *self, Messenger *m, int key)
 {
   if (key == KEY_UP) {
     if (--num_selected < 0)
@@ -121,7 +121,7 @@ static void friendlist_onKey(ToxWindow *self, int key)
         if (WINDOW_STATUS[i] == -1) {
           WINDOW_STATUS[i] = num_selected;
           friends[num_selected].chatwin = num_selected;
-          add_window(new_chat(num_selected), i);
+          add_window(new_chat(m, num_selected), i);
           active_window = i;
           break;
         }
@@ -164,7 +164,7 @@ void disable_chatwin(int f_num)
   friends[f_num].chatwin = -1;
 }
 
-static void friendlist_onInit(ToxWindow *self) 
+static void friendlist_onInit(ToxWindow *self, Messenger *m)
 {
 
 }

--- a/testing/toxic/windows.h
+++ b/testing/toxic/windows.h
@@ -9,7 +9,7 @@
 #define KEY_SIZE_BYTES 32
 
 /* number of permanent default windows */
-#define N_DEFAULT_WINS 2  
+#define N_DEFAULT_WINS 2
 
 /* maximum window slots for WINDOW_STATUS array */
 #define MAX_WINDOW_SLOTS N_DEFAULT_WINS+MAX_FRIENDS_NUM
@@ -17,14 +17,14 @@
 typedef struct ToxWindow_ ToxWindow;
 
 struct ToxWindow_ {
-  void(*onKey)(ToxWindow*, int);
+  void(*onKey)(ToxWindow*, Messenger*, int);
   void(*onDraw)(ToxWindow*);
-  void(*onInit)(ToxWindow*);
+  void(*onInit)(ToxWindow*, Messenger*);
   void(*onFriendRequest)(ToxWindow*, uint8_t*, uint8_t*, uint16_t);
-  void(*onMessage)(ToxWindow*, int, uint8_t*, uint16_t);
+  void(*onMessage)(ToxWindow*, Messenger*, int, uint8_t*, uint16_t);
   void(*onNickChange)(ToxWindow*, int, uint8_t*, uint16_t);
   void(*onStatusChange)(ToxWindow*, int, uint8_t*, uint16_t);
-  void(*onAction)(ToxWindow*, int, uint8_t*, uint16_t);
+  void(*onAction)(ToxWindow*, Messenger*, int, uint8_t*, uint16_t);
   char title[256];
 
   void* x;


### PR DESCRIPTION
Moves static state out of Messenger.c and into a Messenger struct
Purely stylistic, no functional changes were made.

This commit also changed all the callers of Messenger as they now have
to pass an instance of the Messenger struct to messenger functions.

Also removed some uses of the 'static' keyword at the beginning of
function definitions when the function was already declared static, as
these caused gcc to whine.
