### PR TITLE
Some tests fix

### DIFF
--- a/auto_tests/crypto_test.c
+++ b/auto_tests/crypto_test.c
@@ -2,10 +2,11 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <string.h>
-#include <check.h>
 #include <stdlib.h>
 #include <time.h>
 #include <sodium.h>
+#define CK_DEFAULT_TIMEOUT 0
+#include <check.h>
 
 void rand_bytes(uint8_t *b, size_t blen)
 {

--- a/auto_tests/messenger_test.c
+++ b/auto_tests/messenger_test.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <string.h>
+#define CK_DEFAULT_TIMEOUT 0
 #include <check.h>
 
 #define REALLY_BIG_NUMBER ((1) << (sizeof(uint16_t) * 7))
@@ -171,7 +172,7 @@ START_TEST(test_getself_name)
     setname(m, (uint8_t *)nickname, len);
     getself_name(m, (uint8_t *)nick_check);
 
-    ck_assert_msg((!STRINGS_EQUAL(nickname, nick_check)),
+    ck_assert_msg((STRINGS_EQUAL(nickname, nick_check)),
         "getself_name failed to return the known name!\n"
         "known name: %s\nreturned: %s\n", nickname, nick_check);
 }


### PR DESCRIPTION
1. form [Check docs](http://check.sourceforge.net/doc/check_html/check_4.html#Test-Timeouts)
   
   > all tests are run with a timeout, the default being 4 seconds. If the test is not finished within that time, it is killed and logged as an error.
   
   I've removed this functionality to make it possible to run tests on slow mashines
2. fixed wrong condition in getself_name() test
