### PR TITLE
Various fixes and improvements to toxic

### DIFF
--- a/testing/toxic/chat.c
+++ b/testing/toxic/chat.c
@@ -31,7 +31,8 @@ extern void fix_name(uint8_t *name);
 void print_help(ChatContext *self);
 void execute(ToxWindow *self, ChatContext *ctx, Messenger *m, char *cmd);
 
-struct tm *get_time(void) {
+struct tm *get_time(void) 
+{
   struct tm *timeinfo;
   time_t now;
   time(&now);

--- a/testing/toxic/main.c
+++ b/testing/toxic/main.c
@@ -181,7 +181,7 @@ int init_connection(void)
   dht.port = htons(atoi(port));
   uint32_t resolved_address = resolve_addr(ip);
   if (resolved_address == 0)
-    return 4;
+    return 0;
   dht.ip.i = resolved_address;
   unsigned char *binary_string = hex_string_to_bin(key);
   DHT_bootstrap(dht, binary_string);


### PR DESCRIPTION
- Fixed bug that still allowed blank lines to send
- Filled in empty chat_onStatusChange() function
- Moved repeated time code to a function
- Gave users a default name
- Show own name instead of "You: " in chat windows
- Put time stamps on status/nick change messages
- Changed action colour to yellow because people were complaining about the blue on black
- Made auto-connect errors verbose
