### PR TITLE
core,nTox,toxic - Fix for Issue #453. Begin refactoring w/astyle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ tags
 
 #netbeans
 nbproject
+
+#astyle
+*.orig

--- a/tools/README
+++ b/tools/README
@@ -1,0 +1,9 @@
+This directory can house various tools and utilities.
+
+astylerc
+ - This file can be used in the precommit hook to try its best at making the code conform to the coding style document.
+
+pre-commit (*NIX only at the moment)
+ - Lints your file in adherence to the coding style doucment as best as possible in terms of spacing, indenting, etc.
+ - Requires you to have astyle installed.
+ - To use, copy this file to ProjectTox-Core/.git/hooks

--- a/tools/astylerc
+++ b/tools/astylerc
@@ -1,0 +1,11 @@
+--style=kr
+--pad-header
+--max-code-length=120
+--convert-tabs
+--indent-switches
+--pad-oper
+--align-pointer=name
+--align-reference=name
+--preserve-date
+--lineend=linux
+--break-blocks

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+for file in `git diff-index --diff-filter=ACMR --name-only HEAD`; do
+    if [[ $file == *.c || $file == *.h ]]
+    then
+        echo $file
+        `which astyle` $file --options=tools/astylerc
+        git add $file
+    fi
+done


### PR DESCRIPTION
This commit introduces a few things. Basically I didn't like the fact that
although we had a coding style document, no one was following it. See
https://github.com/irungentoo/ProjectTox-Core/issues/453 for more info regarding
that. The only change is that I'm going forward with the style that is posted on the
wiki. This commit just marks the first of my efforts to refactor the code base
according to the posted coding style document.

Using astyle, I was able to lint through all of the source files giving the
provided tools/astylerc as an options input. I propose that users can add
this functionality as a  pre-commit hook. More info is in the README file.

However, this has only been tested on Linux and I imagine should work on OSX as
well. I don't think pre-commit hooks work on Windows, but I may be mistaken. The
pre-commit hook is optional as well, but may be a good idea.

The future commits I plan are refactoring the source files for other offending
items such as using typedefs. See http://wiki.tox.im/index.php/Coding_Style.
