### PR TITLE
Update prompt.c

### DIFF
--- a/testing/toxic/prompt.c
+++ b/testing/toxic/prompt.c
@@ -121,6 +121,11 @@ void cmd_add(ToxWindow *self, Messenger *m, char **args)
     }
     id_bin[i] = x;
   }
+  
+  for (i = 0; i < FRIEND_ADDRESS_SIZE; i++) {
+    id[i] = toupper(id[i]);
+  }
+  
   int num = m_addfriend(m, id_bin, (uint8_t*) msg, strlen(msg)+1);
   switch (num) {
   case FAERR_TOOLONG:


### PR DESCRIPTION
Make id uppercase - Jin^elD mentioned toxic could only parse a key if it was uppercase. Assume this is what he meant.
