### PR TITLE
Fix segfault when using -f in toxic

### DIFF
--- a/testing/toxic/main.c
+++ b/testing/toxic/main.c
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
     else if (argv[i][0] == '-') {
       if (argv[i][1] == 'f') {
         if (argv[i + 1] != NULL)
-          DATA_FILE = argv[i + 1];
+          DATA_FILE = strdup(argv[i + 1]);
         else
           f_flag = -1;
       } else if (argv[i][1] == 'n') {


### PR DESCRIPTION
Call strdup() on the data file argument string to avoid segmentation
fault when it is later freed.
