### PR TITLE
small bug fixes for toxic

### DIFF
--- a/testing/toxic/chat.c
+++ b/testing/toxic/chat.c
@@ -314,7 +314,7 @@ void execute(ToxWindow *self, ChatContext *ctx, Messenger *m, char *cmd)
       snprintf(xx, sizeof(xx), "%02X",  address[i] & 0xff);
       strcat(id, xx);
     }
-    wprintw(ctx->history, "Your ID: %s\n", id);
+    wprintw(ctx->history, "%s\n", id);
   }
 
   else if (strcmp(ctx->line, "/close") == 0) {

--- a/testing/toxic/main.c
+++ b/testing/toxic/main.c
@@ -45,7 +45,7 @@ static void init_term()
   refresh();
 }
 
-static Messenger * init_tox()
+static Messenger *init_tox()
 {
   /* Init core */
   Messenger *m = initMessenger();
@@ -199,7 +199,6 @@ int main(int argc, char *argv[])
   char *DATA_FILE = NULL;
   int config_err = 0;
 
-  /* This is broken */
   int f_loadfromfile = 1;
   int f_flag = 0;
   int i = 0;
@@ -233,7 +232,7 @@ int main(int argc, char *argv[])
 
   init_term();
   Messenger *m = init_tox();
-  ToxWindow * prompt = init_windows(m);
+  ToxWindow *prompt = init_windows(m);
   init_window_status();
 
   if(f_loadfromfile)

--- a/testing/toxic/prompt.c
+++ b/testing/toxic/prompt.c
@@ -238,7 +238,7 @@ void cmd_myid(ToxWindow *self, Messenger *m, char **args)
     snprintf(xx, sizeof(xx), "%02X", address[i] & 0xff);
     strcat(id, xx);
   }
-  wprintw(self->window, "Your ID: %s\n", id);
+  wprintw(self->window, "%s\n", id);
 }
 
 void cmd_nick(ToxWindow *self, Messenger *m, char **args)

--- a/testing/toxic/windows.c
+++ b/testing/toxic/windows.c
@@ -159,7 +159,7 @@ void init_window_status()
     WINDOW_STATUS[j] = -1;
 }
 
-ToxWindow * init_windows()
+ToxWindow *init_windows()
 {
   w_num = 0;
   int n_prompt = 0;
@@ -170,6 +170,7 @@ ToxWindow * init_windows()
     endwin();
     exit(1);
   }
+  active_window = n_prompt;
   prompt = &windows[n_prompt];
   return prompt;
 }
@@ -217,7 +218,7 @@ void prepare_window(WINDOW *w)
   wresize(w, LINES-2, COLS);
 }
 
-void draw_active_window(Messenger * m)
+void draw_active_window(Messenger *m)
 {
 
   ToxWindow *a = &windows[active_window];


### PR DESCRIPTION
Set prompt screen on startup instead of friends window, and made the myid command output shorter so it doesn't wrap and add a newline.
