### PR TITLE
Build fails when SHARED_TOXCORE flag is set in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
 
 	include_directories(${SODIUM_INCLUDE_DIR})
 
-	set(LINK_CRYPTO_LIBRARY ${SODIUM_LIBRARY})
+	set(LINK_CRYPTO_LIBRARY ${SODIUM_LIBRARIES})
 endif()
 
 #MinGW prints more warnings for -Wall than gcc does, thus causing build to fail

--- a/cmake/FindSODIUM.cmake
+++ b/cmake/FindSODIUM.cmake
@@ -54,8 +54,8 @@ endif()
 
 find_library(SODIUM_LIBRARY
     NAMES
-        ${WIN32_LIBSODIUM_FILENAME}
         sodium
+        ${WIN32_LIBSODIUM_FILENAME}
     PATHS
         ${SODIUM_ROOT_DIR}/lib
 )


### PR DESCRIPTION
``` shell
thomas@tom-arch ~/src-private/tox/build (git)-[master] % cmake -DSHARED_TOXCORE=TRUE ..
-- The C compiler identification is GNU 4.8.1
-- The CXX compiler identification is GNU 4.8.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Found Curses: /usr/lib64/libcurses.so  
-- Found SODIUM: /usr/lib64/libsodium.a  
-- ==== GNU detected - Adding compiler flags ====
-- Found Sphinx: /usr/bin/sphinx-build  
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.28") 
-- checking for one of the modules 'check'
-- Configuring done
-- Generating done
-- Build files have been written to: /home/thomas/src-private/tox/build
thomas@tom-arch ~/src-private/tox/build (git)-[master] %
thomas@tom-arch ~/src-private/tox/build (git)-[master] % make -j
Scanning dependencies of target toxcore
[  9%] [  9%] [  9%] [ 12%] [ 15%] Building C object core/CMakeFiles/toxcore.dir/DHT.c.o
Building C object core/CMakeFiles/toxcore.dir/network.c.o
[ 18%] [ 21%] Building C object core/CMakeFiles/toxcore.dir/net_crypto.c.o
Building C object core/CMakeFiles/toxcore.dir/Lossless_UDP.c.o
[ 25%] Building C object core/CMakeFiles/toxcore.dir/friend_requests.c.o
Building C object core/CMakeFiles/toxcore.dir/LAN_discovery.c.o
Building C object core/CMakeFiles/toxcore.dir/Messenger.c.o
Building C object core/CMakeFiles/toxcore.dir/util.c.o
[ 28%] [ 31%] Building C object core/CMakeFiles/toxcore.dir/timer.c.o
Building C object core/CMakeFiles/toxcore.dir/ping.c.o
Linking C shared library libtoxcore.so
/usr/bin/ld: /usr/lib/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../lib/libsodium.a(libsodium_la-randombytes_sysrandom.o): relocation R_X86_64_PC32 against symbol `randombytes_sysrandom_buf' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
make[2]: *** [core/libtoxcore.so] Error 1
make[1]: *** [core/CMakeFiles/toxcore.dir/all] Error 2
make: *** [all] Error 2
```
