### PR TITLE
Made configdir check XDG_CONFIG_HOME for config dir

### DIFF
--- a/testing/toxic/configdir.c
+++ b/testing/toxic/configdir.c
@@ -98,14 +98,18 @@ char *get_user_config_dir(void)
 
     snprintf(user_config_dir, len, "%s/Library/Application Support", home);
 # else /* __APPLE__ */
-    len = strlen(home) + strlen("/.config") + 1;
-    user_config_dir = malloc(len);
 
-    if (user_config_dir == NULL) {
-        return NULL;
+    if (!(user_config_dir = getenv("XDG_CONFIG_HOME"))) {
+        len = strlen(home) + strlen("/.config") + 1;
+        user_config_dir = malloc(len);
+
+        if (user_config_dir == NULL) {
+            return NULL;
+        }
+
+        snprintf(user_config_dir, len, "%s/.config", home);
     }
 
-    snprintf(user_config_dir, len, "%s/.config", home);
 # endif /* __APPLE__ */
 
     return user_config_dir;


### PR DESCRIPTION
The XDG spec [1] says to check if the environmental variable XDG_CONFIG_HOME is defined, and if so, use it to store configuration. This change makes get_user_config_dir do so. 

[1] http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
