### PR TITLE
Fixed a cmake flie to work properly on Windows

### DIFF
--- a/other/CMakeLists.txt
+++ b/other/CMakeLists.txt
@@ -1,13 +1,10 @@
 cmake_minimum_required(VERSION 2.6.0)
 
 cmake_policy(SET CMP0011 NEW)
-SET(USER_NAME $ENV{USERNAME} CACHE STRING UserName)
-
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/DHT_bootstrap.cmake)
 
 if(WIN32)
-  file(MAKE_DIRECTORY "C:/Users/${USER_NAME}/AppData/Roaming/.config/tox")
-  file(INSTALL DHTservers DESTINATION "C:/Users/${USER_NAME}/AppData/Roaming/.config/tox")
+  file(MAKE_DIRECTORY "$ENV{APPDATA}/.config/tox")
+  file(INSTALL DHTservers DESTINATION "$ENV{APPDATA}/.config/tox")
 else()
   set(HOME "$ENV{HOME}")
   if(APPLE)
@@ -18,6 +15,8 @@ else()
     file(INSTALL DHTservers DESTINATION ${HOME}/.config/tox)
   endif()
 endif()
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/DHT_bootstrap.cmake)
 
 if(LINUX)
 	add_subdirectory(bootstrap_serverdaemon)


### PR DESCRIPTION
Instead of assuming that the system is installed on C drive and that it's either Windows 7 or Windows Vista, just use [`%APPDATA%`](http://en.wikipedia.org/wiki/Environment_variable#Default_Values_on_Microsoft_Windows) environment variable, which will work for all drives and other versions of Windows.

Tested on Windows 7.
