### PR TITLE
Fixed segfault and added support for single quotes in toxic

### DIFF
--- a/testing/toxic/prompt.c
+++ b/testing/toxic/prompt.c
@@ -358,8 +358,16 @@ static void execute(ToxWindow *self, Messenger *m, char *u_cmd)
     int numargs = 0;
 
     for (i = 0; i < MAX_STR_SIZE; i++) {
-        if (cmd[i] == '\"')
-            while (cmd[++i] != '\"'); /* skip over strings */
+        char quote_chr;
+        if (cmd[i] == '\"' || cmd[i] == '\'') {
+            quote_chr = cmd[i];
+            while (cmd[++i] != quote_chr && i < MAX_STR_SIZE); /* skip over strings */
+            /* Check if got qoute character */
+            if (cmd[i] != quote_chr) {
+                wprintw(self->window, "Missing terminating %c character\n", quote_chr);
+                return;
+            }
+	}
 
         if (cmd[i] == ' ') {
             cmd[i] = '\0';


### PR DESCRIPTION
Observed segmentation fault if only left double quotes is present in command string in toxic. Fixed this by adding check on index variable. Also added support for single quotes.   
