### PR TITLE
Let clients include <tox/tox.h>

### DIFF
--- a/libtoxcore.pc.in
+++ b/libtoxcore.pc.in
@@ -8,5 +8,5 @@ Description: Tox protocol library
 Requires:
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -ltoxcore @LIBS@
-Cflags: -I${includedir}/tox
+Cflags: -I${includedir}
 


### PR DESCRIPTION
...otherwise it's more difficult for them to find the header when pkg-config is not available.
