### PR TITLE
Also generate a .dll in MinGW builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,7 @@ AC_ARG_WITH(libsodium-libs,
 # Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
+AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL
 
 WIN32=no

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -34,7 +34,8 @@ libtoxcore_la_CFLAGS =  -I$(top_srcdir) \
                         $(LIBSODIUM_CFLAGS)
 
 libtoxcore_la_LDFLAGS = -version-info $(LIBTOXCORE_VERSION) \
-                        $(LIBSODIUM_LDFLAGS)
-
-libtoxcore_la_LIBS =    $(LIBSODIUM_LIBS) \
+                        -no-undefined \
+                        $(LIBSODIUM_LDFLAGS) \
                         $(WINSOCK2_LIBS)
+
+libtoxcore_la_LIBS =    $(LIBSODIUM_LIBS)


### PR DESCRIPTION
Previously only static a static library was produced on MinGW builds,
this PR makes sure that we also build a proper .dll
