### PR TITLE
Tune automake options to avoid problems with newer versions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 SUBDIRS = build
 
 ACLOCAL_AMFLAGS = -I m4
+AUTOMAKE_OPTIONS = subdir-objects
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = $(top_builddir)/libtoxcore.pc


### PR DESCRIPTION
Automake >1.14 complains if makefiles are used in subdirs but
the subdir-objects option is not set.
