### PR TITLE
Make nTox work on MinGW/Win32

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,8 +115,6 @@ AC_CANONICAL_HOST
 case $host_os in
     *mingw*)
         WIN32="yes"
-        AC_MSG_WARN([nTox is not supported on $host_os yet, disabling])
-        BUILD_NTOX="no"
         EXTRA_LT_LDFLAGS="$EXTRA_LT_LDFLAGS -no-undefined"
     ;;
     *solaris*)
@@ -202,9 +200,8 @@ AC_TYPE_UINT8_T
 
 # Checks for library functions.
 AC_FUNC_FORK
-AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([gettimeofday memset socket strchr])
+AC_CHECK_FUNCS([gettimeofday memset socket strchr malloc])
 
 # pkg-config based tests
 PKG_PROG_PKG_CONFIG
@@ -271,22 +268,41 @@ if (test "x$BUILD_NTOX" = "xyes") && (test "x$NCURSES_FOUND" != "xyes"); then
             ]
         )
         if test "x$BUILD_NTOX" = "xyes"; then
-            AC_CHECK_LIB([ncurses], [clear],
-                [],
-                [
-                    unset ac_cv_lib_ncurses_clear
-                    AC_CHECK_LIB([ncurses], [clear],
-                        [],
-                        [
-                            AC_MSG_WARN([not building nTox client because required library ncurses was not found on your system])
-                            BUILD_NTOX="no"
-                        ],
-                        [
-                            -ltinfo
-                        ]
-                    )
-                ]
-            )
+            if test "x$WIN32" = "xyes"; then
+                AC_CHECK_LIB([pdcurses], [clear],
+                    [
+                        NCURSES_LIBS="-lpdcurses"
+                        AC_SUBST(NCURSES_LIBS)
+                    ],
+                    [
+                        AC_MSG_ERROR([required library pdcurses was not found on your system])
+                        BUILD_NTOX="no"
+                    ]
+                )
+            else
+                AC_CHECK_LIB([ncurses], [clear],
+                    [
+                        NCURSES_LIBS="-lncurses"
+                        AC_SUBST(NCURSES_LIBS)
+                    ],
+                    [
+                        unset ac_cv_lib_ncurses_clear
+                        AC_CHECK_LIB([ncurses], [clear],
+                            [
+                                NCURSES_LIBS="-lncurses -ltinfo"
+                                AC_SUBST(NCURSES_LIBS)
+                            ],
+                            [
+                                AC_MSG_WARN([not building nTox client because required library ncurses was not found on your system])
+                                BUILD_NTOX="no"
+                            ],
+                            [
+                                -ltinfo
+                            ]
+                        )
+                    ]
+                )
+            fi
         fi
     fi
 fi

--- a/testing/Makefile.inc
+++ b/testing/Makefile.inc
@@ -13,8 +13,8 @@ nTox_CFLAGS =           $(LIBSODIUM_CFLAGS) \
 nTox_LDADD =            $(LIBSODIUM_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
-                        $(NCURSES_LIBS)
-
+                        $(NCURSES_LIBS) \
+                        $(WINSOCK2_LIBS)
 endif
 
 

--- a/testing/nTox.h
+++ b/testing/nTox.h
@@ -27,61 +27,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ncurses.h>
 #include <curses.h>
 #include <ctype.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <sys/types.h>
-#include <netdb.h>
+
 #include "../toxcore/tox.h"
 
 #define STRING_LENGTH 256
 #define HISTORY 50
 #define PUB_KEY_BYTES 32
 
-/*
-  resolve_addr():
-    address should represent IPv4 or a hostname with A record
-
-    returns a data in network byte order that can be used to set IP.i or IP_Port.ip.i
-    returns 0 on failure
-
-    TODO: Fix ipv6 support
-*/
-
-uint32_t resolve_addr(const char *address)
-{
-    struct addrinfo *server = NULL;
-    struct addrinfo  hints;
-    int              rc;
-    uint32_t         addr;
-
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family   = AF_INET;    // IPv4 only right now.
-    hints.ai_socktype = SOCK_DGRAM; // type of socket Tox uses.
-
-    rc = getaddrinfo(address, "echo", &hints, &server);
-
-    // Lookup failed.
-    if (rc != 0) {
-        return 0;
-    }
-
-    // IPv4 records only..
-    if (server->ai_family != AF_INET) {
-        freeaddrinfo(server);
-        return 0;
-    }
-
-
-    addr = ((struct sockaddr_in *)server->ai_addr)->sin_addr.s_addr;
-
-    freeaddrinfo(server);
-    return addr;
-}
-
+uint32_t resolve_addr(const char *address);
 void new_lines(char *line);
 void line_eval(Tox *m, char *line);
 void wrap(char output[STRING_LENGTH], char input[STRING_LENGTH], int line_width) ;


### PR DESCRIPTION
One remaining problem on Win32 seems to be with a data file - a saved data file can not be loaded, so if you have one - remove it prior to starting nTox
