### PR TITLE
Fixed automake warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_INIT([tox], [0.0.0], [http://tox.im])
 AC_CONFIG_AUX_DIR(configure_aux)
 AC_CONFIG_SRCDIR([toxcore/net_crypto.c])
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([1.10 -Wall])
+AM_INIT_AUTOMAKE([1.10 -Wall -Wno-extra-portability subdir-objects no-dependencies])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_MACRO_DIR([m4])
 


### PR DESCRIPTION
When using autoreconf -i you will get some warnings about subdir-objects stuff(I am no expert)
This patch fixes that, but someone with more experience with autotools should have a look at it since I just threw some stuff in configure.ac I found on the first hit on google...
