### PR TITLE
Wrote a quicksort macro and modified sort_list to use it

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -56,6 +56,8 @@
 #define NAT_PING_REQUEST    0
 #define NAT_PING_RESPONSE   1
 
+/* Create the quicksort function. See misc_tools.h for the definition. */
+make_quick_sort(ClientPair); 
 
 Client_data *DHT_get_close_list(DHT *dht)
 {
@@ -299,8 +301,6 @@ static void sort_list(Client_data *list, uint32_t length, uint8_t *comp_client_i
     ClientPair pairs[length];
     uint32_t i;
 
-    /* Create the quicksort function. See misc_tools.h for the definition. */
-    make_quick_sort(ClientPair); 
     memcpy(cd.client_id, comp_client_id, CLIENT_ID_SIZE);
     for (i = 0; i < length; ++i) {
         pairs[i].c1 = cd;

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -106,6 +106,9 @@ typedef struct {
 } DHT;
 /*----------------------------------------------------------------------------------*/
 
+/* Create the declaration for a quick sort for ClientPair structures. */
+declare_quick_sort(ClientPair);
+
 Client_data *DHT_get_close_list(DHT *dht);
 
 /* Add a new friend to the friends list.

--- a/toxcore/misc_tools.h
+++ b/toxcore/misc_tools.h
@@ -199,6 +199,11 @@ static inline void tox_array_pop(tox_array *arr, uint32_t num)
  * cmpfn - a function that compares two values of type type. 
  *         Must return -1, 0, 1 for a < b, a == b, and a > b respectively.
  */
+/* Must be called in the header file. */ 
+#define declare_quick_sort(type) \
+void type##_quick_sort(type *arr, int n, int (*cmpfn)(type, type));
+
+/* Must be called in the C file. */
 #define make_quick_sort(type) \
 void type##_quick_sort(type *arr, int n, int (*cmpfn)(type, type)) \
 { \


### PR DESCRIPTION
See https://gist.github.com/redwire/6394042  for a self-contained example of using the quick_sort (as well as how it's applied to sort_list).  The gist runs standalone with `gcc -o test -std=c99 [testfile].c && ./test`.
