### PR TITLE
Fixed missing field initializer warnings

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -1070,7 +1070,7 @@ static void punch_holes(DHT *dht, IP ip, uint16_t *port_list, uint16_t numports,
     for (i = dht->friends_list[friend_num].punching_index; i != top; i++) {
         /* TODO: improve port guessing algorithm */
         uint16_t port = port_list[(i / 2) % numports] + (i / (2 * numports)) * ((i % 2) ? -1 : 1);
-        IP_Port pinging = {{ip, htons(port)}};
+        IP_Port pinging = {{ip, htons(port), 0}};
         send_ping_request(dht->ping, dht->c, pinging, dht->friends_list[friend_num].client_id);
     }
 

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -144,7 +144,7 @@ int send_LANdiscovery(uint16_t port, Net_Crypto *c)
     uint8_t data[crypto_box_PUBLICKEYBYTES + 1];
     data[0] = NET_PACKET_LAN_DISCOVERY;
     memcpy(data + 1, c->self_public_key, crypto_box_PUBLICKEYBYTES);
-    IP_Port ip_port = {{broadcast_ip(), port}};
+    IP_Port ip_port = {{broadcast_ip(), port, 0}};
     return sendpacket(c->lossless_udp->net->sock, ip_port, data, 1 + crypto_box_PUBLICKEYBYTES);
 }
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -62,7 +62,7 @@ uint32_t random_int(void)
  */
 int sendpacket(int sock, IP_Port ip_port, uint8_t *data, uint32_t length)
 {
-    ADDR addr = {AF_INET, ip_port.port, ip_port.ip};
+    ADDR addr = {AF_INET, ip_port.port, ip_port.ip, {0}};
     return sendto(sock, (char *) data, length, 0, (struct sockaddr *)&addr, sizeof(addr));
 }
 
@@ -207,7 +207,7 @@ Networking_Core *new_networking(IP ip, uint16_t port)
 #endif
 
     /* Bind our socket to port PORT and address 0.0.0.0 */
-    ADDR addr = {AF_INET, htons(port), ip};
+    ADDR addr = {AF_INET, htons(port), ip, {0}};
     bind(temp->sock, (struct sockaddr *)&addr, sizeof(addr));
     return temp;
 }


### PR DESCRIPTION
Fixed `-Wmissing-field-initializers` warnings.

```
toxcore/DHT.c:1073: warning: missing initializer for field 'padding' of 'struct <anonymous>' [-Wmissing-field-initializers]
toxcore/LAN_discovery.c:147: warning: missing initializer for field 'padding' of 'struct <anonymous>' [-Wmissing-field-initializers]
toxcore/network.c:65: warning: missing initializer for field 'zeroes' of 'ADDR' [-Wmissing-field-initializers]
toxcore/network.c:210: warning: missing initializer for field 'zeroes' of 'ADDR' [-Wmissing-field-initializers]
```
