### PR TITLE
Fixed a crash where crypto_kill would be called, c->crypto_connections (...

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -713,7 +713,7 @@ static void receive_crypto(Net_Crypto *c)
             }
         }
 
-        if (c->crypto_connections[i].status == CONN_NOT_CONFIRMED) {
+        else if (c->crypto_connections[i].status == CONN_NOT_CONFIRMED) {
             if (id_packet(c->lossless_udp, c->crypto_connections[i].number) == 3) {
                 uint8_t temp_data[MAX_DATA_SIZE];
                 uint8_t data[MAX_DATA_SIZE];


### PR DESCRIPTION
...for a single client) would become NULL, and the variable assignment on line 731 would crash. This is after irungentoo's reordering in do_net_crypto
