### PR TITLE
Allow to build vs nacl instead of libsodium

### DIFF
--- a/auto_tests/Makefile.inc
+++ b/auto_tests/Makefile.inc
@@ -9,23 +9,29 @@ messenger_autotest_SOURCES = \
 
 messenger_autotest_CFLAGS = \
                         $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS) \
                         $(CHECK_CFLAGS)
 
 messenger_autotest_LDADD = \
                         $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(CHECK_LIBS)
 
 
 crypto_test_SOURCES =   ../auto_tests/crypto_test.c
 
 crypto_test_CFLAGS =    $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS) \
                         $(CHECK_CFLAGS)
 
 crypto_test_LDADD =     $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(CHECK_LIBS)
 
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,18 @@ BUILD_TESTS="yes"
 NCURSES_FOUND="no"
 LIBCONFIG_FOUND="no"
 LIBCHECK_FOUND="no"
+WANT_NACL="no"
+
+AC_ARG_ENABLE([nacl],
+    [AC_HELP_STRING([--enable-tests], [use nacl instead of libsodium (default: disabled)]) ],
+    [
+        if test "x$enableval" = "xno"; then
+            WANT_NACL="no"
+        elif test "x$enableval" = "xyes"; then
+            WANT_NACL="yes"
+        fi
+    ]
+)
 
 AC_ARG_ENABLE([tests],
     [AC_HELP_STRING([--disable-tests], [build unit tests (default: auto)]) ],
@@ -69,6 +81,8 @@ AC_ARG_ENABLE([dht-bootstrap-daemon],
 DEPSEARCH=
 LIBSODIUM_SEARCH_HEADERS=
 LIBSODIUM_SEARCH_LIBS=
+NACL_SEARCH_HEADERS=
+NACL_SEARCH_LIBS=
 
 AC_ARG_WITH(dependency-search,
     AC_HELP_STRING([--with-dependency-search=DIR],
@@ -85,6 +99,24 @@ if test -n "$DEPSEARCH"; then
     LDFLAGS="$LDFLAGS -L$DEPSEARCH/lib"
     export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$DEPSEARCH/lib/pkgconfig
 fi
+
+AC_ARG_WITH(nacl-headers,
+        AC_HELP_STRING([--with-nacl-headers=DIR],
+                       [search for nacl<F2> header files in DIR]),
+        [
+            NACL_SEARCH_HEADERS="$withval"
+            AC_MSG_NOTICE([will search for nacl header files in $withval])
+        ]
+)
+
+AC_ARG_WITH(nacl-libs,
+        AC_HELP_STRING([--with-nacl-libs=DIR],
+                       [search for nacl libraries in DIR]),
+        [
+            NACL_SEARCH_LIBS="$withval"
+            AC_MSG_NOTICE([will search for nacl libraries in $withval])
+        ]
+)
 
 AC_ARG_WITH(libsodium-headers,
         AC_HELP_STRING([--with-libsodium-headers=DIR],
@@ -132,61 +164,128 @@ AM_CONDITIONAL(WIN32, test "x$WIN32" = "xyes")
 AC_SUBST(EXTRA_LT_LDFLAGS)
 
 # Checks for libraries.
-LIBSODIUM_LIBS=
-LIBSODIUM_LDFLAGS=
-LDFLAGS_SAVE="$LDFLAGS"
-if test -n "$LIBSODIUM_SEARCH_LIBS"; then
-    LDFLAGS="-L$LIBSODIUM_SEARCH_LIBS $LDFLAGS"
-    AC_CHECK_LIB(sodium, randombytes_random,
-        [
-            LIBSODIUM_LDFLAGS="-L$LIBSODIUM_SEARCH_LIBS"
-            LIBSODIUM_LIBS="-lsodium"
-        ],
-        [
-            AC_MSG_ERROR([required library libsodium was not found in requested location $LIBSODIUM_SEARCH_LIBS])
-        ]
-    )
-else
-    AC_CHECK_LIB(sodium, randombytes_random,
-        [],
-        [
-            AC_MSG_ERROR([required library libsodium was not found on your system, please check http://download.libsodium.org/libsodium/releases/])
-        ]
-    )
-fi
 
-LDFLAGS="$LDFLAGS_SAVE"
-AC_SUBST(LIBSODIUM_LIBS)
-AC_SUBST(LIBSODIUM_LDFLAGS)
+if test "x$WANT_NACL" = "xyes"; then
+    NACL_LIBS=
+    NACL_LDFLAGS=
+    LDFLAGS_SAVE="$LDFLAGS"
+    if test -n "$NACL_SEARCH_LIBS"; then
+        LDFLAGS="-L$NACL_SEARCH_LIBS $LDFLAGS"
+        AC_CHECK_LIB(nacl, random,
+            [
+                NACL_LDFLAGS="-L$NACL_SEARCH_LIBS"
+                NACL_LIBS="-lnacl"
+            ],
+            [
+                AC_MSG_ERROR([library nacl was not found in requested location $NACL_SEARCH_LIBS])
+            ]
+        )
+    else
+        AC_CHECK_LIB(nacl, random,
+            [],
+            [
+                AC_MSG_ERROR([you enabled nacl support, but library nacl was not found on your system])
+            ]
+        )
+    fi
+
+    if (test -f "$NACL_SEARCH_LIBS/cpucycles.o") &&
+       (test -f "$NACL_SEARCH_LIBS/randombytes.o"); then
+        NACL_LIBS="$NACL_LIBS $NACL_SEARCH_LIBS/cpucycles.o $NACL_SEARCH_LIBS/randombytes.o"
+    else
+        AC_MSG_ERROR([nacl weirdness: required object files cpucycles.o randombytes.o not found])
+    fi
+
+    LDFLAGS="$LDFLAGS_SAVE"
+    AC_SUBST(NACL_LIBS)
+    AC_SUBST(NACL_LDFLAGS)
+else
+    LIBSODIUM_LIBS=
+    LIBSODIUM_LDFLAGS=
+    LDFLAGS_SAVE="$LDFLAGS"
+    if test -n "$LIBSODIUM_SEARCH_LIBS"; then
+        LDFLAGS="-L$LIBSODIUM_SEARCH_LIBS $LDFLAGS"
+        AC_CHECK_LIB(sodium, randombytes_random,
+            [
+                LIBSODIUM_LDFLAGS="-L$LIBSODIUM_SEARCH_LIBS"
+                LIBSODIUM_LIBS="-lsodium"
+            ],
+            [
+                AC_MSG_ERROR([required library libsodium was not found in requested location $LIBSODIUM_SEARCH_LIBS])
+            ]
+        )
+    else
+        AC_CHECK_LIB(sodium, randombytes_random,
+            [],
+            [
+                AC_MSG_ERROR([required library libsodium was not found on your system, please check http://download.libsodium.org/libsodium/releases/])
+            ]
+        )
+    fi
+
+    LDFLAGS="$LDFLAGS_SAVE"
+    AC_SUBST(LIBSODIUM_LIBS)
+    AC_SUBST(LIBSODIUM_LDFLAGS)
+fi
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdint.h stdlib.h string.h sys/socket.h sys/time.h unistd.h])
 
-LIBSODIUM_CFLAGS=
-CFLAGS_SAVE="$CFLAGS"
-CPPFLAGS_SAVE="$CPPFLAGS"
-if test -n "$LIBSODIUM_SEARCH_HEADERS"; then
-    CFLAGS="-I$LIBSODIUM_SEARCH_HEADERS $CFLAGS"
-    CPPFLAGS="-I$LIBSODIUM_SEARCH_HEADERS $CPPFLAGS"
-    AC_CHECK_HEADER(sodium.h,
-        [
-            LIBSODIUM_CFLAGS="-I$LIBSODIUM_SEARCH_HEADERS"
-        ],
-        [
-            AC_MSG_ERROR([header files for required library libsodium was not found in requested location $LIBSODIUM_SEARCH_HEADERS])
-        ]
-    )
+
+if test "x$WANT_NACL" = "xyes"; then
+    NACL_CFLAGS=
+    CFLAGS_SAVE="$CFLAGS"
+    CPPFLAGS_SAVE="$CPPFLAGS"
+    if test -n "$NACL_SEARCH_HEADERS"; then
+        CFLAGS="-I$NACL_SEARCH_HEADERS $CFLAGS"
+        CPPFLAGS="-I$NACL_SEARCH_HEADERS $CPPFLAGS"
+        AC_CHECK_HEADER(crypto_box.h,
+            [
+                NACL_CFLAGS="-I$NACL_SEARCH_HEADERS"
+            ],
+            [
+                AC_MSG_ERROR([header files for library nacl were not found in requested location $NACL_SEARCH_HEADERS])
+            ]
+        )
+    else
+        AC_CHECK_HEADER(crypto_box.h,
+            [],
+            [
+                AC_MSG_ERROR([you enabled nacl support, but nacl header files were not found on your system])
+            ]
+        )
+    fi
+    CFLAGS="$CFLAGS_SAVE"
+    CPPFLAGS="$CPPFLAGS_SAVE"
+    AC_SUBST(NACL_CFLAGS)
+    AC_DEFINE([VANILLA_NACL], [1], [use nacl instead of libsodium])
 else
-    AC_CHECK_HEADER(sodium.h,
-        [],
-        [
-            AC_MSG_ERROR([header files for required library libsodium was not found on your system, please check http://download.libsodium.org/libsodium/releases/])
-        ]
-    )
+    LIBSODIUM_CFLAGS=
+    CFLAGS_SAVE="$CFLAGS"
+    CPPFLAGS_SAVE="$CPPFLAGS"
+    if test -n "$LIBSODIUM_SEARCH_HEADERS"; then
+        CFLAGS="-I$LIBSODIUM_SEARCH_HEADERS $CFLAGS"
+        CPPFLAGS="-I$LIBSODIUM_SEARCH_HEADERS $CPPFLAGS"
+        AC_CHECK_HEADER(sodium.h,
+            [
+                LIBSODIUM_CFLAGS="-I$LIBSODIUM_SEARCH_HEADERS"
+            ],
+            [
+                AC_MSG_ERROR([header files for required library libsodium were not found in requested location $LIBSODIUM_SEARCH_HEADERS])
+            ]
+        )
+    else
+        AC_CHECK_HEADER(sodium.h,
+            [],
+            [
+                AC_MSG_ERROR([header files for required library libsodium was not found on your system, please check http://download.libsodium.org/libsodium/releases/])
+            ]
+        )
+    fi
+    CFLAGS="$CFLAGS_SAVE"
+    CPPFLAGS="$CPPFLAGS_SAVE"
+    AC_SUBST(LIBSODIUM_CFLAGS)
 fi
-CFLAGS="$CFLAGS_SAVE"
-CPPFLAGS="$CPPFLAGS_SAVE"
-AC_SUBST(LIBSODIUM_CFLAGS)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL
@@ -201,7 +300,6 @@ AC_TYPE_UINT8_T
 
 # Checks for library functions.
 AC_FUNC_FORK
-AC_FUNC_REALLOC
 AC_CHECK_FUNCS([gettimeofday memset socket strchr malloc])
 
 # pkg-config based tests

--- a/other/Makefile.inc
+++ b/other/Makefile.inc
@@ -5,11 +5,14 @@ DHT_bootstrap_SOURCES = ../other/DHT_bootstrap.c \
                         ../toxcore/friend_requests.h
 
 DHT_bootstrap_CFLAGS = -I$(top_srcdir)/other \
-                        $(LIBSODIUM_CFLAGS)
+                        $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS)
 
 DHT_bootstrap_LDADD =   $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(WINSOCK2_LIBS)
 
 EXTRA_DIST +=           $(top_srcdir)/other/DHTservers \

--- a/other/bootstrap_serverdaemon/Makefile.inc
+++ b/other/bootstrap_serverdaemon/Makefile.inc
@@ -8,13 +8,16 @@ DHT_bootstrap_daemon_SOURCES = \
 DHT_bootstrap_daemon_CFLAGS = \
                         -I$(top_srcdir)/other/bootstrap_serverdaemon \
                         $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS) \
                         $(LIBCONFIG_CFLAGS)
 
 DHT_bootstrap_daemon_LDADD = \
                         $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBCONFIG_LIBS) \
-                        $(LIBSODIUM_LIBS)
+                        $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS)
 
 endif
 

--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -27,6 +27,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 //#include "../core/network.h"
 #include "../toxcore/DHT.h"
 #include "../toxcore/friend_requests.h"

--- a/testing/Lossless_UDP_testclient.c
+++ b/testing/Lossless_UDP_testclient.c
@@ -28,6 +28,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "../toxcore/network.h"
 #include "../toxcore/Lossless_UDP.h"
 

--- a/testing/Lossless_UDP_testserver.c
+++ b/testing/Lossless_UDP_testserver.c
@@ -28,6 +28,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "../toxcore/network.h"
 #include "../toxcore/Lossless_UDP.h"
 

--- a/testing/Makefile.inc
+++ b/testing/Makefile.inc
@@ -6,11 +6,14 @@ nTox_SOURCES =          ../testing/nTox.h \
                         ../testing/nTox.c
 
 nTox_CFLAGS =           $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS) \
                         $(NCURSES_CFLAGS)
 
 nTox_LDADD =            $(LIBSODIUM_LDFLAGS) \
+						$(NAC_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(NCURSES_LIBS) \
                         $(WINSOCK2_LIBS)
 endif
@@ -24,11 +27,14 @@ noinst_PROGRAMS +=      DHT_test \
 
 DHT_test_SOURCES =      ../testing/DHT_test.c
 
-DHT_test_CFLAGS =       $(LIBSODIUM_CFLAGS) 
+DHT_test_CFLAGS =       $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS)
 
 DHT_test_LDADD =        $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(WINSOCK2_LIBS)
 
 
@@ -36,12 +42,15 @@ Lossless_UDP_testclient_SOURCES = \
                         ../testing/Lossless_UDP_testclient.c
 
 Lossless_UDP_testclient_CFLAGS = \
-                        $(LIBSODIUM_CFLAGS)
+                        $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS)
 
 Lossless_UDP_testclient_LDADD = \
                         $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(WINSOCK2_LIBS)
 
 
@@ -49,23 +58,29 @@ Lossless_UDP_testserver_SOURCES = \
                         ../testing/Lossless_UDP_testserver.c
 
 Lossless_UDP_testserver_CFLAGS = \
-                        $(LIBSODIUM_CFLAGS)
+                        $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS)
 
 Lossless_UDP_testserver_LDADD = \
                         $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(WINSOCK2_LIBS)
 
 
 Messenger_test_SOURCES = \
                         ../testing/Messenger_test.c
 
-Messenger_test_CFLAGS = $(LIBSODIUM_CFLAGS)
+Messenger_test_CFLAGS = $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS)
 
 Messenger_test_LDADD =  $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(WINSOCK2_LIBS)
 
 
@@ -73,12 +88,15 @@ crypto_speed_test_SOURCES = \
                         ../testing/crypto_speed_test.c
 
 crypto_speed_test_CFLAGS = \
-                        $(LIBSODIUM_CFLAGS)
+                        $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS)
 
 crypto_speed_test_LDADD = \
                         $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         libtoxcore.la \
                         $(LIBSODIUM_LIBS) \
+                        $(NACL_LIBS) \
                         $(WINSOCK2_LIBS)
 
 EXTRA_DIST += 			$(top_srcdir)/testing/misc_tools.c

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -37,6 +37,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "../toxcore/Messenger.h"
 #include "misc_tools.c"
 

--- a/testing/crypto_speed_test.c
+++ b/testing/crypto_speed_test.c
@@ -1,3 +1,7 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // Hi-resolution timer
 #ifdef WIN32
 #ifndef WINVER

--- a/testing/misc_tools.c
+++ b/testing/misc_tools.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -23,6 +23,10 @@
 
 /*----------------------------------------------------------------------------------*/
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "DHT.h"
 #include "ping.h"
 #include "misc_tools.h"

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "LAN_discovery.h"
 
 #define MAX_INTERFACES 16

--- a/toxcore/Lossless_UDP.c
+++ b/toxcore/Lossless_UDP.c
@@ -26,6 +26,10 @@
  * There are a couple of useless variables to get rid of.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "Lossless_UDP.h"
 
 

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -29,10 +29,13 @@ libtoxcore_la_SOURCES = ../toxcore/DHT.h \
 
 libtoxcore_la_CFLAGS =  -I$(top_srcdir) \
                         -I$(top_srcdir)/toxcore \
-                        $(LIBSODIUM_CFLAGS)
+                        $(LIBSODIUM_CFLAGS) \
+                        $(NACL_CFLAGS)
 
 libtoxcore_la_LDFLAGS = $(EXTRA_LT_LDFLAGS) \
                         $(LIBSODIUM_LDFLAGS) \
+                        $(NACL_LDFLAGS) \
                         $(WINSOCK2_LIBS)
 
-libtoxcore_la_LIBS =    $(LIBSODIUM_LIBS)
+libtoxcore_la_LIBS =    $(LIBSODIUM_LIBS) \
+                        $(NAC_LIBS)

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "Messenger.h"
 
 #define MIN(a,b) (((a)<(b))?(a):(b))

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "friend_requests.h"
 
 /* Try to send a friend request to peer with public_key.

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -24,6 +24,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "net_crypto.h"
 
 #define CONN_NO_CONNECTION 0

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "network.h"
 
 /*  return current UNIX time in microseconds (us). */

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -39,8 +39,6 @@
 #include <windows.h>
 #include <ws2tcpip.h>
 
-#undef VANILLA_NACL /* Make sure on Windows we use libsodium. */
-
 #else // Linux includes
 
 #include <fcntl.h>

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -5,6 +5,10 @@
  * Copyright 2013  plutooo
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "Messenger.h"
 /*
  * returns a FRIEND_ADDRESS_SIZE byte address to give to others.

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -5,6 +5,10 @@
  * Copyright 2013  plutooo
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <time.h>
 #include <stdint.h>
 #include <stdbool.h>


### PR DESCRIPTION
By default libsodium is used. Only if --enable-nacl is specified, then
nacl will be used instead of libsodium.

Pass locations of nacl headers and libraries by using the following
options:

--with-nacl-headers=/home/me/somewhere/nacl-20110221/build/469/include/amd64/
--with-nacl-libs=/home/me/somewhere/nacl-20110221/build/469/lib/amd64/
