### PR TITLE
Allow loginit() to be delayed, store loglog() data in intermediate buffer...

### DIFF
--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -352,10 +352,6 @@ Networking_Core *new_networking(IP ip, uint16_t port)
     fcntl(temp->sock, F_SETFL, O_NONBLOCK, 1);
 #endif
 
-#ifdef LOGGING
-    loginit(ntohs(port));
-#endif
-
     /* Bind our socket to port PORT and the given IP address (usually 0.0.0.0 or ::) */
     uint16_t *portptr = NULL;
     struct sockaddr_storage addr;
@@ -461,6 +457,8 @@ Networking_Core *new_networking(IP ip, uint16_t port)
         if (!res) {
             temp->port = *portptr;
 #ifdef LOGGING
+            loginit(temp->port);
+
             sprintf(logbuffer, "Bound successfully to %s:%u.\n", ip_ntoa(&ip), ntohs(temp->port));
             loglog(logbuffer);
 #endif


### PR DESCRIPTION
... and flush it out when loginit() is called

util.c:
- handle loglog() before loginit() by storing the lines into an expanding buffer
- when loginit() is called, (try to) write out and then (always) kill the buffer

network.c:
- push loginit() to the point where we know the actually used port
