### PR TITLE
Thou shalt not take singular commands after an if into #ifdef DEBUG...

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1425,12 +1425,12 @@ static int Messenger_load_old(Messenger *m, uint8_t *data, uint32_t length)
     if (length < size)
         return -1;
 
-    if (DHT_load_old(m->dht, data, size) == -1)
+    if (DHT_load_old(m->dht, data, size) == -1) {
 #ifdef DEBUG
         fprintf(stderr, "Data file: Something wicked happened to the stored connections...\n");
-
+        /* DO go on, friends/name still might be intact */
 #endif
-    /* DO go on, friends/name still might be intact */
+    }
 
     data += size;
     length -= size;


### PR DESCRIPTION
toxcore/Messenger.c:
- Messenger_load_old(): brackets around an #ifdef'ed line to avoid data pointer being only pushed forward properly in the error case
