### PR TITLE
Change tox_get_friendlist API.

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1640,6 +1640,50 @@ int Messenger_load(Messenger *m, uint8_t *data, uint32_t length)
         return Messenger_load_old(m, data, length);
 }
 
+/* Return the number of friends in the instance m.
+ * You should use this to determine how much memory to allocate
+ * for copy_friendlist. */
+size_t count_friendlist(Messenger *m)
+{
+    size_t ret = 0;
+    uint32_t i;
+    for (i = 0; i < m->numfriends; i++) {
+        if (m->friendlist[i].status > 0) {
+            ret++;
+        }
+    }
+    return ret;
+}
+
+/* Copy a list of valid friend IDs into the array out_list.
+ * If out_list is NULL, returns -1.
+ * Otherwise, returns the number of elements copied.
+ * If the array was too small, the contents
+ * of out_list will be truncated to list_size. */
+size_t copy_friendlist(Messenger *m, int *out_list, size_t list_size)
+{
+    if (!out_list)
+        return -1;
+        
+    if (m->numfriends == 0) {
+        return 0;
+    }
+    
+    uint32_t i;
+    size_t ret = 0;
+    for (i = 0; i < m->numfriends; i++) {
+        if (i >= list_size) {
+            break; /* Abandon ship */
+        }
+        if (m->friendlist[i].status > 0) {
+            out_list[i] = i;
+            ret++;
+        }
+    }
+    
+    return ret;
+}
+
 /* Allocate and return a list of valid friend id's. List must be freed by the
  * caller.
  *

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -456,6 +456,18 @@ void Messenger_save(Messenger *m, uint8_t *data);
 /* Load the messenger from data of size length. */
 int Messenger_load(Messenger *m, uint8_t *data, uint32_t length);
 
+/* Return the number of friends in the instance m.
+ * You should use this to determine how much memory to allocate
+ * for copy_friendlist. */
+size_t count_friendlist(Messenger *m);
+
+/* Copy a list of valid friend IDs into the array out_list.
+ * If out_list is NULL, returns -1.
+ * Otherwise, returns the number of elements copied.
+ * If the array was too small, the contents
+ * of out_list will be truncated to list_size. */
+size_t copy_friendlist(Messenger *m, int *out_list, size_t list_size);
+
 /* Allocate and return a list of valid friend id's. List must be freed by the
  * caller.
  *

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -262,16 +262,24 @@ void tox_set_sends_receipts(void *tox, int friendnumber, int yesno)
     m_set_sends_receipts(m, friendnumber, yesno);
 }
 
-/* Allocate and return a list of valid friend id's. List must be freed by the
- * caller.
- *
- * retun 0 if success.
- * return -1 if failure.
- */
-int tox_get_friendlist(void *tox, int **out_list, uint32_t *out_list_length)
+/* Return the number of friends in the instance m.
+ * You should use this to determine how much memory to allocate
+ * for copy_friendlist. */
+size_t tox_count_friendlist(void *tox)
 {
     Messenger *m = tox;
-    return get_friendlist(m, out_list, out_list_length);
+    return count_friendlist(m);
+}
+
+/* Copy a list of valid friend IDs into the array out_list.
+ * If out_list is NULL, returns -1.
+ * Otherwise, returns the number of elements copied.
+ * If the array was too small, the contents
+ * of out_list will be truncated to list_size. */
+size_t tox_copy_friendlist(void *tox, int *out_list, size_t list_size)
+{
+    Messenger *m = tox;
+    return copy_friendlist(m, out_list, list_size);
 }
 
 /* Set the function that will be executed when a friend request is received.

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -280,13 +280,17 @@ TOX_USERSTATUS tox_get_selfuserstatus(Tox *tox);
  */
 void tox_set_sends_receipts(Tox *tox, int friendnumber, int yesno);
 
-/* Allocate and return a list of valid friend id's. List must be freed by the
- * caller.
- *
- * retun 0 if success.
- * return -1 if failure.
- */
-int tox_get_friendlist(void *tox, int **out_list, uint32_t *out_list_length);
+/* Return the number of friends in the instance m.
+ * You should use this to determine how much memory to allocate
+ * for copy_friendlist. */
+size_t tox_count_friendlist(void *tox);
+    
+/* Copy a list of valid friend IDs into the array out_list.
+ * If out_list is NULL, returns -1.
+ * Otherwise, returns the number of elements copied.
+ * If the array was too small, the contents
+ * of out_list will be truncated to list_size. */
+size_t tox_copy_friendlist(void *tox, int *out_list, size_t list_size);
 
 /* Set the function that will be executed when a friend request is received.
  *  Function format is function(uint8_t * public_key, uint8_t * data, uint16_t length)


### PR DESCRIPTION
tox_get_friendlist() -> tox_copy_friendlist().
You now have to allocate your own memory to pass into tox_copy_friendlist.
To help with this, tox_count_friendlist() has been added to get the length
of the friend list.
