### PR TITLE
Added message ids to action messages

### DIFF
--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -267,7 +267,7 @@ int m_friend_exists(Messenger *m, int friendnumber);
  *  return the message id if packet was successfully put into the send queue.
  *  return 0 if it was not.
  *
- *  You will want to retain the return value, it will be passed to your read receipt callback
+ *  You will want to retain the return value, it will be passed to your read_receipt callback
  *  if one is received.
  *  m_sendmessage_withid will send a message with the id of your choosing,
  *  however we can generate an id for you by calling plain m_sendmessage.
@@ -277,10 +277,16 @@ uint32_t m_sendmessage_withid(Messenger *m, int friendnumber, uint32_t theid, ui
 
 /* Send an action to an online friend.
  *
- *  return 1 if packet was successfully put into the send queue.
+ *  return the message id if packet was successfully put into the send queue.
  *  return 0 if it was not.
+ *
+ *  You will want to retain the return value, it will be passed to your read_receipt callback
+ *  if one is received.
+ *  m_sendaction_withid will send an action message with the id of your choosing,
+ *  however we can generate an id for you by calling plain m_sendaction.
  */
-int m_sendaction(Messenger *m, int friendnumber, uint8_t *action, uint32_t length);
+uint32_t m_sendaction(Messenger *m, int friendnumber, uint8_t *action, uint32_t length);
+uint32_t m_sendaction_withid(Messenger *m, int friendnumber, uint32_t theid, uint8_t *action, uint32_t length);
 
 /* Set the name and name_length of a friend.
  * name must be a string of maximum MAX_NAME_LENGTH length.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -132,7 +132,7 @@ int tox_friend_exists(Tox *tox, int friendnumber)
  *  return the message id if packet was successfully put into the send queue.
  *  return 0 if it was not.
  *
- *  You will want to retain the return value, it will be passed to your read receipt callback
+ *  You will want to retain the return value, it will be passed to your read_receipt callback
  *  if one is received.
  *  m_sendmessage_withid will send a message with the id of your choosing,
  *  however we can generate an id for you by calling plain m_sendmessage.
@@ -150,13 +150,25 @@ uint32_t tox_sendmessage_withid(Tox *tox, int friendnumber, uint32_t theid, uint
 }
 
 /* Send an action to an online friend.
- *  return 1 if packet was successfully put into the send queue.
+ *
+ *  return the message id if packet was successfully put into the send queue.
  *  return 0 if it was not.
+ *
+ *  You will want to retain the return value, it will be passed to your read_receipt callback
+ *  if one is received.
+ *  m_sendaction_withid will send an action message with the id of your choosing,
+ *  however we can generate an id for you by calling plain m_sendaction.
  */
-int tox_sendaction(Tox *tox, int friendnumber, uint8_t *action, uint32_t length)
+uint32_t tox_sendaction(Tox *tox, int friendnumber, uint8_t *action, uint32_t length)
 {
     Messenger *m = tox;
     return m_sendaction(m, friendnumber, action, length);
+}
+
+uint32_t tox_sendaction_withid(Tox *tox, int friendnumber, uint32_t theid, uint8_t *action, uint32_t length)
+{
+    Messenger *m = tox;
+    return m_sendaction_withid(m, friendnumber, theid, action, length);
 }
 
 /* Set friendnumber's nickname.

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -209,7 +209,7 @@ int tox_friend_exists(Tox *tox, int friendnumber);
  *  return the message id if packet was successfully put into the send queue.
  *  return 0 if it was not.
  *
- * You will want to retain the return value, it will be passed to your read receipt callback
+ * You will want to retain the return value, it will be passed to your read_receipt callback
  * if one is received.
  * m_sendmessage_withid will send a message with the id of your choosing,
  * however we can generate an id for you by calling plain m_sendmessage.
@@ -219,10 +219,16 @@ uint32_t tox_sendmessage_withid(Tox *tox, int friendnumber, uint32_t theid, uint
 
 /* Send an action to an online friend.
  *
- *  return 1 if packet was successfully put into the send queue.
+ *  return the message id if packet was successfully put into the send queue.
  *  return 0 if it was not.
+ *
+ *  You will want to retain the return value, it will be passed to your read_receipt callback
+ *  if one is received.
+ *  m_sendaction_withid will send an action message with the id of your choosing,
+ *  however we can generate an id for you by calling plain m_sendaction.
  */
-int tox_sendaction(Tox *tox, int friendnumber, uint8_t *action, uint32_t length);
+uint32_t tox_sendaction(Tox *tox, int friendnumber, uint8_t *action, uint32_t length);
+uint32_t tox_sendaction_withid(Tox *tox, int friendnumber, uint32_t theid, uint8_t *action, uint32_t length);
 
 /* Set friendnumber's nickname.
  * name must be a string of maximum MAX_NAME_LENGTH length.


### PR DESCRIPTION
Added message ids to action messages, apparently that made them exactly the same as regular messages. 

Maybe we could introduce `enum message_type {plain_message, action_message}`, add an extra byte to the message sending function to include that enum and use a single message sending and processing function, instead of having several identical copies? (with this pull request `m_sendmessage` == `m_sendaction`, `m_sendmessage_withid` == `m_sendaction_withid`, `case: PACKET_ID_MESSAGE` == `case: PACKET_ID_ACTION`) We can keep the tox API the same and use enums only internally, or propagate them into the API and merge `m_sendmessage*` and `m_sendaction*` into a single function with an `enum message_type` as a parameter.
