### PR TITLE
Group chat: load/save

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2048,9 +2048,12 @@ static int dht_load_state_callback(void *outer, uint8_t *data, uint32_t length, 
 
             break;
 
+#ifdef DEBUG
         default:
             fprintf(stderr, "Load state (DHT): contains unrecognized part (len %u, type %u)\n",
                     length, type);
+            break;
+#endif
     }
 
     return 0;

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -106,6 +106,13 @@ uint32_t group_newpeer(Group_Chat *chat, uint8_t *client_id);
  */
 Group_Chat *new_groupchat(Networking_Core *net);
 
+/* reinitialize a stored chat
+ *
+ * Returns a new group chat instance if success.
+ *
+ * Returns a NULL pointer if fail.
+ */
+Group_Chat *load_groupchat(Networking_Core *net, uint8_t *data, size_t length);
 
 /* Kill a group chat
  *
@@ -127,5 +134,4 @@ int handle_groupchatpacket(Group_Chat *chat, IP_Port source, uint8_t *packet, ui
 void chat_bootstrap(Group_Chat *chat, IP_Port ip_port, uint8_t *client_id);
 void chat_bootstrap_nonlazy(Group_Chat *chat, IP_Port ip_port, uint8_t *client_id);
 
-
-#endif
+#endif /* !GROUP_CHATS_H */

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -429,6 +429,7 @@ void tox_callback_group_message(Tox *tox, void (*function)(Messenger *tox, int, 
     Messenger *m = tox;
     m_callback_group_message(m, function, userdata);
 }
+
 /* Creates a new groupchat and puts it in the chats array.
  *
  * return group number on success.
@@ -439,6 +440,15 @@ int tox_add_groupchat(Tox *tox)
     Messenger *m = tox;
     return add_groupchat(m);
 }
+
+/* Returns current number of groupchats. Required after loading state from file.
+ */
+uint16_t tox_num_groupchats(Tox *tox)
+{
+    Messenger *m = tox;
+    return m->numchats;
+}
+
 /* Delete a groupchat from the chats array.
  *
  * return 0 on success.

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -399,6 +399,10 @@ void tox_callback_group_message(Tox *tox, void (*function)(Tox *tox, int, int, u
  */
 int tox_add_groupchat(Tox *tox);
 
+/* Returns current number of groupchats. Required after loading state from file.
+ */
+uint16_t tox_num_groupchats(Tox *tox);
+
 /* Delete a groupchat from the chats array.
  *
  * return 0 on success.


### PR DESCRIPTION
Messenger.c:
- size&store groupchats, load back with load_groupchat()
- fix in #LOGGING: correctly convert an ID to a string

group_chats.*:
- load_groupchat(): converts the stored bytes back into a chat structure
- handle_data::switch(packet type): don't fall-through from case 0 (ping) to case 16 (new peer) (yet peer case exits from fall-through at once)

tox.*:
- offer the number of group chats (ignores invalid chats, so only useful after loading)

DHT.c:
- enclose a fprintf(stderr, ...) in #DEBUG
