### PR TITLE
Started as a simple bugfix for wrap(), expanded to more detailed help.

### DIFF
--- a/testing/nTox.h
+++ b/testing/nTox.h
@@ -24,24 +24,19 @@
 #ifndef NTOX_H
 #define NTOX_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <curses.h>
+/*
+ * module actually exports nothing for the outside
+ */
+
 #include <ctype.h>
+#include <curses.h>
 
 #include "../toxcore/tox.h"
 
 #define STRING_LENGTH 256
 #define HISTORY 50
-#define PUB_KEY_BYTES 32
 
-uint32_t resolve_addr(const char *address);
 void new_lines(char *line);
-void line_eval(Tox *m, char *line);
-void wrap(char output[STRING_LENGTH], char input[STRING_LENGTH], int line_width) ;
-int count_lines(char *string) ;
-char *appender(char *str, const char c);
 void do_refresh();
 
 #endif


### PR DESCRIPTION
nTox.c:
- flag[]: additional flag for special wrapping
- help expanded and split (to keep below 256 chars)
- new_lines_mark(): stores flag for special wrapping
- print_friendlist():
  .  - extracted pattern for output
  .  - added length of id string allocation
  .  - replaced '\t' with '+ ', wrappers don't account for '\t'
- line_eval():
  .  - removed a few do_refresh() directly after a new_lines() (calls do_refresh() at its end)
  .  - 'h' (help): parsing of an additional character for f(riend) or g(roup)
- wrap():
  .  - the major bugfix:
  .    - no more endless looping if the input had a substring with no spaces
  .      for more than line_width (e.g. ID of 78 and window smaller than 78)
- wrap_bars(): wrap() for "rich" messages, honors embedded '\n', breaks preferable at '|'
- print_help(): listed all options and added explanations
- print_invite(): fixed minuscule typo
- main(): made print_help() reachable again

nTox.h:
- majorly cut down to what is really needed
