### PR TITLE
Group chat: Add a nickname message. Remove strange default nickname. (Seriously...)

### DIFF
--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -821,8 +821,16 @@ void print_groupmessage(Tox *m, int groupnumber, int peernumber, uint8_t *messag
 {
     char msg[256 + length];
     uint8_t name[TOX_MAX_NAME_LENGTH];
-    tox_group_peername(m, groupnumber, peernumber, name);
-    sprintf(msg, "[g] %u: <%s>: %s", groupnumber, name, message);
+    int len = tox_group_peername(m, groupnumber, peernumber, name);
+
+    if (len <= 0)
+        name[0] = 0;
+
+    if (name[0] != 0)
+        sprintf(msg, "[g] %u: %u <%s>: %s", groupnumber, peernumber, name, message);
+    else
+        sprintf(msg, "[g] %u: %u Unknown: %s", groupnumber, peernumber, message);
+
     new_lines(msg);
 }
 

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -63,12 +63,15 @@ typedef struct Group_Chat {
     uint32_t message_number;
     void (*group_message)(struct Group_Chat *m, int, uint8_t *, uint16_t, void *);
     void *group_message_userdata;
+
     uint64_t last_sent_ping;
 
+    uint64_t last_sent_nick;
 } Group_Chat;
 
 #define GROUP_CHAT_PING 0
 #define GROUP_CHAT_NEW_PEER 16
+#define GROUP_CHAT_PEER_NICK 17
 #define GROUP_CHAT_CHAT_MESSAGE 64
 
 /* Copy the name of peernum to name.
@@ -95,6 +98,12 @@ void callback_groupmessage(Group_Chat *chat, void (*function)(Group_Chat *chat, 
  */
 uint32_t group_sendmessage(Group_Chat *chat, uint8_t *message, uint32_t length);
 
+/*
+ * Send id/nick combo to the group.
+ *
+ * returns the number of peers it has sent it to.
+ */
+uint32_t group_send_nick(Group_Chat *chat, uint8_t *client_id, uint8_t *nick, uint16_t nick_len);
 
 /*
  * Tell everyone about a new peer (a person we are inviting for example.)


### PR DESCRIPTION
group_chats.*:
- group_send_nick() to send own name
- setnick() to store a received name

Messenger.c:
- group_send_nick() before group_sendmessage() (in regular intervals, to inform new peers)

nTox.c:
- print_groupmessage(): on error or on a name of length zero the result of tox_group_peername() isn't null-terminated, catch that
