### PR TITLE
Allow to specify a password that's then subsequently used to encode/decode the secret key.

### DIFF
--- a/auto_tests/messenger_test.c
+++ b/auto_tests/messenger_test.c
@@ -288,17 +288,14 @@ START_TEST(test_messenger_state_saveloadsave)
     }
 
     int res = messenger_load(m, buffer + extra, size);
+    ck_assert_msg(res == 0, "Failed to load back stored buffer: res == %i", res);
 
-    if (res == -1)
-        ck_assert_msg(res == 0, "Failed to load back stored buffer: res == -1");
-    else {
-        char msg[128];
-        size_t offset = res >> 4;
-        uint8_t *ptr = buffer + extra + offset;
-        sprintf(msg, "Failed to load back stored buffer: 0x%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx @%zu/%zu, code %d",
-                ptr[-2], ptr[-1], ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], offset, size, res & 0x0F);
-        ck_assert_msg(res == 0, msg);
-    }
+    char msg[128];
+    size_t offset = res >> 4;
+    uint8_t *ptr = buffer + extra + offset;
+    sprintf(msg, "Failed to load back stored buffer: 0x%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx @%zu/%zu, code %d",
+            ptr[-2], ptr[-1], ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], offset, size, res & 0x0F);
+    ck_assert_msg(res == 0, msg);
 
     size_t size2 = messenger_size(m);
     ck_assert_msg(size == size2, "Messenger \"grew\" in size from a store/load cycle: %u -> %u", size, size2);
@@ -350,7 +347,7 @@ int main(int argc, char *argv[])
     bad_id    = hex_string_to_bin(bad_id_str);
 
     /* IPv6 status from global define */
-    m = new_messenger(TOX_ENABLE_IPV6_DEFAULT);
+    m = new_messenger(TOX_ENABLE_IPV6_DEFAULT, NULL);
 
     /* setup a default friend and friendnum */
     if (m_addfriend_norequest(m, (uint8_t *)friend_id) < 0)

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
         exit(0);
     }
 
-    m = new_messenger(ipv6enabled);
+    m = new_messenger(ipv6enabled, NULL);
 
     if ( !m ) {
         fputs("Failed to allocate messenger datastructure\n", stderr);

--- a/testing/tox_sync.c
+++ b/testing/tox_sync.c
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
         exit(0);
     }
 
-    Tox *tox = tox_new(ipv6enabled);
+    Tox *tox = tox_new(ipv6enabled, NULL);
     tox_callback_file_data(tox, write_file, NULL);
     tox_callback_file_control(tox, file_print_control, NULL);
     tox_callback_file_sendrequest(tox, file_request_accept, NULL);

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -161,6 +161,10 @@ typedef struct Messenger {
     Net_Crypto *net_crypto;
     DHT *dht;
     Friend_Requests fr;
+
+    uint8_t pwdset;
+    uint8_t pwdhash[crypto_box_SECRETKEYBYTES];
+
     uint8_t name[MAX_NAME_LENGTH];
     uint16_t name_length;
 
@@ -585,7 +589,7 @@ int m_msi_packet(Messenger *m, int friendnumber, uint8_t *data, uint16_t length)
  *  return allocated instance of Messenger on success.
  *  return 0 if there are problems.
  */
-Messenger *new_messenger(uint8_t ipv6enabled);
+Messenger *new_messenger(uint8_t ipv6enabled, char *pwd);
 
 /* Run this before closing shop
  * Free all datastructures.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -607,9 +607,9 @@ int tox_isconnected(Tox *tox)
  *  return allocated instance of tox on success.
  *  return 0 if there are problems.
  */
-Tox *tox_new(uint8_t ipv6enabled)
+Tox *tox_new(uint8_t ipv6enabled, char *pwd)
 {
-    return new_messenger(ipv6enabled);
+    return new_messenger(ipv6enabled, pwd);
 }
 
 /* Run this before closing shop.

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -549,11 +549,12 @@ int tox_isconnected(Tox *tox);
  *    IPv4 communication
  *  If set to anything else, creates an IPv6 socket which allows both IPv4 AND
  *    IPv6 communication
+ *  pwd is an optional password, the secret key is xor-hashed if set
  *
  *  return allocated instance of tox on success.
  *  return 0 if there are problems.
  */
-Tox *tox_new(uint8_t ipv6enabled);
+Tox *tox_new(uint8_t ipv6enabled, char *pwd);
 
 /* Run this before closing shop.
  * Free all datastructures. */


### PR DESCRIPTION
An additional checksum over the hashed password is stored as well, and checked on loading, so a mistyped password doesn't result in a dysfunctional key pair.
The password is in nTox read from console. (WIN32 - console echo-off untested)
