### PR TITLE
Various changes to nTox including a potential crash (also possible from remote!)...

### DIFF
--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -310,9 +310,12 @@ typedef struct {
 
 int networking_wait_prepare(Networking_Core *net, uint32_t sendqueue_length, uint8_t *data, uint16_t *lenptr)
 {
-    if ((data == NULL) || (*lenptr < sizeof(select_info))) {
-        *lenptr = sizeof(select_info);
-        return 0;
+    if ((data == NULL) || !lenptr || (*lenptr < sizeof(select_info))) {
+        if (lenptr) {
+            *lenptr = sizeof(select_info);
+            return 0;
+        } else
+            return -1;
     }
 
     *lenptr = sizeof(select_info);

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -606,10 +606,11 @@ void tox_do(Tox *tox);
  * Prepares the data required to call tox_wait_execute() asynchronously
  *
  * data[] is reserved and kept by the caller
- * len is in/out: in = reserved data[], out = required data[]
+ * *lenptr is in/out: in = reserved data[], out = required data[]
  *
- *  returns 1 on success
- *  returns 0 on failure (length is insufficient)
+ *  returns  1 on success
+ *  returns  0 if *lenptr is insufficient
+ *  returns -1 if lenptr is NULL
  *
  *
  * tox_wait_execute(): function can be called asynchronously


### PR DESCRIPTION
... and a tiny change to toxcore.

Crash stuff:

nTox.c:
- do_refresh(): avoid crashes (input a "%s" and the client goes "boom!", send someone a string with embedded "%s" and see him blow up...)

Other stuff:

toxcore: tox.h (doc.)/network.c (code):
- networking_wait_prepare(): return -1 if lenptr was NULL and therefore not settable

nTox.c:
- fraddr_to_str(): function to convert a TOX_FRIEND_ADDRESS into a segmented (and therefore line-breakable) string
- print_friendlist(): print index of friend on name line, print id on 2nd line
- command /f: skip spaces (and +) inside a friend id
- command /r (new): "/r #" to remove a friend
- main(): reduce cpu consumption if we're not currently sending files
