### PR TITLE
fix 'typedef redefinition' build errors on older gcc versions

### DIFF
--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -133,24 +133,21 @@ typedef struct {
     uint64_t timestamp;
 } pinged_t;
 
-typedef struct PING PING;
-typedef struct Assoc Assoc;
-
 typedef struct {
     Net_Crypto  *c;
 
-    Client_data  close_clientlist[LCLIENT_LIST];
-    uint64_t     close_lastgetnodes;
+    Client_data    close_clientlist[LCLIENT_LIST];
+    uint64_t       close_lastgetnodes;
 
-    DHT_Friend  *friends_list;
-    uint16_t     num_friends;
+    DHT_Friend    *friends_list;
+    uint16_t       num_friends;
 
-    pinged_t     send_nodes[LSEND_NODES_ARRAY];
-    PING        *ping;
+    pinged_t       send_nodes[LSEND_NODES_ARRAY];
+    struct PING   *ping;
 
-    Assoc       *assoc;
+    struct Assoc  *assoc;
 
-    uint64_t    last_run;
+    uint64_t       last_run;
 } DHT;
 /*----------------------------------------------------------------------------------*/
 

--- a/toxcore/assoc.c
+++ b/toxcore/assoc.c
@@ -81,7 +81,8 @@ typedef struct Client_entry {
 typedef struct candidates_bucket {
     Client_entry          *list;                               /* hashed list */
 } candidates_bucket;
-typedef struct Assoc {
+
+struct Assoc {
     hash_t                 self_hash;                          /* hash of self_client_id */
     uint8_t                self_client_id[CLIENT_ID_SIZE];     /* don't store entries for this */
 
@@ -90,7 +91,7 @@ typedef struct Assoc {
     size_t                 candidates_bucket_count;
     size_t                 candidates_bucket_size;
     candidates_bucket     *candidates;
-} Assoc;
+};
 
 /*****************************************************************************/
 /*                             HELPER FUNCTIONS                              */

--- a/toxcore/assoc.h
+++ b/toxcore/assoc.h
@@ -12,7 +12,6 @@
  * for a potential future use
  */
 
-typedef struct IP_Port IP_Port;
 typedef struct Assoc Assoc;
 
 /*****************************************************************************/

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -27,8 +27,6 @@
 
 #include "net_crypto.h"
 
-typedef struct Assoc Assoc;
-
 #define MAX_NICK_BYTES 128
 
 typedef struct {
@@ -70,11 +68,11 @@ typedef struct Group_Chat {
 
     uint64_t last_sent_ping;
 
-    uint8_t     nick[MAX_NICK_BYTES];
-    uint16_t    nick_len;
-    uint64_t last_sent_nick;
+    uint8_t        nick[MAX_NICK_BYTES];
+    uint16_t       nick_len;
+    uint64_t       last_sent_nick;
 
-    Assoc *assoc;
+    struct Assoc  *assoc;
 } Group_Chat;
 
 #define GROUP_CHAT_PING 0

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -44,7 +44,7 @@
 /* Ping newly announced nodes to ping per TIME_TOPING seconds*/
 #define TIME_TOPING 5
 
-typedef struct PING {
+struct PING {
     Net_Crypto *c;
 
     pinged_t    pings[PING_NUM_MAX];
@@ -53,7 +53,7 @@ typedef struct PING {
 
     Node_format toping[MAX_TOPING];
     uint64_t    last_toping;
-} PING;
+};
 
 static int is_ping_timeout(uint64_t time)
 {


### PR DESCRIPTION
Several typedef definition included in current toxcore master prevent systems with older GCC version from building the project. FreeBSD 9 (latest stable) for example still uses GCC 4.2.1. and has no intentions of upgrading (http://www.freebsd.org/doc/en/articles/custom-gcc/article.html) due to licensing issues. 

The problem is caused by typedeffing structure types to themselves, i.e. "typedef struct foo foo" in multiple places. This behaviour no longer triggers an error in recent gcc versions, but causes builds to fail for gcc versions <4.6. The patch included removes the duplicate typedefs where necessary.
