### PR TITLE
fix naming inconsistency in tox.h

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -222,7 +222,7 @@ int tox_set_status_message(Tox *tox, uint8_t *status, uint16_t length)
     return m_set_statusmessage(m, status, length);
 }
 
-int tox_set_userstatus(Tox *tox, TOX_USERSTATUS status)
+int tox_set_user_status(Tox *tox, TOX_USERSTATUS status)
 {
     Messenger *m = tox;
     return m_set_userstatus(m, (USERSTATUS)status);

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -247,7 +247,7 @@ int tox_get_name(Tox *tox, int friendnumber, uint8_t *name);
  *  returns -1 on failure.
  */
 int tox_set_status_message(Tox *tox, uint8_t *status, uint16_t length);
-int tox_set_userstatus(Tox *tox, TOX_USERSTATUS status);
+int tox_set_user_status(Tox *tox, TOX_USERSTATUS status);
 
 /*  return the length of friendnumber's status message, including null.
  *  Pass it into malloc


### PR DESCRIPTION
The  tox_set_userstatus() function in tox.h does not match the naming convention of the other functions, such as its counterpart tox_get_user_status(). 
