### PR TITLE
Fix a code cleanup.

### DIFF
--- a/toxcore/assoc.c
+++ b/toxcore/assoc.c
@@ -698,6 +698,10 @@ uint8_t Assoc_get_close_entries(Assoc *assoc, Assoc_close_entries *state)
     ssize_t taken_last = - 1;
 
     for (i = 0; (i < dist_list_len) && (pos < state->count); i++) {
+        /* sorted increasingly, so an invalid entry marks the end */
+        if ((dist_list[i] & DISTANCE_INDEX_INDEX_MASK) == DISTANCE_INDEX_INDEX_MASK)
+            break;
+
         Client_entry *entry = dist_index_entry(assoc, dist_list[i]);
 
         if (entry && entry->hash) {
@@ -727,6 +731,10 @@ uint8_t Assoc_get_close_entries(Assoc *assoc, Assoc_close_entries *state)
      */
     if (pos < state->count) {
         for (i = taken_last + 1; (i < dist_list_len) && (pos < state->count); i++) {
+            /* sorted increasingly, so an invalid entry marks the end */
+            if ((dist_list[i] & DISTANCE_INDEX_INDEX_MASK) == DISTANCE_INDEX_INDEX_MASK)
+                break;
+
             Client_entry *entry = dist_index_entry(assoc, dist_list[i]);
 
             if (entry && entry->hash)


### PR DESCRIPTION
DHT.c:
- get_close_nodes():
  - allow two 'indirect' nodes ('indirect' as in distant from us and therefore not tested regularly, "bad")
  - be consequent when testing for NULLed results, pack nodes_list dense
  - (logging) dump number of found entries from assoc
- returnedip_ports():
  - fix code cleanup, the entry to be added is about the node we were told, not about the node who told us

assoc.c:
- Assoc_get_close_entries(): break from loops as soon as a marking-invalid-node is hit
