### PR TITLE
Always build DHT_bootstrap

### DIFF
--- a/other/Makefile.inc
+++ b/other/Makefile.inc
@@ -1,5 +1,3 @@
-if BUILD_DHT_BOOTSTRAP_DAEMON
-
 bin_PROGRAMS += DHT_bootstrap
 
 DHT_bootstrap_SOURCES = ../other/DHT_bootstrap.c \
@@ -16,8 +14,6 @@ DHT_bootstrap_LDADD =   $(LIBSODIUM_LDFLAGS) \
                         $(LIBSODIUM_LIBS) \
                         $(NACL_LIBS) \
                         $(WINSOCK2_LIBS)
-
-endif
 
 EXTRA_DIST +=           $(top_srcdir)/other/DHTservers \
                         $(top_srcdir)/other/tox.png


### PR DESCRIPTION
DHT_bootstrap is not the same as DHT_bootstrap_serverdaemon, the latter
depends on libconfig and can be enabled/disable via a configure
parameter.

DHT_bootstrap has no dependencies and can always be built.
