### PR TITLE
added solution to the 'Unable to locate package libopus-dev' problem

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,10 @@ On Ubuntu:
 ```bash
 sudo apt-get install build-essential libtool autotools-dev automake libconfig-dev ncurses-dev checkinstall check git libswscale-dev libsdl-dev libopenal-dev libopus-dev libvpx-dev yasm
 ```
+If you get the "Unable to locate package libopus-dev" message, add the following ppa
+```bash
+sudo add-apt-repository ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get dist-upgrade
+```
 
 On Fedora:
 


### PR DESCRIPTION
Hi,
Apparently the "libopus-dev" is not in the default repo, however it can be obtained from the "ubuntu-sdk-team" ppa. I have updated the "INSTALL.md" file to reflect this.
Thanks
