### PR TITLE
Fixed PID forgetfulness.

### DIFF
--- a/other/bootstrap_serverdaemon/tox_bootstrap_daemon.c
+++ b/other/bootstrap_serverdaemon/tox_bootstrap_daemon.c
@@ -398,20 +398,20 @@ int main(int argc, char *argv[])
     pid_t pid = fork();
 
     if (pid < 0) {
+        fclose(pidf);
         syslog(LOG_ERR, "Forking failed. Exiting.\n");
         return 1;
     }
 
     if (pid > 0) {
+        fprintf(pidf, "%d\n", pid);
+        fclose(pidf);
         syslog(LOG_DEBUG, "Forked successfully: PID: %d.\n", pid);
         return 0;
     }
 
     // Change the file mode mask
     umask(0);
-
-    fprintf(pidf, "%d\n", pid);
-    fclose(pidf);
 
     // Create a new SID for the child process
     if (setsid() < 0) {


### PR DESCRIPTION
Without this change the daemon would report its PID as 0 for me. Writing the PID file before the parent is exited fixes this behavior.
