### PR TITLE
Fix for Debian Wheezy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -370,7 +370,16 @@ fi
 
 if test "x$BUILD_AV" = "xyes"; then
     PKG_CHECK_MODULES([AVUTIL], [libavutil],
-        [],
+        [
+            # Debian Wheezy only has an early libavutil which doesn't have av_calloc
+            CFLAGS_SAVE="$CFLAGS"
+            LDLAGS_SAVE="$LDLAGS"
+            CFLAGS="$AVUTIL_CFLAGS"
+            LDFLAGS="$AVUTIL_LIBS"
+            AC_CHECK_FUNCS(av_calloc, AC_DEFINE([HAVE_AV_CALLOC],[],[av_calloc is present in -lavutil]))
+            CFLAGS="$CFLAGS_SAVE"
+            LDLAGS="$LDLAGS_SAVE"
+        ],
         [
             AC_MSG_WARN([disabling AV support $AVUTIL_PKG_ERRORS])
             BUILD_AV="no"

--- a/toxmsi/toxmedia.c
+++ b/toxmsi/toxmedia.c
@@ -48,6 +48,15 @@
 #include "phone.h"
 #include "toxmedia.h"
 
+#ifndef HAVE_AV_CALLOC
+void *av_calloc(size_t nmemb, size_t size)
+{
+    if (size <= 0 || nmemb >= INT_MAX / size)
+            return NULL;
+    return av_mallocz(nmemb * size);
+}
+#endif
+
 SDL_Surface *screen;
 
 int display_received_frame(codec_state *cs, AVFrame *r_video_frame)

--- a/toxmsi/toxmedia.h
+++ b/toxmsi/toxmedia.h
@@ -75,6 +75,11 @@
 #define DEFAULT_WEBCAM "0"
 #endif
 
+/* Fix for the earlier libavutil libs */
+#ifndef HAVE_AV_CALLOC
+void *av_calloc(size_t nmemb, size_t size) av_malloc_attrib;
+#endif
+
 extern SDL_Surface *screen;
 
 typedef struct {


### PR DESCRIPTION
Earlier versions of libavutil didn't have the av_calloc function, making a fallback one
