### PR TITLE
Adding "user is typing" functionality to toxcore.

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -743,7 +743,7 @@ void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, int, USE
     m->friend_userstatuschange_userdata = userdata;
 }
 
-void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, int, uint8_t, void *), void *userdata)
+void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, int, int, void *), void *userdata)
 {
     m->friend_typingchange = function;
     m->friend_typingchange_userdata = userdata;

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -208,7 +208,7 @@ typedef struct Messenger {
     void *friend_statusmessagechange_userdata;
     void (*friend_userstatuschange)(struct Messenger *m, int, USERSTATUS, void *);
     void *friend_userstatuschange_userdata;
-    void (*friend_typingchange)(struct Messenger *m, int, uint8_t, void *);
+    void (*friend_typingchange)(struct Messenger *m, int, int, void *);
     void *friend_typingchange_userdata;
     void (*read_receipt)(struct Messenger *m, int, uint32_t, void *);
     void *read_receipt_userdata;
@@ -461,9 +461,9 @@ void m_callback_statusmessage(Messenger *m, void (*function)(Messenger *m, int, 
 void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, int, USERSTATUS, void *), void *userdata);
 
 /* Set the callback for typing changes.
- *  Function(int friendnumber, uint8_t is_typing)
+ *  Function(int friendnumber, int is_typing)
  */
-void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, int, uint8_t, void *), void *userdata);
+void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, int, int, void *), void *userdata);
 
 /* Set the callback for read receipts.
  *  Function(int friendnumber, uint32_t receipt)

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -394,12 +394,12 @@ void tox_callback_user_status(Tox *tox, void (*_function)(Tox *tox, int, TOX_USE
 }
 
 /* Set the callback for typing changes.
- *  function (int friendnumber, uint8_t is_typing)
+ *  function (int friendnumber, int is_typing)
  */
-void tox_callback_typing_change(Tox *tox, void (*function)(Tox *tox, int, uint8_t, void *), void *userdata)
+void tox_callback_typing_change(Tox *tox, void (*function)(Tox *tox, int, int, void *), void *userdata)
 {
     Messenger *m = tox;
-    typedef void (*function_type)(Messenger *, int, uint8_t, void *);
+    typedef void (*function_type)(Messenger *, int, int, void *);
     function_type function_new = (function_type)function;
     m_callback_typingchange(m, function_new, userdata);
 }

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -352,9 +352,9 @@ void tox_callback_status_message(Tox *tox, void (*function)(Tox *tox, int, uint8
 void tox_callback_user_status(Tox *tox, void (*function)(Tox *tox, int, TOX_USERSTATUS, void *), void *userdata);
     
 /* Set the callback for typing changes.
- *  function (int friendnumber, uint8_t is_typing)
+ *  function (int friendnumber, int is_typing)
  */
-void tox_callback_typing_change(Tox *tox, void (*function)(Tox *tox, int, uint8_t, void *), void *userdata);
+void tox_callback_typing_change(Tox *tox, void (*function)(Tox *tox, int, int, void *), void *userdata);
 
 /* Set the callback for read receipts.
  *  function(int friendnumber, uint32_t receipt)


### PR DESCRIPTION
Two API functions:

```
/* Set our typing status for a friend.
 * You are responsible for turning it on or off.
 *
 * returns 0 on success.
 * returns -1 on failure.
 */
int tox_set_user_is_typing(Tox *tox, int friendnumber, uint8_t is_typing);
/* Get the typing status of a friend.
 *
 * returns 0 if friend is not typing.
 * returns 1 if friend is typing.
 */
int tox_get_is_typing(Tox *tox, int friendnumber);
```

Also added a new packet ID to messenger for the typing. Everything was done very similarly to the USERSTATUS type messages, as it's just passing a single uint8_t. So it mimics it in the various parts in Messenger as well as the api. If there are better ways to name the variables or functions, please say so. If I missed anything (as in necessary functions, anything with the callbacks, anything in init'ing or memory freeing, etc) please say so.
