### PR TITLE
Groupchat crashing bug fixed.

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -787,7 +787,10 @@ static void del_dead_peers(Group_Chat *chat)
             delpeer(chat, i);
         }
 
-        if (chat->group != NULL && chat->group[i].deleted) {
+        if (chat->group == NULL || i >= chat->numpeers)
+            break;
+
+        if (chat->group[i].deleted) {
             if (is_timeout(chat->group[i].deleted_time, DEL_PEER_DELAY))
                 delpeer(chat, i);
         }


### PR DESCRIPTION
`delpeer()` will delete the `chat->group` pointer if it sees the array is empty. Since another call to `chat->group` comes directly after, and `chat->group` was freed, then it would crash. Now it just makes a check before doing so.

This resolves https://github.com/Tox/toxic/issues/75 with the issue of crashing after computer sleeps, all peers timeout, so all get deleted in the first `delpeer()`
