### PR TITLE
Added size functions for names and status messages

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -533,6 +533,19 @@ int getname(Messenger *m, int32_t friendnumber, uint8_t *name)
     return m->friendlist[friendnumber].name_length;
 }
 
+int m_get_name_size(Messenger *m, int32_t friendnumber)
+{
+    if (friend_not_valid(m, friendnumber))
+        return -1;
+
+    return m->friendlist[friendnumber].name_length;
+}
+
+int m_get_self_name_size(Messenger *m)
+{
+    return m->name_length;
+}
+
 int m_set_statusmessage(Messenger *m, uint8_t *status, uint16_t length)
 {
     if (length > MAX_STATUSMESSAGE_LENGTH)
@@ -586,6 +599,14 @@ int m_copy_statusmessage(Messenger *m, int32_t friendnumber, uint8_t *buf, uint3
     memset(buf, 0, maxlen);
     memcpy(buf, m->friendlist[friendnumber].statusmessage, MIN(maxlen, m->friendlist[friendnumber].statusmessage_length));
     return MIN(maxlen, m->friendlist[friendnumber].statusmessage_length);
+}
+
+/* return the size of friendnumber's user status.
+ * Guaranteed to be at most MAX_STATUSMESSAGE_LENGTH.
+ */
+int m_get_self_statusmessage_size(Messenger *m)
+{
+    return m->statusmessage_length;
 }
 
 int m_copy_self_statusmessage(Messenger *m, uint8_t *buf, uint32_t maxlen)

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -370,6 +370,12 @@ uint16_t getself_name(Messenger *m, uint8_t *name);
  */
 int getname(Messenger *m, int32_t friendnumber, uint8_t *name);
 
+/*  return the length of name, including null on success.
+ *  return -1 on failure.
+ */
+int m_get_name_size(Messenger *m, int32_t friendnumber);
+int m_get_self_name_size(Messenger *m);
+
 /* returns valid ip port of connected friend on success
  * returns zeroed out IP_Port on failure
  */
@@ -384,10 +390,11 @@ IP_Port get_friend_ipport(Messenger *m, int32_t friendnumber);
 int m_set_statusmessage(Messenger *m, uint8_t *status, uint16_t length);
 int m_set_userstatus(Messenger *m, USERSTATUS status);
 
-/*  return the length of friendnumber's status message, including null.
- *  Pass it into malloc.
+/*  return the length of friendnumber's status message, including null on success.
+ *  return -1 on failure.
  */
 int m_get_statusmessage_size(Messenger *m, int32_t friendnumber);
+int m_get_self_statusmessage_size(Messenger *m);
 
 /* Copy friendnumber's status message into buf, truncating if size is over maxlen.
  * Get the size you need to allocate from m_get_statusmessage_size.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -210,6 +210,21 @@ int tox_get_name(Tox *tox, int32_t friendnumber, uint8_t *name)
     return getname(m, friendnumber, name);
 }
 
+/*  returns the length of name on success.
+ *  returns -1 on failure.
+ */
+int tox_get_name_size(Tox *tox, int32_t friendnumber)
+{
+    Messenger *m = tox;
+    return m_get_name_size(m, friendnumber);
+}
+
+int tox_get_self_name_size(Tox *tox)
+{
+    Messenger *m = tox;
+    return m_get_self_name_size(m);
+}
+
 /* Set our user status;
  * you are responsible for freeing status after.
  *
@@ -227,13 +242,19 @@ int tox_set_user_status(Tox *tox, TOX_USERSTATUS status)
     return m_set_userstatus(m, status);
 }
 
-/*  return the length of friendnumber's status message, including null.
- *  Pass it into malloc.
+/*  returns the length of status message on success.
+ *  returns -1 on failure.
  */
 int tox_get_status_message_size(Tox *tox, int32_t friendnumber)
 {
     Messenger *m = tox;
     return m_get_statusmessage_size(m, friendnumber);
+}
+
+int tox_get_self_status_message_size(Tox *tox)
+{
+    Messenger *m = tox;
+    return m_get_self_statusmessage_size(m, friendnumber);
 }
 
 /* Copy friendnumber's status message into buf, truncating if size is over maxlen.

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -223,6 +223,12 @@ uint16_t tox_get_self_name(Tox *tox, uint8_t *name);
  */
 int tox_get_name(Tox *tox, int32_t friendnumber, uint8_t *name);
 
+/*  returns the length of name on success.
+ *  returns -1 on failure.
+ */
+int tox_get_name_size(Tox *tox, int32_t friendnumber);
+int tox_get_self_name_size(Tox *tox);
+
 /* Set our user status.
  * You are responsible for freeing status after.
  *
@@ -234,10 +240,11 @@ int tox_get_name(Tox *tox, int32_t friendnumber, uint8_t *name);
 int tox_set_status_message(Tox *tox, uint8_t *status, uint16_t length);
 int tox_set_user_status(Tox *tox, TOX_USERSTATUS userstatus);
 
-/*  return the length of friendnumber's status message.
- *  Pass it into malloc
+/*  returns the length of status message on success.
+ *  returns -1 on failure.
  */
 int tox_get_status_message_size(Tox *tox, int32_t friendnumber);
+int tox_get_self_status_message_size(Tox *tox);
 
 /* Copy friendnumber's status message into buf, truncating if size is over maxlen.
  * Get the size you need to allocate from m_get_statusmessage_size.


### PR DESCRIPTION
There are

``` C
int tox_get_status_message(Tox *tox, int32_t friendnumber, uint8_t *buf, uint32_t maxlen);
int tox_get_self_status_message(Tox *tox, uint8_t *buf, uint32_t maxlen);
```

but only one of them has a corresponding `*_size` function

``` C
int tox_get_status_message_size(Tox *tox, int32_t friendnumber);
```

which makes people wonder how should they get a size of the `self_status_message`, pass `-1` for `friendnumber`? The answer is that there is no function that would get you `self_status_message_size`.

Also,

``` C
uint16_t tox_get_self_name(Tox *tox, uint8_t *name);
int tox_get_name(Tox *tox, int32_t friendnumber, uint8_t *name);
```

don't have any corresponding `*_size` function, instead it's asked to use a big enough buffer, of `MAX_NAME_LENGTH` length.

Something must be done with such API inconsistency.
Since we have exact lengths of name and status message stored, we can easily provide `*_size` functions, it's just a matter of returning already existing variable. If users wish to continue initialize buffers with `MAX_NAME_LENGTH` and alike, they can continue doing that -- nothing would break.
## 

@irungentoo we return `uint16_t` lengths as an `int`. `int`'s minimum guaranteed max size is 2^15 - 1 = 32767, while `uint16_t`'s, obviously, is 2^16 - 1 = 65535. It's not that name and status message use such big values or we are running Tox on micro-controllers, but that's still worth of mentioning.
## 

Also, wait on Travis.
