### PR TITLE
Fixed the size function for self status message

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -254,7 +254,7 @@ int tox_get_status_message_size(Tox *tox, int32_t friendnumber)
 int tox_get_self_status_message_size(Tox *tox)
 {
     Messenger *m = tox;
-    return m_get_self_statusmessage_size(m, friendnumber);
+    return m_get_self_statusmessage_size(m);
 }
 
 /* Copy friendnumber's status message into buf, truncating if size is over maxlen.


### PR DESCRIPTION
Fixed previous PR https://github.com/irungentoo/ProjectTox-Core/pull/757.

There is still an issue with `USERSTATUS` enum from your first commit to `api-fix` branch. Not sure what you meant to do there, so I left it to you.
