### PR TITLE
Main buildscripts for android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ nbproject
 
 # astyle
 *.orig
+
+# Android buildscript
+android-toolchain-*
+toxcore-android-*

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,11 @@ CLEANFILES = $(top_builddir)/libtoxcore.pc
 
 EXTRA_DIST = \
 	libtoxcore.pc.in \
+	dist-build/android-arm.sh \
+	dist-build/android-armv7.sh \
+	dist-build/android-x86.sh \
+	dist-build/android-mips.sh \
+	dist-build/android-build.sh \
 	$(top_srcdir)/docs/updates/Crypto.md \
 	$(top_srcdir)/docs/updates/Spam-Prevention.md \
 	$(top_srcdir)/docs/updates/Symmetric-NAT-Transversal.md \

--- a/dist-build/android-arm.sh
+++ b/dist-build/android-arm.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export CFLAGS="-Ofast -mthumb -marm -march=armv6"
+TARGET_ARCH=arm TOOLCHAIN_NAME=arm-linux-androideabi-4.8 HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-armv7.sh
+++ b/dist-build/android-armv7.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export CFLAGS="-Ofast -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -marm -march=armv7-a"
+TARGET_ARCH=armv7 TOOLCHAIN_NAME=arm-linux-androideabi-4.8 HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+if [ -z "$ANDROID_NDK_HOME" ]; then
+    echo "You should probably set ANDROID_NDK_HOME to the directory containing"
+    echo "the Android NDK"
+    exit
+fi
+
+if [ -z "$SODIUM_HOME" ]; then
+    echo "You should probably set SODIUM_HOME to the directory containing root sodium sources"
+    exit
+fi
+
+if [[ -z $TARGET_ARCH ]] || [[ -z $HOST_COMPILER ]]; then
+    echo "You shouldn't use android-build.sh directly, use android-[arch].sh instead"
+    exit 1
+fi
+
+if [ ! -f ./configure ]; then
+	echo "Can't find ./configure. Wrong directory or haven't run autogen.sh?"
+	exit 1
+fi
+
+if [ -z "$TOOLCHAIN_DIR" ]; then
+  export TOOLCHAIN_DIR="$(pwd)/android-toolchain-${TARGET_ARCH}"
+  export MAKE_TOOLCHAIN="${ANDROID_NDK_HOME}/build/tools/make-standalone-toolchain.sh"
+  
+  if [ -z "$MAKE_TOOLCHAIN" ]; then
+    echo "Cannot find a make-standalone-toolchain.sh in ndk dir, interrupt..."
+    exit 1
+  fi
+  
+  $MAKE_TOOLCHAIN --platform="${NDK_PLATFORM:-android-14}" \
+                  --arch="${TARGET_ARCH}" \
+                  --toolchain="${TOOLCHAIN_NAME:-arm-linux-androideabi-4.8}" \
+                  --install-dir="${TOOLCHAIN_DIR}"
+fi
+
+export PREFIX="$(pwd)/toxcore-android-${TARGET_ARCH}"
+export SYSROOT="${TOOLCHAIN_DIR}/sysroot"
+export PATH="${PATH}:${TOOLCHAIN_DIR}/bin"
+
+# Clean up before build
+rm -rf "${PREFIX}"
+
+export CFLAGS="${CFLAGS} --sysroot=${SYSROOT} -I${SYSROOT}/usr/include"
+export CPPFLAGS="${CFLAGS}"
+export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib"
+
+./configure --host="${HOST_COMPILER}" \
+            --with-sysroot="${SYSROOT}" \
+            --with-libsodium-headers="${SODIUM_HOME}/libsodium-android-${TARGET_ARCH}/include" \
+            --with-libsodium-libs="${SODIUM_HOME}/libsodium-android-${TARGET_ARCH}/lib" \
+            --disable-soname-versions \
+            --disable-av \
+            --disable-ntox \
+            --disable-daemon \
+            --disable-phone \
+            --prefix="${PREFIX}" && \
+
+make clean && \
+make -j3 install && \
+echo "libtoxcore has been installed into ${PREFIX}"

--- a/dist-build/android-mips.sh
+++ b/dist-build/android-mips.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export CFLAGS="-Ofast"
+TARGET_ARCH=mips TOOLCHAIN_NAME=mipsel-linux-android-4.8 HOST_COMPILER=mipsel-linux-android "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-x86.sh
+++ b/dist-build/android-x86.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export CFLAGS="-Ofast"
+TARGET_ARCH=x86 TOOLCHAIN_NAME=x86-4.8 HOST_COMPILER=i686-linux-android "$(dirname "$0")/android-build.sh"


### PR DESCRIPTION
Include 4 architectures: armv6, armv7, x86, mips.
libsodium should be compiled by their own buildscripts (with the same names) before run.
Example:
`SODIUM_HOME=/home/user/libsodium dist-build/android-arm.sh` will make a armv6 binaries for android.
