### PR TITLE
Allow to optionally use randombytes_stir() instead of sodium_init()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,20 @@ AC_ARG_ENABLE([nacl],
     ]
 )
 
+AC_ARG_ENABLE([randombytes-stir],
+    [AC_HELP_STRING([--enable-randombytes-stir], [use randombytes_stir() instead of sodium_init() for faster startup on android (default: disabled)]) ],
+    [
+        if test "x$enableval" = "xyes"; then
+            if test "x$WANT_NACL" = "xyes"; then
+                AC_MSG_WARN([randombytes_stir() is not available with NaCl library])
+            else
+                AC_DEFINE([USE_RANDOMBYTES_STIR], [1], [randombytes_stir() instead of sodium_init()])
+            fi
+        fi
+    ]
+)
+
+
 PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE([phone],

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -415,8 +415,14 @@ static int at_startup(void)
         return 0;
 
 #ifndef VANILLA_NACL
+
+#ifdef USE_RANDOMBYTES_STIR
+    randombytes_stir();
+#else
     sodium_init();
-#endif
+#endif /*USE_RANDOMBYTES_STIR*/
+
+#endif/*VANILLA_NACL*/
 
 #if defined(_WIN32) || defined(__WIN32__) || defined (WIN32)
     WSADATA wsaData;


### PR DESCRIPTION
According to sonOfRa sodium_init() has some timing issues on Android.
libsodium people said randombytes_stir() can be used instead:
https://github.com/jedisct1/libsodium/issues/121

sodium_init() stays the default, randombytes_stir() can be enabled by
passing --enable-randombytes-stir to the configure script.
