### PR TITLE
All OSX commands now copying friendly

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -131,7 +131,7 @@ brew list libsodium
 
 Configure include and lib folder and build again:
 ```bash
-./configure--with-libsodium-headers=/usr/local/Cellar/libsodium/0.4.5/include/ --with-libsodium-libs=/usr/local/Cellar/libsodium/0.4.5/lib/
+./configure --with-libsodium-headers=/usr/local/Cellar/libsodium/0.4.5/include/ --with-libsodium-libs=/usr/local/Cellar/libsodium/0.4.5/lib/
 make
 make install
 ```


### PR DESCRIPTION
Saves confusion to those not entirely sure why "./configure--with-libsodium-headers=/usr/local/Cellar/libsodium/0.4.5/include/ --with-libsodium-libs=/usr/local/Cellar/libsodium/0.4.5/lib/" did not work.
