### PR TITLE
Issue 771 - https://github.com/irungentoo/ProjectTox-Core/issues/771

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1703,7 +1703,7 @@ Messenger *new_messenger(uint8_t ipv6enabled)
 
     /* Issue #771 - https://github.com/irungentoo/ProjectTox-Core/issues/771 */
     int tries = 0;
-    while( ip == NULL )
+    while( m->net == NULL )
     {
         ip_init(&ip, ipv6enabled);
         m->net = new_networking(ip, TOX_PORT_DEFAULT);

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1818,6 +1818,13 @@ void do_friends(Messenger *m)
     uint64_t temp_time = unix_time();
 
     for (i = 0; i < m->numfriends; ++i) {
+        if (m->friendlist[i].status == FRIEND_IGNORE) {
+            if(m->friendlist[i].crypt_connection_id != -1) {
+                crypto_kill(m->net_crypto, m->friendlist[i].crypt_connection_id);
+                m->friendlist[i].crypt_connection_id = -1;
+            }
+            break;
+        }
         if (m->friendlist[i].status == FRIEND_ADDED) {
             int fr = send_friendrequest(m->onion_c, m->friendlist[i].client_id, m->friendlist[i].friendrequest_nospam,
                                         m->friendlist[i].info,

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -64,6 +64,7 @@ enum {
     FRIEND_REQUESTED,
     FRIEND_CONFIRMED,
     FRIEND_ONLINE,
+    FRIEND_IGNORE,
 };
 
 /* Errors for m_addfriend

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -1,4 +1,4 @@
-/* network.h
+/* network.c
  *
  * Functions for the core networking.
  *


### PR DESCRIPTION
Addresses #771, wherein it is noted that the core doesn't attempt reconnect, which can cause problems with auto-start. To fix this, I implemented a 30-second wait time, with a maximum of 3 attempts.

Provides a means to ignore users and seem offline to them, as requested in #734.