### PR TITLE
Fix libtoxav linking issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   #installing vpx
   - git clone http://git.chromium.org/webm/libvpx.git > /dev/null
   - cd libvpx
-  - ./configure > /dev/null
+  - ./configure --enable-shared > /dev/null
   - make -j3 >/dev/null
   - sudo make install > /dev/null
   - cd ..

--- a/configure.ac
+++ b/configure.ac
@@ -487,9 +487,9 @@ fi
 if test "x$BUILD_AV" = "xyes"; then
     # toxcore lib needs an global?
     # So far this works okay
-    AV_LIBS="$OPUS_LIBS $VPX_LIBS -ltoxcore"
+    AV_LIBS="$OPUS_LIBS $VPX_LIBS"
     AC_SUBST(AV_LIBS)
-    
+
     AV_CFLAGS="$OPUS_CFLAGS $VPX_CFLAGS"
     AC_SUBST(AV_CFLAGS)
 fi

--- a/toxav/Makefile.inc
+++ b/toxav/Makefile.inc
@@ -25,25 +25,26 @@ libtoxav_la_CFLAGS = -I../toxcore \
 libtoxav_la_LDFLAGS = $(TOXAV_LT_LDFLAGS) \
                       $(NACL_LDFLAGS) \
                       $(EXTRA_LT_LDFLAGS)
-                      
-libtoxav_la_LIBS =    $(NACL_LIBS) \
+
+libtoxav_la_LIBADD =  libtoxcore.la \
+                      $(NACL_LIBS) \
                       $(PTHREAD_LIBS) \
                       $(AV_LIBS)
 
-                        
+
 endif
-                        
-                        
-                        
-                        
-                        
-                        
+
+
+
+
+
+
 if BUILD_PHONE
 
-                          
+
 noinst_PROGRAMS += phone
 
-phone_SOURCES = ../toxav/phone.c 
+phone_SOURCES = ../toxav/phone.c
 
 phone_CFLAGS = -I../toxcore \
                -I../toxav \
@@ -68,6 +69,6 @@ phone_LDADD =   libtoxav.la \
                 $(VPX_LIBS)\
                 $(PTHREAD_LIBS)\
                 $(NACL_LIBS)
-                
-                
+
+
 endif


### PR DESCRIPTION
Removed some whitespaces and fix linking issue.

Original:

``` shell
% ldd libtoxav.so.0.0.0
        linux-vdso.so.1 (0x00007fff351fe000)
        libsodium.so.4 => /usr/lib/libsodium.so.4 (0x00007fc0e4743000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007fc0e4442000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007fc0e4225000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007fc0e3e7c000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007fc0e4bdd000)
```

But instead it should have been

``` shell
% ldd libtoxav.so.0.0.0
        linux-vdso.so.1 (0x00007fff05bfe000)
        libopus.so.0 => /usr/lib/libopus.so.0 (0x00007f8bc2c74000)
        libvpx.so.1 => /usr/lib/libvpx.so.1 (0x00007f8bc2890000)
        libtoxcore.so.0 => /home/aitjcize/Work/tox/dist/lib/libtoxcore.so.0 (0x00007f8bc266c000)
        libsodium.so.4 => /usr/lib/libsodium.so.4 (0x00007f8bc2416000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f8bc2115000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f8bc1ef8000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f8bc1b4f000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f8bc3106000)
```

toxav/Makefile.inc

the libtoxav_la_LIBS should be libtoxav_la_LIBADD
