### PR TITLE
Some tox_wait_* improvements

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2342,19 +2342,24 @@ void do_messenger(Messenger *m)
 /*
  * functions to avoid excessive polling
  */
-int wait_prepare_messenger(Messenger *m, uint8_t *data, uint16_t *lenptr)
+size_t wait_data_size()
 {
-    return networking_wait_prepare(m->net, sendqueue_total(m->net_crypto->lossless_udp), data, lenptr);
+    return networking_wait_data_size();
 }
 
-int wait_execute_messenger(Messenger *m, uint8_t *data, uint16_t len, uint16_t milliseconds)
+int wait_prepare_messenger(Messenger *m, uint8_t *data)
 {
-    return networking_wait_execute(data, len, milliseconds);
-};
+    return networking_wait_prepare(m->net, sendqueue_total(m->net_crypto->lossless_udp), data);
+}
 
-void wait_cleanup_messenger(Messenger *m, uint8_t *data, uint16_t len)
+int wait_execute_messenger(uint8_t *data, long seconds, long microseconds)
 {
-    networking_wait_cleanup(m->net, data, len);
+    return networking_wait_execute(data, seconds, microseconds);
+}
+
+int wait_cleanup_messenger(Messenger *m, uint8_t *data)
+{
+    return networking_wait_cleanup(m->net, data);
 }
 
 /* new messenger format for load/save, more robust and forward compatible */

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -715,9 +715,10 @@ void do_messenger(Messenger *m);
 /*
  * functions to avoid excessive polling
  */
-int wait_prepare_messenger(Messenger *m, uint8_t *data, uint16_t *lenptr);
-int wait_execute_messenger(Messenger *m, uint8_t *data, uint16_t len, uint16_t milliseconds);
-void wait_cleanup_messenger(Messenger *m, uint8_t *data, uint16_t len);
+size_t wait_data_size();
+int wait_prepare_messenger(Messenger *m, uint8_t *data);
+int wait_execute_messenger(uint8_t *data, long seconds, long microseconds);
+int wait_cleanup_messenger(Messenger *m, uint8_t *data);
 
 /* SAVING AND LOADING FUNCTIONS: */
 

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -312,9 +312,10 @@ void networking_poll(Networking_Core *net);
 /*
  * functions to avoid excessive polling
  */
-int networking_wait_prepare(Networking_Core *net, uint32_t sendqueue_length, uint8_t *data, uint16_t *lenptr);
-int networking_wait_execute(uint8_t *data, uint16_t len, uint16_t milliseconds);
-void networking_wait_cleanup(Networking_Core *net, uint8_t *data, uint16_t len);
+size_t networking_wait_data_size();
+int networking_wait_prepare(Networking_Core *net, uint32_t sendqueue_length, uint8_t *data);
+int networking_wait_execute(uint8_t *data, long seconds, long microseconds);
+int networking_wait_cleanup(Networking_Core *net, uint8_t *data);
 
 /* Initialize networking.
  * bind to ip and port.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -767,22 +767,27 @@ void tox_do(Tox *tox)
 /*
  * functions to avoid excessive polling
  */
-int tox_wait_prepare(Tox *tox, uint8_t *data, uint16_t *lenptr)
+
+size_t tox_wait_data_size()
 {
-    Messenger *m = tox;
-    return wait_prepare_messenger(m, data, lenptr);
+    return wait_data_size();
 }
 
-int tox_wait_execute(Tox *tox, uint8_t *data, uint16_t len, uint16_t milliseconds)
+int tox_wait_prepare(Tox *tox, uint8_t *data)
 {
     Messenger *m = tox;
-    return wait_execute_messenger(m, data, len, milliseconds);
+    return wait_prepare_messenger(m, data);
 }
 
-void tox_wait_cleanup(Tox *tox, uint8_t *data, uint16_t len)
+int tox_wait_execute(uint8_t *data, long seconds, long microseconds)
+{
+    return wait_execute_messenger(data, seconds, microseconds);
+}
+
+int tox_wait_cleanup(Tox *tox, uint8_t *data)
 {
     Messenger *m = tox;
-    wait_cleanup_messenger(m, data, len);
+    return wait_cleanup_messenger(m, data);
 }
 
 /* SAVING AND LOADING FUNCTIONS: */

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -662,37 +662,43 @@ void tox_kill(Tox *tox);
 void tox_do(Tox *tox);
 
 /*
- * tox_wait_prepare(): function should be called under lock
+ * tox_wait_data_size():
+ *
+ *  returns a size of data buffer to allocate. the size is constant.
+ *
+ * tox_wait_prepare(): function should be called under lock every time we want to call tox_wait_execute()
  * Prepares the data required to call tox_wait_execute() asynchronously
  *
- * data[] is reserved and kept by the caller
- * *lenptr is in/out: in = reserved data[], out = required data[]
+ * data[] should be of at least tox_wait_data_size() size and it's reserved and kept by the caller
+ * Use that data[] to call tox_wait_execute()
  *
  *  returns  1 on success
- *  returns  0 if *lenptr is insufficient
- *  returns -1 if lenptr is NULL
+ *  returns  0 if data was NULL
  *
  *
  * tox_wait_execute(): function can be called asynchronously
- * Waits for something to happen on the socket for up to milliseconds milliseconds.
- * *** Function MUSTN'T poll. ***
- * The function mustn't modify anything at all, so it can be called completely
- * asynchronously without any worry.
+ * Waits for something to happen on the socket for up to seconds seconds and mircoseconds microseconds.
+ * mircoseconds should be between 0 and 999999.
+ * If you set either or both seconds and microseconds to negatives, it will block indefinetly until there
+ * is an activity.
  *
- *  returns  1 if there is socket activity (i.e. tox_do() should be called)
- *  returns  0 if the timeout was reached
- *  returns -1 if data was NULL or len too short
+ *  returns  2 if there is socket activity (i.e. tox_do() should be called)
+ *  returns  1 if the timeout was reached (tox_do() should be called anyway. it's advised to call it at least
+ *             once per second)
+ *  returns  0 if data was NULL
  *
  *
- * tox_wait_cleanup(): function should be called under lock
+ * tox_wait_cleanup(): function should be called under lock,  every time tox_wait_execute() finishes
  * Stores results from tox_wait_execute().
  *
- * data[]/len shall be the exact same as given to tox_wait_execute()
+ *  returns  1 on success
+ *  returns  0 if data was NULL
  *
  */
-int tox_wait_prepare(Tox *tox, uint8_t *data, uint16_t *lenptr);
-int tox_wait_execute(Tox *tox, uint8_t *data, uint16_t len, uint16_t milliseconds);
-void tox_wait_cleanup(Tox *tox, uint8_t *data, uint16_t len);
+size_t tox_wait_data_size();
+int tox_wait_prepare(Tox *tox, uint8_t *data);
+int tox_wait_execute(uint8_t *data, long seconds, long microseconds);
+int tox_wait_cleanup(Tox *tox, uint8_t *data);
 
 
 /* SAVING AND LOADING FUNCTIONS: */


### PR DESCRIPTION
Previously `networking_wait_prepare()` needed to be called twice -- once to get length of the buffer to allocate and then one more to actually prepare the buffer, so I just made `networking_wait_data_size()` which returns the required size of the buffer and let `networking_wait_prepare()` handling only preparation step.
`networking_wait_data_size()` is a function instead of a define because `sizeof(select_info)` depends on size on int and more importantly -- memory alignment. Making a define would require putting the whole `select_info` struct in tox.h, which is kind of ugly.

Added some important comments, like the limit of `microseconds` variable.

Changed return values to be more consistent.

Added more timeout options.
