### PR TITLE
Tell pkg-config when tox core is built vs. nacl

### DIFF
--- a/libtoxcore.pc.in
+++ b/libtoxcore.pc.in
@@ -7,5 +7,5 @@ Name: libtoxcore
 Description: Tox protocol library
 Requires:
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -ltoxcore @LIBS@
+Libs: -L${libdir} @NACL_LDFLAGS@ -ltoxcore @NACL_LIBS@ @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
This is required so that applications using tox core do not fail to link when
core is built vs. the nacl library.
