### PR TITLE
Yet another fix for building vs. NaCl library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,18 +207,17 @@ AC_ARG_WITH(libsodium-libs,
         ]
 )
 
+if test "x$WANT_NACL" = "xyes"; then
+    enable_shared=no
+    enable_static=yes
+fi
+
 # Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL
-
-if test "x$WANT_NACL" = "xyes"; then
-    disable_shared=yes
-    enable_static=yes
-fi
-
 
 WIN32=no
 AC_CANONICAL_HOST


### PR DESCRIPTION
Make sure the shared lib build is really disabled when compiling vs.
NaCl library:

moved settings before libtool initialization
fixed parameter name
