### PR TITLE
sockets: support Mac OS X way of disabling SIGPIPE on a socket

### DIFF
--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -253,6 +253,11 @@ TCP_Client_Connection *new_TCP_connection(IP_Port ip_port, uint8_t *public_key, 
         return NULL;
     }
 
+    if (!set_socket_nosigpipe(sock)) {
+        kill_sock(sock);
+        return 0;
+    }
+
     if (!(set_socket_nonblock(sock) && connect_sock_to(sock, ip_port))) {
         kill_sock(sock);
         return NULL;

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -702,6 +702,11 @@ static int accept_connection(TCP_Server *TCP_server, sock_t sock)
         return 0;
     }
 
+    if (!set_socket_nosigpipe(sock)) {
+        kill_sock(sock);
+        return 0;
+    }
+
     TCP_Secure_Connection *conn =
         &TCP_server->incomming_connection_queue[TCP_server->incomming_connection_queue_index % MAX_INCOMMING_CONNECTIONS];
 

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -26,7 +26,7 @@
 #include "net_crypto.h"
 #include "onion.h"
 
-#if defined(_WIN32) || defined(__WIN32__) || defined (WIN32)
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(__MACH__)
 #define MSG_NOSIGNAL 0
 #endif
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -150,6 +150,21 @@ int set_socket_nonblock(sock_t sock)
 #endif
 }
 
+/* Set socket to not emit SIGPIPE
+ *
+ * return 1 on success
+ * return 0 on failure
+ */
+int set_socket_nosigpipe(sock_t sock)
+{
+#if defined(__MACH__)
+    int set = 1;
+    return (setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(int)) == 0);
+#else
+    return 1;
+#endif
+}
+
 /* Set socket to dual (IPv4 + IPv6 socket)
  *
  * return 1 on success

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -332,6 +332,13 @@ void kill_sock(sock_t sock);
  */
 int set_socket_nonblock(sock_t sock);
 
+/* Set socket to not emit SIGPIPE
+ *
+ * return 1 on success
+ * return 0 on failure
+ */
+int set_socket_nosigpipe(sock_t sock);
+
 /* Set socket to dual (IPv4 + IPv6 socket)
  *
  * return 1 on success


### PR DESCRIPTION
Mac OS X doesn't have MSG_NOSIGNAL, so we need to use SO_NOSIGPIPE.
