### PR TITLE
SunOS Systems compatibility for TCP_client.c and TCP_server.c

### DIFF
--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -27,6 +27,10 @@
 #include <sys/ioctl.h>
 #endif
 
+#if defined(__sun)
+#define	MSG_NOSIGNAL 0
+#endif
+
 #include "util.h"
 
 /* return 1 on success

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -26,6 +26,11 @@
 #include <sys/ioctl.h>
 #endif
 
+#if defined(__sun)
+#include <sys/filio.h>
+#define	MSG_NOSIGNAL 0
+#endif
+
 #include "util.h"
 
 /* return 1 on success


### PR DESCRIPTION
Includes sys/filio.h which has the FIONREAD definition, and defines MSG_NOSIGNAL to 0, as that's missing on SunOS systems.