### PR TITLE
A slightly different #810

### DIFF
--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -327,12 +327,6 @@ int friend_ips(DHT *dht, IP_Port *ip_portlist, uint8_t *friend_id);
 
 /* SAVE/LOAD functions */
 
-/* Get the size of the DHT (for saving). */
-uint32_t DHT_size(DHT *dht);
-
-/* Save the DHT in data where data is an array of size DHT_size(). */
-void DHT_save(DHT *dht, uint8_t *data);
-
 /* Load the DHT from data of size size.
  *
  *  return -1 if failure.

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -1,7 +1,8 @@
 lib_LTLIBRARIES += libtoxcore.la
 
 libtoxcore_la_include_HEADERS = \
-                        ../toxcore/tox.h
+                        ../toxcore/tox.h \
+                        ../toxcore/data.h
 
 libtoxcore_la_includedir = $(includedir)/tox
 
@@ -39,7 +40,11 @@ libtoxcore_la_SOURCES = ../toxcore/DHT.h \
                         ../toxcore/TCP_client.c \
                         ../toxcore/TCP_server.h \
                         ../toxcore/TCP_server.c \
-                        ../toxcore/misc_tools.h
+                        ../toxcore/misc_tools.h \
+                        ../toxcore/data_intermediate.c \
+                        ../toxcore/data_export.c \
+                        ../toxcore/data.h \
+                        ../toxcore/data_private.h
 
 libtoxcore_la_CFLAGS =  -I$(top_srcdir) \
                         -I$(top_srcdir)/toxcore \

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -238,6 +238,7 @@ typedef struct Messenger {
     void (*msi_packet)(struct Messenger *m, int32_t, uint8_t *, uint16_t, void *);
     void *msi_packet_userdata;
 
+    void *cached_intermediate;
 } Messenger;
 
 /* Format: [client_id (32 bytes)][nospam number (4 bytes)][checksum (2 bytes)]
@@ -730,11 +731,16 @@ int wait_cleanup_messenger(Messenger *m, uint8_t *data);
 
 /* SAVING AND LOADING FUNCTIONS: */
 
-/* return size of the messenger data (for saving). */
+/* return size of the messenger data (for saving). 
+ * (Deprecated. use messenger_export) */
 uint32_t messenger_size(Messenger *m);
 
-/* Save the messenger in data (must be allocated memory of size Messenger_size()) */
+/* Save the messenger in data (must be allocated memory of size Messenger_size()) 
+ * (Deprecated. use messenger_export) */
 void messenger_save(Messenger *m, uint8_t *data);
+
+/* Save the messenger in data, allocating it for you */
+int32_t messenger_export(Messenger *m, uint8_t **data, uint64_t *out_length);
 
 /* Load the messenger from data of size length. */
 int messenger_load(Messenger *m, uint8_t *data, uint32_t length);

--- a/toxcore/data.h
+++ b/toxcore/data.h
@@ -1,0 +1,207 @@
+/**
+ * data.h (formerly txd.h, and SCProfileIO.h)
+ * Copyright (c) 2014 the Tox developers. All rights reserved.
+ * Rest of copyright notice omitted; look at another file.
+ */
+
+#ifndef TXD_H
+#define TXD_H
+#include "tox.h"
+
+/* Data types. */
+
+/**
+ * Defines TXD FourCC (4-character code) as uint32_t.
+ * This is the type of all TXD magic numbers.
+ */
+typedef uint32_t txd_fourcc_t;
+/**
+ * Defines TXD TwoCC (2-character code) as uint16_t.
+ * This is the type of FrEx keys.
+ */
+typedef uint16_t txd_twocc_t;
+/**
+ * Defines txd_intermediate_t as an opaque pointer to
+ * txd_intermediate_s.
+ */
+typedef struct txd_intermediate *txd_intermediate_t;
+
+
+/* Format constants. */
+
+/**
+ * Defines the 4CC (magic number) of the Binary data format.
+ * It is the only one available to Core.
+ */
+extern const txd_fourcc_t TXD_FORMAT_BINARY1;
+
+
+/* Error constants. */
+
+/**
+ * The envelope has a bad magic number, or it was shorter than the BASE_LEN.
+ */
+extern const int32_t TXD_ERR_BAD_BLOCK;
+/**
+ * One of the sizes in the block does not correspond with what we know.
+ */
+extern const int32_t TXD_ERR_SIZE_MISMATCH;
+/**
+ * The operation completed successfully (0).
+ */
+extern const int32_t TXD_ERR_SUCCESS;
+/**
+ * This function is not implemented yet. Failure is guaranteed
+ * for all future calls to this function for this version of the library.
+ */
+extern const int32_t TXD_ERR_NOT_IMPLEMENTED;
+
+
+/* Selective archival constants.
+ * Use bitwise or to combine flags, then pass them to
+ * txd_export_to_buf_ex(). */
+
+/**
+ * Save everything that can possibly be saved.
+ * This is implied when you call txd_export_to_buf().
+ * If you want more control, you should use txd_export_to_buf_ex().
+ */
+extern const uint32_t TXD_ALL_BLOCKS;
+
+/**
+ * Save the self block. It contains name and status.
+ */
+extern const uint32_t TXD_ARC_SELF_BLOCK;
+/**
+ * Save the keys block. It contains public and private keys, plus the nospam.
+ */
+extern const uint32_t TXD_ARC_KEYS_BLOCK;
+/**
+ * Save the friend block. It contains your friends.
+ */
+extern const uint32_t TXD_ARC_FRIEND_BLOCK;
+/**
+ * Save the DHT block. It contains the close nodes known to Tox at the
+ * time of archival.
+ */
+extern const uint32_t TXD_ARC_DHT_BLOCK;
+
+/* Intermediate structure functions. */
+
+/**
+ * Create a new intermediate structure from tox. The returned pointer
+ * must be freed with a call to txd_intermediate_free.
+ * @param tox the Tox API object containing data to initialize the
+ *            intermediate structure.
+ * @return the initialized txd_intermediate_t.
+ */
+txd_intermediate_t txd_intermediate_from_tox(Tox *tox);
+
+/**
+ * Restore data from the intermediate structure pointed to by interm
+ * into the Tox API object tox.
+ * @param interm the intermediate structure to restore data from.
+ *               It must not be NULL.
+ * @param tox the Tox API object receiving the data.
+ * @return TXD_ERR_SUCCESS (0) on success, otherwise an error code.
+ *         See TXD_ERR_* constants.
+ */
+int txd_restore_intermediate(txd_intermediate_t interm, Tox *tox);
+
+/**
+ * Destroy the intermediate structure pointed to by interm,
+ * securely erasing the data from memory before releasing it. When
+ * this function returns, interm shall be an invalid pointer.
+ * @param interm The intermediate structure to destroy. It must not
+ *               be NULL.
+ * @return nothing.
+ */
+void txd_intermediate_free(txd_intermediate_t interm);
+
+/**
+ * Extracting data out of the txd_intermediate_t safely.
+ * These functions should be self-explanatory.
+ * txd_copy_* do not output NULL terminators.
+ */
+uint32_t txd_get_length_of_name(txd_intermediate_t interm);
+void txd_copy_name(txd_intermediate_t interm, uint8_t *out_, uint32_t max_len);
+uint32_t txd_get_length_of_status_message(txd_intermediate_t interm);
+void txd_copy_status_message(txd_intermediate_t interm, uint8_t *out_, uint32_t max_len);
+TOX_USERSTATUS txd_get_user_status(txd_intermediate_t interm);
+void txd_copy_public_key(txd_intermediate_t interm, uint8_t *out_);
+/* note: use with caution - the secret key should not be copied
+ * willy-nilly */
+void txd_copy_secret_key(txd_intermediate_t interm, uint8_t *out_);
+/* technically a 4-byte int, but we handle it like bytes
+ * because core does too */
+void txd_copy_nospam(txd_intermediate_t interm, uint8_t *out_);
+
+uint32_t txd_get_number_of_friends(txd_intermediate_t interm);
+/* a bad index will give undefined behaviour */
+uint32_t txd_get_length_of_friend_name(txd_intermediate_t interm, uint32_t f_n);
+void txd_copy_friend_name(txd_intermediate_t interm, uint32_t f_n, uint8_t *out_, uint32_t max_len);
+void txd_copy_friend_client_id(txd_intermediate_t interm, uint32_t f_n, uint8_t *out_);
+/* do not use this function. */
+void txd_copy_friend_address(txd_intermediate_t interm, uint32_t f_n, uint8_t *out_);
+uint8_t txd_get_sends_receipts(txd_intermediate_t interm, uint32_t f_n);
+uint8_t txd_get_needs_requests(txd_intermediate_t interm, uint32_t f_n);
+uint16_t txd_get_length_of_request_data(txd_intermediate_t interm, uint32_t f_n);
+void txd_copy_request_data(txd_intermediate_t interm, uint32_t f_n, uint8_t *out_, uint32_t max_len);
+
+uint32_t txd_get_number_of_dht_nodes(txd_intermediate_t interm);
+void txd_copy_dht_client_id(txd_intermediate_t interm, uint32_t node, uint8_t *out_);
+uint8_t txd_get_dht_has_ip4(txd_intermediate_t interm, uint32_t node);
+uint8_t txd_get_dht_has_ip6(txd_intermediate_t interm, uint32_t node);
+uint16_t txd_get_dht_port4(txd_intermediate_t interm, uint32_t node);
+void txd_copy_dht_ip4(txd_intermediate_t interm, uint32_t node, uint8_t *out_);
+uint16_t txd_get_dht_port6(txd_intermediate_t interm, uint32_t node);
+void txd_copy_dht_ip6(txd_intermediate_t interm, uint32_t node, uint8_t *out_);
+
+/**
+ * Return the size of the buffer required to archive im.
+ * @param im the TXD intermediate you [are going to] archive.
+ */
+uint64_t txd_get_size_of_intermediate(txd_intermediate_t im);
+/**
+ * Same as txd_get_size_of_intermediate.
+ * For arc_blocks, pass in a bitmask of TXD_ARC_* constants,
+ * or TXD_ALL_BLOCKS.
+ * @param arc_blocks bitmask of TXD_ARC_* representing the blocks you are going
+ *                   to archive
+ */
+uint64_t txd_get_size_of_intermediate_ex(txd_intermediate_t im, uint32_t arc_blocks);
+/**
+ * Copy the contents of im into memory such that is it safe to shoot over
+ * the wire, save on disk, etc.
+ * You can re-create im by passing the returned buffer to
+ * txd_intermediate_from_buf.
+ * @param im the TXD intermediate struct to dump
+ * @param buf if this function returns TXD_ERR_SUCCESS, the value it points to
+ *            will be a valid pointer to the dumped memory.
+ * @param size see above, it will point to the size of buf.
+ * @discussion You can pass NULL for buf or size. (e.g. to get the size you
+ *             need to allocate, pass NULL for buf and a valid pointer for size)
+ */
+uint32_t txd_export_to_buf(txd_intermediate_t im, uint8_t **buf, uint64_t *size);
+uint32_t txd_export_to_buf_ex(txd_intermediate_t im, uint8_t **buf, uint64_t *size,
+                              uint32_t arc_blocks);
+/**
+ * You should use the functions above instead of this one.
+ */
+uint32_t txd_export_to_buf_prealloc(txd_intermediate_t im, uint8_t *buf,
+                                    uint64_t block_size, uint32_t arc_blocks);
+/**
+ * Create a new intermediate structure from archived data in buf.
+ * must be freed with a call to txd_intermediate_free.
+ * @param buf the memory buffer containing data to initialize the
+ *            intermediate structure.
+ * @param size the size of buf.
+ * @param out_ if this function returns TXD_ERR_SUCCESS, points to a valid
+ *             txd_intermediate_t structure. You are responsible for releasing
+ *             it with a call to txd_intermediate_free. Otherwise, it is undefined.
+ * @return an error code. See "Error constants." in this file for possible
+ *         values.
+ */
+uint32_t txd_intermediate_from_buf(uint8_t *buf, uint64_t size, txd_intermediate_t *out_);
+
+#endif

--- a/toxcore/data_export.c
+++ b/toxcore/data_export.c
@@ -1,0 +1,541 @@
+/**
+ * data_export.c: Functions for working with txd_intermediate_t
+ * in wire format.
+ * Copyright (c) 2014 the Tox developers. All rights reserved.
+ * Rest of copyright notice omitted; look at another file.
+ * Documentation for functions in this file is located in the relevant
+ * headers.
+ */
+
+#include <stdlib.h>
+#include "data.h"
+#include "data_private.h"
+#pragma GCC diagnostic ignored "-Wmultichar"
+
+/* you'll never guess which utf-8 character this is!
+ * yep, you were right! it's [REDACTED] */
+const txd_fourcc_t TXD_FORMAT_BINARY1 = 0xE6A19C00;
+#define TXD_BLOCK_SELF    ((txd_fourcc_t)'SELf')
+#define TXD_BLOCK_KEYS    ((txd_fourcc_t)'KEYs')
+#define TXD_BLOCK_FRIENDS ((txd_fourcc_t)'FRNd')
+#define TXD_BLOCK_DHT     ((txd_fourcc_t)'DHt*')
+
+#define TXD_FEX_LASTSEEN  ((txd_twocc_t)'Ls')
+
+const uint32_t TXD_ARC_SELF_BLOCK = 1;
+const uint32_t TXD_ARC_KEYS_BLOCK = 1 << 1;
+const uint32_t TXD_ARC_FRIEND_BLOCK = 1 << 2;
+const uint32_t TXD_ARC_DHT_BLOCK = 1 << 3;
+
+const uint32_t TXD_ALL_BLOCKS = 0xFFFFFFFF;
+
+#define TXD_KEYS_BLOCK_LEN (crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES + 4)
+
+uint32_t _txd_load_self_block(uint8_t *buf, uint32_t block_size, txd_intermediate_t out)
+{
+    uint8_t *pos = buf;
+    uint32_t adv, copy_len;
+    /* name */
+    adv = _txd_read_int_32(pos);
+    pos += 4;
+
+    if (adv > TOX_MAX_NAME_LENGTH)
+        copy_len = 0;
+    else
+        copy_len = adv;
+
+    out -> txd_name = copy_len ? malloc(copy_len) : NULL;
+    memcpy(out -> txd_name, pos, copy_len);
+    out -> txd_name_length = copy_len;
+    pos += adv;
+
+    /* status msg */
+    adv = _txd_read_int_32(pos);
+    pos += 4;
+
+    if (adv > TOX_MAX_STATUSMESSAGE_LENGTH)
+        copy_len = 0;
+    else
+        copy_len = adv;
+
+    out -> txd_status = copy_len ? malloc(copy_len) : NULL;
+    memcpy(out -> txd_status, pos, copy_len);
+    out -> txd_status_length = copy_len;
+    pos += adv;
+
+    out -> txd_status_troolean = (TOX_USERSTATUS) * pos;
+    return TXD_ERR_SUCCESS;
+}
+
+uint32_t _txd_load_keys_block(uint8_t *buf, uint32_t block_size, txd_intermediate_t out)
+{
+    if (block_size != crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES + 4)
+        return TXD_ERR_SIZE_MISMATCH; /* the keys block is constant size */
+
+    memcpy(out -> txd_public, buf, crypto_box_PUBLICKEYBYTES);
+    buf += crypto_box_PUBLICKEYBYTES;
+    memcpy(out -> txd_private, buf, crypto_box_SECRETKEYBYTES);
+    buf += crypto_box_SECRETKEYBYTES;
+    memcpy(out -> txd_nospam, buf, 4);
+    return TXD_ERR_SUCCESS;
+}
+
+uint32_t _txd_load_friends_block(uint8_t *buf, uint32_t block_size, txd_intermediate_t out)
+{
+    uint8_t *pos = buf;
+
+    if (block_size < 4)
+        return TXD_ERR_SIZE_MISMATCH;
+
+    uint32_t friend_count = _txd_read_int_32(buf);
+    pos += 4;
+    uint32_t guaranteed_size = (9 + TOX_FRIEND_ADDRESS_SIZE) * friend_count;
+
+    /* i'm kinda paranoid about people jacking up the friend count
+     * and making us alloc too much memory
+     * this check helps but not really */
+    if (guaranteed_size > block_size - 4)
+        return TXD_ERR_SIZE_MISMATCH;
+
+    struct timeval today;
+    gettimeofday(&today, NULL); /* FIXME: standardise to UTC */
+
+    struct txd_friend *friends = calloc(sizeof(struct txd_friend), friend_count);
+    int i, j;
+
+    for (i = 0; i < friend_count; ++i) {
+        struct txd_friend *f = &(friends[i]);
+        f -> txd_flags = *pos;
+        pos += 1;
+        memcpy(f -> txd_addr, pos, TOX_FRIEND_ADDRESS_SIZE);
+        pos += TOX_FRIEND_ADDRESS_SIZE;
+        uint32_t nl = _txd_read_int_32(pos);
+        pos += 4;
+
+        if (guaranteed_size + nl > block_size)
+            goto kill;
+
+        f -> txd_name_length = nl;
+        f -> txd_name = malloc(nl);
+        memcpy(f -> txd_name, pos, nl);
+        pos += nl;
+        uint32_t dl = 0;
+
+        if (f -> txd_flags & TXD_BIT_NEEDS_FRIEND_REQUEST) {
+            dl = _txd_read_int_32(pos);
+            pos += 4;
+
+            if (guaranteed_size + nl + dl > block_size)
+                goto kill;
+
+            f -> txd_data_length = dl;
+            f -> txd_data = malloc(dl);
+            memcpy(f -> txd_data, pos, dl);
+            pos += dl;
+        } else {
+            f -> txd_data_length = 0;
+            f -> txd_data = NULL;
+        }
+
+        uint32_t fex_count = _txd_read_int_32(pos);
+        pos += 4;
+
+        if (guaranteed_size + nl + dl + (fex_count * 6) > block_size)
+            goto kill;
+
+        int k;
+
+        for (k = 0; k < fex_count; ++k) {
+            txd_twocc_t fex_key = ntohs(*(txd_twocc_t*)pos);
+            uint32_t fex_data_length = _txd_read_int_32(pos + 2);
+            pos += 6;
+            switch (fex_key) {
+                case TXD_FEX_LASTSEEN: {
+                    uint64_t ls = _txd_read_int_64(pos);
+                    /* bad time? */
+                    if (ls > today.tv_sec)
+                        ls = 0;
+                    f -> txd_lastseen = ls;
+                    break;
+                }
+                default:
+                    break;
+            }
+            pos += fex_data_length;
+        }
+
+        uint32_t read_so_far = (uint32_t)(pos - buf);
+
+        if (read_so_far > block_size)
+            goto kill;
+    }
+
+    out -> txd_friends = friends;
+    out -> txd_friends_length = friend_count;
+    return TXD_ERR_SUCCESS;
+kill: /* we need to release the friend structs here, all of it */
+
+    for (j = 0; j < friend_count; ++j) {
+        free(friends[j].txd_name);
+        free(friends[j].txd_data);
+    }
+
+    _txd_kill_memory(friends, sizeof(struct txd_friend) * friend_count);
+    free(friends);
+    out -> txd_friends = NULL;
+    out -> txd_friends_length = 0;
+    return TXD_ERR_SIZE_MISMATCH;
+}
+
+uint32_t _txd_load_dht_block(uint8_t *buf, uint32_t block_size, txd_intermediate_t out)
+{
+    uint8_t *pos = buf;
+
+    if (block_size < 4)
+        return TXD_ERR_SIZE_MISMATCH;
+
+    uint32_t dht_count = _txd_read_int_32(pos);
+    pos += 4;
+
+    if (dht_count > LCLIENT_LIST)
+        dht_count = LCLIENT_LIST;
+
+    if (block_size < 4 + ((crypto_box_PUBLICKEYBYTES + 25) * dht_count))
+        return TXD_ERR_SIZE_MISMATCH;
+
+    struct txd_dhtlite *dhtlites = calloc(sizeof(struct txd_dhtlite), dht_count);
+    int i;
+
+    for (i = 0; i < dht_count; ++i) {
+        struct txd_dhtlite *cur = &(dhtlites[i]);
+        memcpy(cur -> txd_dhtlite_onion_id, pos, crypto_box_PUBLICKEYBYTES);
+        pos += crypto_box_PUBLICKEYBYTES;
+        uint8_t flag = *pos;
+        pos += 1;
+        cur -> txd_flags = flag;
+
+        if (flag & TXD_BIT_HAS_INET4) {
+            memcpy(&(cur -> txd_bytes_inet4), pos, 4);
+            memcpy(&(cur -> txd_port4), pos + 4, 2);
+        }
+
+        pos += 6;
+
+        if (flag & TXD_BIT_HAS_INET6) {
+            memcpy(&(cur -> txd_bytes_inet6), pos, 16);
+            memcpy(&(cur -> txd_port6), pos + 16, 2);
+        }
+
+        pos += 18;
+    }
+
+    out -> txd_dhtlite = dhtlites;
+    out -> txd_dhtlite_length = dht_count;
+    return TXD_ERR_SUCCESS;
+}
+
+/* Operations on full intermediates. */
+
+uint64_t txd_get_size_of_intermediate(txd_intermediate_t im)
+{
+    return txd_get_size_of_intermediate_ex(im, TXD_ALL_BLOCKS);
+}
+
+uint64_t txd_get_size_of_intermediate_ex(txd_intermediate_t im, uint32_t arc_blocks)
+{
+    uint64_t running_total = 12;
+
+    /* the base length is ??? bytes.
+     * 4 bytes for magic TXD_FORMAT_BINARY1
+     * 8 bytes for the length of the rest of the file
+     * + more for various magics */
+    /* self block: magic, name&status lengths, troolean, keys & nospam
+     * don't worry, the compiler will optimize it down to a constant :^) */
+    if (arc_blocks & TXD_ARC_SELF_BLOCK) {
+        running_total += 17;
+        running_total += txd_get_length_of_name(im);
+        running_total += txd_get_length_of_status_message(im);
+    }
+
+    if (arc_blocks & TXD_ARC_KEYS_BLOCK) {
+        running_total += 12 + crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES;
+    }
+
+    if (arc_blocks & TXD_ARC_FRIEND_BLOCK) {
+        running_total += 12; /* friend count */
+        uint32_t friend_count = txd_get_number_of_friends(im);
+        running_total += (9 + 14 + TOX_FRIEND_ADDRESS_SIZE) * friend_count;
+        int i;
+
+        for (i = 0; i < friend_count; ++i) {
+            running_total += txd_get_length_of_friend_name(im, i);
+
+            if (txd_get_needs_requests(im, i))
+                running_total += 4 + txd_get_length_of_request_data(im, i);
+        }
+    }
+
+    if (arc_blocks & TXD_ARC_DHT_BLOCK) {
+        running_total += 12; /* dht count */
+        uint32_t dhtlite_count = txd_get_number_of_dht_nodes(im);
+        running_total += (crypto_box_PUBLICKEYBYTES + 25) * dhtlite_count;
+    }
+
+    return running_total;
+}
+
+uint32_t txd_export_to_buf(txd_intermediate_t im, uint8_t **buf,
+                           uint64_t *size)
+{
+    return txd_export_to_buf_ex(im, buf, size, TXD_ALL_BLOCKS);
+}
+
+uint32_t txd_export_to_buf_ex(txd_intermediate_t im, uint8_t **buf,
+                              uint64_t *size, uint32_t arc_blocks)
+{
+    uint64_t block_size = txd_get_size_of_intermediate_ex(im, arc_blocks);
+
+    if (size)
+        *size = block_size;
+
+    if (!buf)
+        return TXD_ERR_SUCCESS;
+
+    uint8_t *rbuf = malloc(block_size);
+    uint32_t save_ret = txd_export_to_buf_prealloc(im, rbuf, block_size, arc_blocks);
+
+    if (save_ret != TXD_ERR_SUCCESS) {
+        _txd_kill_memory(rbuf, block_size);
+        free(rbuf);
+        *buf = NULL;
+    } else {
+        *buf = rbuf;
+    }
+
+    return save_ret;
+}
+
+uint32_t txd_export_to_buf_prealloc(txd_intermediate_t im, uint8_t *buf,
+                                    uint64_t block_size, uint32_t arc_blocks)
+{
+    uint8_t *pos = buf;
+    _txd_write_int_32(TXD_FORMAT_BINARY1, pos);
+    pos += 4;
+    _txd_write_int_64(block_size - 12, pos);
+    pos += 8;
+
+    if (arc_blocks & TXD_ARC_SELF_BLOCK) {
+        /* layout of self block:
+         * [SELf:4][len:4]
+         * [name len:4][name:nl]
+         * [stat len:4][stat:sl]
+         * [ustat:1]
+         */
+        _txd_write_int_32(TXD_BLOCK_SELF, pos);
+        pos += 4;
+        uint32_t nl = txd_get_length_of_name(im),
+                 sl = txd_get_length_of_status_message(im);
+        uint32_t sb_size = (9 + nl + sl);
+        _txd_write_int_32(sb_size, pos);
+        pos += 4;
+        _txd_write_int_32(nl, pos);
+        pos += 4;
+        txd_copy_name(im, pos, nl);
+        pos += nl;
+        _txd_write_int_32(sl, pos);
+        pos += 4;
+        txd_copy_status_message(im, pos, sl);
+        pos += sl;
+        *pos = txd_get_user_status(im);
+        pos += 1;
+    }
+
+    if (arc_blocks & TXD_ARC_KEYS_BLOCK) {
+        _txd_write_int_32(TXD_BLOCK_KEYS, pos);
+        pos += 4;
+        _txd_write_int_32(TXD_KEYS_BLOCK_LEN, pos);
+        pos += 4;
+        txd_copy_public_key(im, pos);
+        pos += crypto_box_PUBLICKEYBYTES;
+        txd_copy_secret_key(im, pos);
+        pos += crypto_box_SECRETKEYBYTES;
+        txd_copy_nospam(im, pos);
+        pos += 4;
+    }
+
+    if (arc_blocks & TXD_ARC_FRIEND_BLOCK) {
+        _txd_write_int_32(TXD_BLOCK_FRIENDS, pos);
+        pos += 4;
+        uint8_t *lptr = pos;
+        pos += 4;
+        /* saves the position of the length so we can calculate
+         * as we go along, then write at end */
+        uint32_t block_total = 4;
+        uint32_t friend_count = txd_get_number_of_friends(im);
+        _txd_write_int_32(friend_count, pos);
+        pos += 4;
+        int i;
+
+        for (i = 0; i < friend_count; ++i) {
+            *pos = im -> txd_friends[i].txd_flags;
+            pos += 1;
+            txd_copy_friend_address(im, i, pos);
+            pos += TOX_FRIEND_ADDRESS_SIZE;
+            uint32_t nl = txd_get_length_of_friend_name(im, i);
+            _txd_write_int_32(nl, pos);
+            pos += 4;
+            txd_copy_friend_name(im, i, pos, nl);
+            pos += nl;
+
+            if (txd_get_needs_requests(im, i)) {
+                uint32_t dl = txd_get_length_of_request_data(im, i);
+                _txd_write_int_32(dl, pos);
+                pos += 4;
+                txd_copy_request_data(im, i, pos, dl);
+                pos += dl;
+                block_total += 4 + dl;
+            }
+
+            _txd_write_int_32(1, pos);
+            pos += 4;
+            uint16_t tag = htons(TXD_FEX_LASTSEEN);
+            memcpy(pos, &tag, 2);
+            _txd_write_int_32(8, pos + 2);
+            pos += 6;
+            _txd_write_int_64(im -> txd_friends[i].txd_lastseen, pos);
+            pos += 8;
+            block_total += 14;
+
+            /* count of FrEx k/v pairs */
+            block_total += 9 + TOX_FRIEND_ADDRESS_SIZE + nl;
+        }
+
+        _txd_write_int_32(block_total, lptr);
+    }
+
+    if (arc_blocks & TXD_ARC_DHT_BLOCK) {
+        _txd_write_int_32(TXD_BLOCK_DHT, pos);
+        pos += 4;
+        uint8_t *lptr = pos;
+        pos += 4;
+        /* saves the position of the length so we can calculate
+         * as we go along, then write at end */
+        uint32_t block_total = 4;
+        uint32_t node_count = txd_get_number_of_dht_nodes(im);
+        _txd_write_int_32(node_count, pos);
+        pos += 4;
+        int i;
+
+        for (i = 0; i < node_count; ++i) {
+            txd_copy_dht_client_id(im, i, pos);
+            pos += crypto_box_PUBLICKEYBYTES;
+            *pos = im -> txd_dhtlite[i].txd_flags;
+            pos += 1;
+
+            if (txd_get_dht_has_ip4(im, i)) {
+                txd_copy_dht_ip4(im, i, pos);
+                pos += 4;
+                uint16_t port4 = htons(txd_get_dht_port4(im, i));
+                memcpy(pos, &port4, 2);
+                pos += 2;
+            } else {
+                memset(pos, 0, 6);
+                pos += 6;
+            }
+
+            if (txd_get_dht_has_ip6(im, i)) {
+                txd_copy_dht_ip6(im, i, pos);
+                pos += 16;
+                uint16_t port6 = htons(txd_get_dht_port6(im, i));
+                memcpy(pos, &port6, 2);
+                pos += 2;
+            } else {
+                memset(pos, 0, 18);
+                pos += 18;
+            }
+
+            block_total += crypto_box_PUBLICKEYBYTES + 25;
+            /* we used padding here because i am a lazy shit */
+        }
+
+        _txd_write_int_32(block_total, lptr);
+    }
+
+    return TXD_ERR_SUCCESS;
+}
+
+uint32_t txd_intermediate_from_buf(uint8_t *buf, uint64_t size,
+                                   txd_intermediate_t *out)
+{
+    if (size <= 12)
+        return TXD_ERR_BAD_BLOCK;
+
+    uint8_t *pos = buf + 4;
+    uint32_t magic = _txd_read_int_32(buf);
+
+    if (magic != TXD_FORMAT_BINARY1)
+        return TXD_ERR_BAD_BLOCK;
+
+    uint64_t vsize = _txd_read_int_64(pos);
+    pos += 8;
+
+    if (size - 12 != vsize)
+        return TXD_ERR_SIZE_MISMATCH;
+
+    size -= 12;
+    txd_intermediate_t base = calloc(sizeof(*base), 1);
+
+    while (size > 0) {
+        uint32_t b_magic = _txd_read_int_32(pos);
+        pos += 4;
+        uint32_t b_size = _txd_read_int_32(pos);
+        pos += 4;
+
+        if (b_size == 0 || b_size > size) {
+            /* a block size of 0 is illegal */
+            txd_intermediate_free(base);
+            return TXD_ERR_SIZE_MISMATCH;
+        }
+
+        uint32_t delegation_ret = 0;
+
+        switch (b_magic) {
+            case TXD_BLOCK_SELF:
+                delegation_ret = _txd_load_self_block(pos, b_size, base);
+                break;
+
+            case TXD_BLOCK_KEYS:
+                delegation_ret = _txd_load_keys_block(pos, b_size, base);
+                break;
+
+            case TXD_BLOCK_FRIENDS:
+                delegation_ret = _txd_load_friends_block(pos, b_size, base);
+                break;
+
+            case TXD_BLOCK_DHT:
+                delegation_ret = _txd_load_dht_block(pos, b_size, base);
+
+            default:
+                break;
+        }
+
+        if (delegation_ret != TXD_ERR_SUCCESS) {
+            txd_intermediate_free(base);
+
+            if (out)
+                *out = NULL;
+
+            return delegation_ret;
+        }
+
+        size -= b_size + 8;
+        pos += b_size;
+    }
+
+    if (out)
+        *out = base;
+    else
+        txd_intermediate_free(base);
+
+    return TXD_ERR_SUCCESS;
+}

--- a/toxcore/data_intermediate.c
+++ b/toxcore/data_intermediate.c
@@ -1,0 +1,389 @@
+/**
+ * data_intermediate.c: Functions for working with txd_intermediate_t
+ * as an internal data structure.
+ * Copyright (c) 2014 the Tox developers. All rights reserved.
+ * Rest of copyright notice omitted; look at another file.
+ */
+
+#include "data.h"
+#include "data_private.h"
+#include "util.h"
+
+const int32_t TXD_ERR_BAD_BLOCK        = -2049;
+const int32_t TXD_ERR_SIZE_MISMATCH    = -2050;
+const int32_t TXD_ERR_NOT_IMPLEMENTED  = -2052;
+const int32_t TXD_ERR_SUCCESS          = 0;
+
+const uint8_t TXD_BIT_NEEDS_FRIEND_REQUEST = 1; /* bit 1 */
+const uint8_t TXD_BIT_SENDS_RECEIPTS = 1 << 1; /* bit 2 */
+
+const uint8_t TXD_BIT_HAS_INET4 = 1; /* bit 1 */
+const uint8_t TXD_BIT_HAS_INET6 = 1 << 1; /* bit 2 */
+
+/* Intermediates */
+
+/* TODO: save DHT stuff */
+txd_intermediate_t txd_intermediate_from_tox(Tox *tox)
+{
+    Messenger *tox_ = (Messenger *)tox;
+    txd_intermediate_t interm = malloc(sizeof(*interm));
+    interm -> txd_name_length = tox_ -> name_length;
+    /* interm -> txd_name_length = tox_get_self_name_size(tox); */
+    interm -> txd_name = malloc(interm -> txd_name_length);
+    /* tox.h: "it must be at least MAX_NAME_LENGTH"... but Messenger code
+     * says otherwise */
+    tox_get_self_name(tox, interm -> txd_name);
+
+    /* interm -> txd_status_length = tox_get_self_status_message_size(tox); */
+    interm -> txd_status_length = tox_ -> statusmessage_length;
+    interm -> txd_status = malloc(interm -> txd_status_length);
+    tox_get_self_status_message(tox, interm -> txd_status, interm -> txd_status_length);
+    interm -> txd_status_troolean = tox_get_self_user_status(tox);
+
+    memcpy(interm -> txd_public, tox_ -> net_crypto -> self_public_key, crypto_box_PUBLICKEYBYTES);
+    memcpy(interm -> txd_private, tox_ -> net_crypto -> self_secret_key, crypto_box_PUBLICKEYBYTES);
+    memcpy(interm -> txd_nospam, &(tox_ -> fr.nospam), sizeof(uint32_t));
+
+    uint32_t numfriends = tox_count_friendlist(tox);
+    struct txd_friend *friends = malloc(numfriends * sizeof(struct txd_friend));
+    int32_t toxfl[numfriends];
+    tox_get_friendlist(tox, toxfl, numfriends);
+    int i;
+
+    for (i = 0; i < numfriends; ++i) {
+        int32_t f_n = toxfl[i];
+        uint8_t flag = 0;
+
+        if (tox_ -> friendlist[f_n].status < FRIEND_CONFIRMED) {
+            flag |= TXD_BIT_NEEDS_FRIEND_REQUEST;
+            uint16_t info_len = tox_ -> friendlist[f_n].info_size;
+            uint8_t *data = malloc(info_len);
+            memcpy(data, tox_ -> friendlist[f_n].info, info_len);
+            friends[i].txd_data = data;
+            friends[i].txd_data_length = info_len;
+            friends[i].txd_lastseen = 0;
+        } else {
+            friends[i].txd_data = NULL;
+            friends[i].txd_data_length = 0;
+            friends[i].txd_lastseen = tox_get_last_online(tox, f_n);
+        }
+
+        if (tox_ -> friendlist[f_n].receives_read_receipts) {
+            flag |= TXD_BIT_SENDS_RECEIPTS;
+        }
+
+        friends[i].txd_flags = flag;
+        /* uint32_t friend_name_len = tox_get_name_size(tox, f_n); */
+        uint32_t friend_name_len = tox_ -> friendlist[f_n].name_length;
+        friends[i].txd_name_length = friend_name_len;
+        friends[i].txd_name = malloc(friend_name_len);
+        tox_get_name(tox, f_n, friends[i].txd_name);
+        tox_get_client_id(tox, f_n, friends[i].txd_addr);
+        memcpy(friends[i].txd_addr + TOX_CLIENT_ID_SIZE,
+               &(tox_ -> friendlist[f_n].friendrequest_nospam), sizeof(uint32_t));
+    }
+
+    /* something to think about: can we prevent ourselves from allocating
+     * more memory than we actually need here? */
+    struct txd_dhtlite *dht_save = calloc(sizeof(struct txd_dhtlite), LCLIENT_LIST);
+    /* copy out dht nodes (irungentoo said this was all i needed...) */
+    Client_data *dht_close = tox_ -> dht -> close_clientlist;
+    unix_time_update();
+    uint32_t num_dhtlite = 0;
+    int j;
+
+    for (j = 0; j < LCLIENT_LIST; ++j) {
+        uint8_t flags = 0;
+
+        if (!is_timeout(dht_close[j].assoc4.timestamp, BAD_NODE_TIMEOUT)) {
+            flags = (flags | TXD_BIT_HAS_INET4);
+            IP_Port ipp4 = dht_close[j].assoc4.ip_port;
+
+            if (ipp4.ip.family != AF_INET)
+                continue; /* wtf?? */
+
+            dht_save[num_dhtlite].txd_port4 = ipp4.port;
+            memcpy(dht_save[num_dhtlite].txd_bytes_inet4, ipp4.ip.ip4.uint8, 4);
+        }
+
+        if (!is_timeout(dht_close[j].assoc6.timestamp, BAD_NODE_TIMEOUT)) {
+            flags = (flags | TXD_BIT_HAS_INET6);
+            IP_Port ipp6 = dht_close[j].assoc6.ip_port;
+
+            if (ipp6.ip.family != AF_INET6)
+                continue; /* wtf wtf wtf wtf?? */
+
+            dht_save[num_dhtlite].txd_port6 = ipp6.port;
+            memcpy(dht_save[num_dhtlite].txd_bytes_inet4, ipp6.ip.ip6.uint8, 16);
+        }
+
+        dht_save[num_dhtlite].txd_flags = flags;
+        memcpy(dht_save[num_dhtlite].txd_dhtlite_onion_id,
+               dht_close[num_dhtlite].client_id, TOX_CLIENT_ID_SIZE);
+
+        if (flags)
+            ++num_dhtlite;
+
+    }
+
+    interm -> txd_dhtlite = dht_save;
+    interm -> txd_dhtlite_length = num_dhtlite;
+
+    interm -> txd_friends_length = numfriends;
+    interm -> txd_friends = friends;
+    return interm;
+}
+
+int txd_restore_intermediate(txd_intermediate_t interm, Tox *tox)
+{
+    tox_set_name(tox, interm -> txd_name, interm -> txd_name_length);
+    tox_set_status_message(tox, interm -> txd_status, interm -> txd_status_length);
+    tox_set_user_status(tox, interm -> txd_status_troolean);
+
+    Messenger *tox_ = (Messenger *)tox;
+
+    memcpy(tox_ -> net_crypto -> self_public_key,
+           interm -> txd_public, crypto_box_PUBLICKEYBYTES);
+    memcpy(tox_ -> net_crypto -> self_secret_key,
+           interm -> txd_private, crypto_box_SECRETKEYBYTES);
+    memcpy(&(tox_ -> fr.nospam),
+           interm -> txd_nospam, sizeof(uint32_t));
+
+    struct txd_friend *friend = NULL;
+    int i;
+
+    for (i = 0; i < interm -> txd_friends_length; ++i) {
+        friend = &(interm -> txd_friends[i]);
+        int32_t new_friendnum = -1;
+
+        if (friend -> txd_flags & TXD_BIT_NEEDS_FRIEND_REQUEST) {
+            /* probably doesn't work */
+            new_friendnum = tox_add_friend(tox, friend -> txd_addr,
+                                           friend -> txd_data,
+                                           friend -> txd_data_length);
+        } else {
+            new_friendnum = tox_add_friend_norequest(tox, friend -> txd_addr);
+        }
+        if (new_friendnum < 0)
+            continue; /* failure */
+
+        if (friend -> txd_flags & TXD_BIT_SENDS_RECEIPTS)
+            tox_set_sends_receipts(tox, new_friendnum, 1);
+        setfriendname(tox_, new_friendnum, friend -> txd_name, friend -> txd_name_length);
+        tox_ -> friendlist[new_friendnum].ping_lastrecv = friend -> txd_lastseen;
+    }
+
+    struct txd_dhtlite *server = NULL; /* lu stqism :^) */
+
+    int j;
+
+    for (j = 0; j < interm -> txd_dhtlite_length; ++j) {
+        server = &(interm -> txd_dhtlite[j]);
+        /* is it bad to DHT_bootstrap so many times? */
+        IP_Port ippn;
+
+        if (server -> txd_flags & TXD_BIT_HAS_INET4) {
+            IP the_ip;
+            the_ip.family = AF_INET;
+            memset(the_ip.padding, 0, 3);
+            IP4 ip4;
+            memcpy(ip4.uint8, server -> txd_bytes_inet4, 4);
+            the_ip.ip4 = ip4;
+            ippn.ip = the_ip;
+            ippn.port = server -> txd_port4;
+            DHT_bootstrap(tox_ -> dht, ippn, server -> txd_dhtlite_onion_id);
+        }
+
+        if (server -> txd_flags & TXD_BIT_HAS_INET6) {
+            IP the_ip;
+            the_ip.family = AF_INET;
+            IP6 ip6;
+            memcpy(ip6.uint8, server -> txd_bytes_inet6, 16);
+            the_ip.ip6 = ip6;
+            ippn.ip = the_ip;
+            ippn.port = server -> txd_port4;
+            DHT_bootstrap(tox_ -> dht, ippn, server -> txd_dhtlite_onion_id);
+        }
+    }
+
+    return TXD_ERR_SUCCESS;
+}
+
+void txd_intermediate_free(txd_intermediate_t interm)
+{
+    _txd_kill_memory(interm -> txd_name, interm -> txd_name_length);
+    free(interm -> txd_name);
+
+    _txd_kill_memory(interm -> txd_status, interm -> txd_status_length);
+    free(interm -> txd_status);
+
+    struct txd_friend *friend = NULL;
+    int i;
+
+    for (i = 0; i < interm -> txd_friends_length; ++i) {
+        friend = &(interm -> txd_friends[i]);
+        _txd_kill_memory(friend -> txd_data, friend -> txd_data_length);
+        _txd_kill_memory(friend -> txd_name, friend -> txd_name_length);
+        free(friend -> txd_data);
+        free(friend -> txd_name);
+    }
+
+    _txd_kill_memory(interm -> txd_dhtlite,
+                     sizeof(struct txd_dhtlite) * interm -> txd_dhtlite_length);
+    free(interm -> txd_dhtlite);
+    _txd_kill_memory(interm -> txd_friends, sizeof(struct txd_friend) * interm -> txd_friends_length);
+    free(interm -> txd_friends);
+    _txd_kill_memory(interm, sizeof(struct txd_intermediate));
+    free(interm);
+}
+
+/* Intermediate getters
+ * The intermediate is immutable. */
+
+uint32_t txd_get_length_of_name(txd_intermediate_t interm)
+{
+    return interm -> txd_name_length;
+}
+
+void txd_copy_name(txd_intermediate_t interm, uint8_t *out, uint32_t max_len)
+{
+    uint32_t copy_len = interm -> txd_name_length;
+
+    /* tfw C stdlib has no min/max macros */
+    if (copy_len > max_len)
+        copy_len = max_len;
+
+    memcpy(out, interm -> txd_name, copy_len);
+}
+
+uint32_t txd_get_length_of_status_message(txd_intermediate_t interm)
+{
+    return interm -> txd_status_length;
+}
+
+void txd_copy_status_message(txd_intermediate_t interm, uint8_t *out, uint32_t max_len)
+{
+    uint32_t copy_len = interm -> txd_status_length;
+
+    if (copy_len > max_len)
+        copy_len = max_len;
+
+    memcpy(out, interm -> txd_status, copy_len);
+}
+
+TOX_USERSTATUS txd_get_user_status(txd_intermediate_t interm)
+{
+    return (TOX_USERSTATUS)interm -> txd_status_troolean;
+}
+
+void txd_copy_public_key(txd_intermediate_t interm, uint8_t *out)
+{
+    memcpy(out, interm -> txd_public, crypto_box_PUBLICKEYBYTES);
+}
+
+void txd_copy_secret_key(txd_intermediate_t interm, uint8_t *out)
+{
+    memcpy(out, interm -> txd_private, crypto_box_SECRETKEYBYTES);
+}
+
+void txd_copy_nospam(txd_intermediate_t interm, uint8_t *out)
+{
+    memcpy(out, interm -> txd_nospam, 4);
+}
+
+uint32_t txd_get_number_of_friends(txd_intermediate_t interm)
+{
+    return interm -> txd_friends_length;
+}
+
+uint32_t txd_get_length_of_friend_name(txd_intermediate_t interm, uint32_t f_n)
+{
+    return interm -> txd_friends[f_n].txd_name_length;
+}
+
+void txd_copy_friend_name(txd_intermediate_t interm, uint32_t f_n, uint8_t *out, uint32_t max_len)
+{
+    uint32_t copy_len = interm -> txd_friends[f_n].txd_name_length;
+
+    if (copy_len > max_len)
+        copy_len = max_len;
+
+    memcpy(out, interm -> txd_friends[f_n].txd_name, copy_len);
+}
+
+void txd_copy_friend_client_id(txd_intermediate_t interm, uint32_t f_n, uint8_t *out)
+{
+    memcpy(out, interm -> txd_friends[f_n].txd_addr, TOX_CLIENT_ID_SIZE);
+}
+
+void txd_copy_friend_address(txd_intermediate_t interm, uint32_t f_n, uint8_t *out)
+{
+    memcpy(out, interm -> txd_friends[f_n].txd_addr, TOX_FRIEND_ADDRESS_SIZE);
+}
+
+uint8_t txd_get_sends_receipts(txd_intermediate_t interm, uint32_t f_n)
+{
+    return (interm -> txd_friends[f_n].txd_flags & TXD_BIT_SENDS_RECEIPTS) == TXD_BIT_SENDS_RECEIPTS;
+}
+
+uint8_t txd_get_needs_requests(txd_intermediate_t interm, uint32_t f_n)
+{
+    return (interm -> txd_friends[f_n].txd_flags & TXD_BIT_NEEDS_FRIEND_REQUEST) == TXD_BIT_NEEDS_FRIEND_REQUEST;
+}
+
+uint16_t txd_get_length_of_request_data(txd_intermediate_t interm, uint32_t f_n)
+{
+    return interm -> txd_friends[f_n].txd_data_length;
+}
+
+void txd_copy_request_data(txd_intermediate_t interm, uint32_t f_n, uint8_t *out, uint32_t max_len)
+{
+    uint32_t copy_len = interm -> txd_friends[f_n].txd_data_length;
+
+    if (copy_len > max_len)
+        copy_len = max_len;
+
+    memcpy(out, interm -> txd_friends[f_n].txd_data, copy_len);
+}
+
+uint32_t txd_get_number_of_dht_nodes(txd_intermediate_t interm)
+{
+    return interm -> txd_dhtlite_length;
+}
+
+void txd_copy_dht_client_id(txd_intermediate_t interm, uint32_t node, uint8_t *out)
+{
+    memcpy(out, interm -> txd_dhtlite[node].txd_dhtlite_onion_id, TOX_CLIENT_ID_SIZE);
+}
+
+uint8_t txd_get_dht_has_ip4(txd_intermediate_t interm, uint32_t node)
+{
+    return (interm -> txd_dhtlite[node].txd_flags & TXD_BIT_HAS_INET4)
+           == TXD_BIT_HAS_INET4;
+}
+
+uint8_t txd_get_dht_has_ip6(txd_intermediate_t interm, uint32_t node)
+{
+    return (interm -> txd_dhtlite[node].txd_flags & TXD_BIT_HAS_INET6)
+           == TXD_BIT_HAS_INET6;
+}
+
+uint16_t txd_get_dht_port4(txd_intermediate_t interm, uint32_t node)
+{
+    return ntohs(interm -> txd_dhtlite[node].txd_port4);
+}
+
+void txd_copy_dht_ip4(txd_intermediate_t interm, uint32_t node, uint8_t *out)
+{
+    memcpy(out, interm -> txd_dhtlite[node].txd_bytes_inet4, 4);
+}
+
+uint16_t txd_get_dht_port6(txd_intermediate_t interm, uint32_t node)
+{
+    return ntohs(interm -> txd_dhtlite[node].txd_port6);
+}
+
+void txd_copy_dht_ip6(txd_intermediate_t interm, uint32_t node, uint8_t *out)
+{
+    memcpy(out, interm -> txd_dhtlite[node].txd_bytes_inet6, 16);
+}

--- a/toxcore/data_private.h
+++ b/toxcore/data_private.h
@@ -1,0 +1,186 @@
+/**
+ * data_private.h: it's like data.h, but private, like bread
+ * Copyright (c) 2014 the Tox developers. All rights reserved.
+ * Rest of copyright notice omitted; look at another file.
+ */
+
+#ifndef TXD_PRIVATE_H
+#define TXD_PRIVATE_H
+#include <sys/types.h>
+#include <sys/param.h>
+#include "Messenger.h"
+
+extern const uint8_t TXD_BIT_NEEDS_FRIEND_REQUEST;
+extern const uint8_t TXD_BIT_SENDS_RECEIPTS;
+extern const uint8_t TXD_BIT_HAS_INET4;
+extern const uint8_t TXD_BIT_HAS_INET6;
+
+/**
+ * Endian-ness and stuff
+ * probably only works on linux and BSD-like
+ */
+
+static inline void _txd_write_int_32_le(uint32_t the_int, uint8_t *buf)
+{
+    buf[0] = the_int >> 24;
+    buf[1] = the_int >> 16;
+    buf[2] = the_int >> 8;
+    buf[3] = the_int;
+}
+
+static inline void _txd_write_int_64_le(uint64_t the_int, uint8_t *buf)
+{
+    buf[0] = the_int >> 56;
+    buf[1] = the_int >> 48;
+    buf[2] = the_int >> 40;
+    buf[3] = the_int >> 32;
+    buf[4] = the_int >> 24;
+    buf[5] = the_int >> 16;
+    buf[6] = the_int >> 8;
+    buf[7] = the_int;
+}
+static inline uint32_t _txd_read_int_32_le(const uint8_t *buf)
+{
+    return (((uint32_t)buf[0] << 24) + ((uint32_t)buf[1] << 16) +
+            ((uint32_t)buf[2] << 8) + (uint32_t)buf[3]);
+}
+
+static inline uint64_t _txd_read_int_64_le(const uint8_t *buf)
+{
+    return (((uint64_t)buf[0] << 56) + ((uint64_t)buf[1] << 48) +
+            ((uint64_t)buf[2] << 40) + ((uint64_t)buf[3] << 32) +
+            ((uint64_t)buf[4] << 24) + ((uint64_t)buf[5] << 16) +
+            ((uint64_t)buf[6] << 8) + (uint64_t)buf[7]);
+}
+/* otherwise, we write them backwards.
+ * It's like how the British drive on the wrong side of the road.
+ */
+static inline void _txd_write_int_32_be(uint32_t the_int, uint8_t *buf)
+{
+    buf[3] = the_int >> 24;
+    buf[2] = the_int >> 16;
+    buf[1] = the_int >> 8;
+    buf[0] = the_int;
+}
+
+static inline void _txd_write_int_64_be(uint64_t the_int, uint8_t *buf)
+{
+    buf[7] = the_int >> 56;
+    buf[6] = the_int >> 48;
+    buf[5] = the_int >> 40;
+    buf[4] = the_int >> 32;
+    buf[3] = the_int >> 24;
+    buf[2] = the_int >> 16;
+    buf[1] = the_int >> 8;
+    buf[0] = the_int;
+}
+
+static inline uint32_t _txd_read_int_32_be(const uint8_t *buf)
+{
+    return *((uint32_t *)buf);
+}
+
+static inline uint64_t _txd_read_int_64_be(const uint8_t *buf)
+{
+    return *((uint64_t *)buf);
+}
+
+static inline void _txd_write_int_64(uint64_t the_int, uint8_t *buf)
+{
+#if BYTE_ORDER == LITTLE_ENDIAN
+    _txd_write_int_64_le(the_int, buf);
+#elif BYTE_ORDER == BIG_ENDIAN
+    _txd_write_int_64_be(the_int, buf);
+#else
+#error u w0t m8
+#endif
+}
+
+static inline void _txd_write_int_32(uint32_t the_int, uint8_t *buf)
+{
+#if BYTE_ORDER == LITTLE_ENDIAN
+    _txd_write_int_32_le(the_int, buf);;
+#elif BYTE_ORDER == BIG_ENDIAN
+    _txd_write_int_32_be(the_int, buf);;
+#else
+#error u w0t m8
+#endif
+}
+
+static inline uint64_t _txd_read_int_64(const uint8_t *buf)
+{
+#if BYTE_ORDER == LITTLE_ENDIAN
+    return _txd_read_int_64_le(buf);
+#elif BYTE_ORDER == BIG_ENDIAN
+    return _txd_read_int_64_be(buf);
+#else
+#error u w0t m8
+#endif
+}
+
+static inline uint32_t _txd_read_int_32(const uint8_t *buf)
+{
+#if BYTE_ORDER == LITTLE_ENDIAN
+    return _txd_read_int_32_le(buf);
+#elif BYTE_ORDER == BIG_ENDIAN
+    return _txd_read_int_32_be(buf);
+#else
+#error u w0t m8
+#endif
+}
+
+static inline void _txd_kill_memory(void *buf, size_t size)
+{
+    volatile char *p = buf;
+
+    while (size--) {
+        *p++ = 0;
+    }
+}
+
+struct txd_friend {
+    uint32_t txd_name_length;
+    uint8_t *txd_name;
+    uint8_t txd_addr[TOX_FRIEND_ADDRESS_SIZE];
+    uint8_t txd_flags;
+
+    uint32_t txd_data_length;
+    uint8_t *txd_data;
+    /* note: Status isn't saved because we're going to show
+     * friends offline anyway while the connection resyncs. */
+    uint64_t txd_lastseen;
+};
+
+struct txd_dhtlite {
+    /* Associated IPs. They are only valid if the flags say they are. */
+    /* the below members are in network order; you shouldn't [need] to care
+     * because it is an implementation detail only (+ this entire struct) */
+    /* The getters for ports return host-order - you're good. */
+    uint8_t txd_bytes_inet4[4];
+    uint16_t txd_port4;
+    uint8_t txd_bytes_inet6[16];
+    uint16_t txd_port6;
+    /* use bitwise AND to check these. */
+    uint8_t txd_flags;
+    uint8_t txd_dhtlite_onion_id[crypto_box_PUBLICKEYBYTES];
+};
+
+struct txd_intermediate {
+    uint32_t txd_name_length;
+    uint8_t *txd_name;
+    uint32_t txd_status_length;
+    uint8_t *txd_status;
+    uint8_t txd_status_troolean;
+
+    uint8_t txd_public[crypto_box_PUBLICKEYBYTES];
+    uint8_t txd_private[crypto_box_SECRETKEYBYTES];
+    uint8_t txd_nospam[sizeof(uint32_t)];
+
+    uint32_t txd_friends_length;
+    struct txd_friend *txd_friends;
+
+    uint32_t txd_dhtlite_length;
+    struct txd_dhtlite *txd_dhtlite;
+};
+
+#endif

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -834,6 +834,12 @@ void tox_save(Tox *tox, uint8_t *data)
     messenger_save(m, data);
 }
 
+int32_t tox_export(Tox *tox, uint8_t **data, uint64_t *out_length)
+{
+    Messenger *m = tox;
+    messenger_export(m, data, out_length);
+}
+
 /* Load the messenger from data of size length. */
 int tox_load(Tox *tox, uint8_t *data, uint32_t length)
 {

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -726,11 +726,18 @@ int tox_wait_cleanup(Tox *tox, uint8_t *data);
 
 /* SAVING AND LOADING FUNCTIONS: */
 
-/*  return size of messenger data (for saving). */
+/*  return size of messenger data (for saving).
+ *  Deprecated. use tox_export */
 uint32_t tox_size(Tox *tox);
 
-/* Save the messenger in data (must be allocated memory of size Messenger_size()). */
+/* Save the messenger in data (must be allocated memory of size Messenger_size()).
+ * Deprecated. use tox_export */
 void tox_save(Tox *tox, uint8_t *data);
+
+/* Saves the messenger. It allocs the buffer for you, and returns by reference
+ * in data. Length is also returned in out_length. 
+ * You are responsible for freeing it if tox_export returns 0. */
+int32_t tox_export(Tox *m, uint8_t **data, uint64_t *out_length);
 
 /* Load the messenger from data of size length.
  *

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -737,7 +737,7 @@ void tox_save(Tox *tox, uint8_t *data);
 /* Saves the messenger. It allocs the buffer for you, and returns by reference
  * in data. Length is also returned in out_length. 
  * You are responsible for freeing it if tox_export returns 0. */
-int32_t tox_export(Tox *m, uint8_t **data, uint64_t *out_length);
+int32_t tox_export(Tox *tox, uint8_t **data, uint64_t *out_length);
 
 /* Load the messenger from data of size length.
  *


### PR DESCRIPTION
https://github.com/irungentoo/ProjectTox-Core/pull/810

Basically the same thing, but data.h is now an optional header, and the saving glue is implemented at the Messenger layer instead of the tox layer.

Everyone should use tox_export instead of tox_save now.