### PR TITLE
Fixed the undefined reference to pow error

### DIFF
--- a/testing/Makefile.inc
+++ b/testing/Makefile.inc
@@ -15,7 +15,6 @@ nTox_LDADD =            $(LIBSODIUM_LDFLAGS) \
                         $(LIBSODIUM_LIBS) \
                         $(NACL_OBJECTS) \
                         $(NACL_LIBS) \
-                        $(MATH_LDFLAGS) \
                         $(NCURSES_LIBS) \
                         $(WINSOCK2_LIBS)
 endif
@@ -53,7 +52,6 @@ Messenger_test_LDADD =  $(LIBSODIUM_LDFLAGS) \
                         $(LIBSODIUM_LIBS) \
                         $(NACL_OBJECTS) \
                         $(NACL_LIBS) \
-                        $(MATH_LDFLAGS) \
                         $(WINSOCK2_LIBS)
 
 
@@ -88,7 +86,6 @@ tox_sync_LDADD =        $(LIBSODIUM_LDFLAGS) \
                         $(LIBSODIUM_LIBS) \
                         $(NACL_OBJECTS) \
                         $(NACL_LIBS) \
-                        $(MATH_LDFLAGS) \
                         $(WINSOCK2_LIBS)
 endif
 

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -56,6 +56,7 @@ libtoxcore_la_LDFLAGS = $(TOXCORE_LT_LDFLAGS) \
                         $(EXTRA_LT_LDFLAGS) \
                         $(LIBSODIUM_LDFLAGS) \
                         $(NACL_LDFLAGS) \
+                        $(MATH_LDFLAGS) \
                         $(RT_LIBS) \
                         $(WINSOCK2_LIBS)
 


### PR DESCRIPTION
That [fixes](https://travis-ci.org/nurupo/InsertProjectNameHere/jobs/26461313) the [pow error](https://travis-ci.org/nurupo/ProjectTox-Qt-GUI/jobs/26079284) on Travis with gcc-4.8 for me, though one of tests seems to be timing out constantly

```
../auto_tests/tox_test.c:317:E:many_clients:test_many_clients:0: (after this point) Test timeout expired
```
