### PR TITLE
Use memcpy for FreeBSD

### DIFF
--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -532,7 +532,11 @@ inline__ int toxav_prepare_video_frame(ToxAv *av, int32_t call_index, uint8_t *d
         if (pkt->kind == VPX_CODEC_CX_FRAME_PKT) {
             if ( copied + pkt->data.frame.sz > dest_max ) return ErrorPacketTooLarge;
 
+#ifdef __FreeBSD__
             memcpy(dest + copied, pkt->data.frame.buf, pkt->data.frame.sz);
+#else
+            mempcpy(dest + copied, pkt->data.frame.buf, pkt->data.frame.sz);
+#endif
             copied += pkt->data.frame.sz;
         }
     }


### PR DESCRIPTION
Without this change, font-ends cannot link with libtoxav on FreeBSD.
