### PR TITLE
Fix possible nullptr dereferences in toxav/msi.c

### DIFF
--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -928,13 +928,13 @@ MSICall *init_call ( MSISession *session, int peers, int ringing_timeout )
 
 
     MSICall *_call = session->calls[_call_idx];
-    _call->call_idx = _call_idx;
 
     if ( _call == NULL ) {
         LOGGER_WARNING("Allocation failed!");
         return NULL;
     }
-
+    
+    _call->call_idx = _call_idx;
     _call->type_peer = calloc ( sizeof ( MSICallType ), peers );
 
     if ( _call->type_peer == NULL ) {
@@ -1026,9 +1026,11 @@ void *handle_timeout ( void *arg )
      */
     MSICall *_call = arg;
 
-    LOGGER_DEBUG("[Call: %s] Request timed out!", _call->id);
-
-    invoke_callback(_call->call_idx, MSI_OnRequestTimeout);
+    if (_call) {
+        LOGGER_DEBUG("[Call: %s] Request timed out!", _call->id);
+    
+        invoke_callback(_call->call_idx, MSI_OnRequestTimeout);
+    }
 
     if ( _call && _call->session ) {
 


### PR DESCRIPTION
Fixes two possible dereferences of null pointers in toxav/msi.c

The first is just reordering a dereference after actually checking the pointer's non-nullity, the second adds an extra if in (as far as I know) cold code to check for non-nullity.

In both cases there already are some nullity checks for those pointers, so I assumed that they can actually be null (otherwise those checks would be redundant).
