### PR TITLE
Comment out extra argument to sprintf in toxcore/logger.c

### DIFF
--- a/toxcore/logger.c
+++ b/toxcore/logger.c
@@ -91,7 +91,7 @@ const char *logger_stringify_level(LoggerLevel level)
 int logger_init(const char *file_name, LoggerLevel level)
 {
     char *final_l = calloc(sizeof(char), strlen(file_name) + 32);
-    sprintf(final_l, "%s"/*.%u"*/, file_name, logger_get_pid());
+    sprintf(final_l, "%s"/*.%u"*/, file_name/*, logger_get_pid()*/);
 
     if ( logger.log_file ) {
         fprintf(stderr, "Error opening logger name: %s with level %d: file already opened!\n", final_l, level);


### PR DESCRIPTION
Comment out an argument of sprintf that isn't used (already commented out in the format string).
The argument was discarded at runtime by sprintf, but still evaluated (call to logger_get_pid()).
