### PR TITLE
Fix undefined symbol: encrypt_data_symmetric

### DIFF
--- a/toxdns/toxdns.h
+++ b/toxdns/toxdns.h
@@ -25,6 +25,7 @@
 #define TOXDNS_H
 
 #include <stdint.h>
+#include "../toxcore/crypto_core.c"
 
 /* How to use this api to make secure tox dns3 requests:
  *


### PR DESCRIPTION
This allows toxdns to be used with FFI.
