### PR TITLE
Fix CppCheck style errors

### DIFF
--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -531,11 +531,11 @@ void line_eval(Tox *m, char *line)
                 }
             }
         } else if (inpt_command == 't') {
-            char msg[512];
             char *posi[1];
             int friendnum = strtoul(line + prompt_offset, posi, 0);
 
             if (**posi != 0) {
+                char msg[512];
                 sprintf(msg, "[t] Sending file %s to friendnum %u filenumber is %i (-1 means failure)", *posi + 1, friendnum,
                         add_filesender(m, friendnum, *posi + 1));
                 new_lines(msg);
@@ -634,7 +634,7 @@ void line_eval(Tox *m, char *line)
  * otherwise turns spaces into newlines if possible */
 void wrap(char output[STRING_LENGTH_WRAPPED], char input[STRING_LENGTH], int line_width)
 {
-    size_t i, k, m, len = strlen(input);
+    size_t i, len = strlen(input);
 
     if ((line_width < 4) || (len < (size_t)line_width)) {
         /* if line_width ridiculously tiny, it's not worth the effort */
@@ -652,8 +652,8 @@ void wrap(char output[STRING_LENGTH_WRAPPED], char input[STRING_LENGTH], int lin
 
     for (i = line_width; i < len; i += line_width) {
         /* look backward for a space to expand/turn into a new line */
-        k = i;
-        m = i - line_width;
+        size_t k = i;
+        size_t m = i - line_width;
 
         while (input[k] != ' ' && k > m) {
             k--;
@@ -837,7 +837,6 @@ void do_refresh()
 {
     int count = 0;
     char wrap_output[STRING_LENGTH_WRAPPED];
-    int L;
     int i;
 
     for (i = 0; i < HISTORY; i++) {
@@ -846,7 +845,7 @@ void do_refresh()
         else
             wrap(wrap_output, lines[i], x);
 
-        L = count_lines(wrap_output);
+        int L = count_lines(wrap_output);
         count = count + L;
 
         if (count < y) {
@@ -921,11 +920,10 @@ static char *data_file_name = NULL;
 static int load_data(Tox *m)
 {
     FILE *data_file = fopen(data_file_name, "r");
-    size_t size = 0;
 
     if (data_file) {
         fseek(data_file, 0, SEEK_END);
-        size = ftell(data_file);
+        size_t size = ftell(data_file);
         rewind(data_file);
 
         uint8_t data[size];
@@ -1215,7 +1213,6 @@ int main(int argc, char *argv[])
         exit(1);
 
     int on = 0;
-    int c = 0;
     char *filename = "data";
     char idstring[200] = {0};
     Tox *m;
@@ -1282,8 +1279,6 @@ int main(int argc, char *argv[])
 
     time_t timestamp0 = time(NULL);
 
-    uint8_t pollok = 0;
-
     while (1) {
         if (on == 0) {
             if (tox_isconnected(m)) {
@@ -1305,7 +1300,7 @@ int main(int argc, char *argv[])
         tox_do(m);
         do_refresh();
 
-        c = timeout_getch(m);
+        int c = timeout_getch(m);
 
         if (c == ERR || c == 27)
             continue;

--- a/toxav/media.c
+++ b/toxav/media.c
@@ -153,12 +153,11 @@ void queue(JitterBuffer *q, RTPMessage *pk)
     q->queue[q->rear] = pk;
 
     int a;
-    int b;
     int j;
     a = q->rear;
 
     for (j = 0; j < q->size - 1; ++j) {
-        b = a - 1;
+        int b = a - 1;
 
         if (b < 0)
             b += q->capacity;

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -431,8 +431,11 @@ MSIMessage *parse_message ( const uint8_t *data, uint16_t length )
  */
 int stringify_message(MSIMessage *msg, char *dest)
 {
+// THIS CODE HAS NO EFFECT, AND THE ARGUMENTS ARE NOT MODIFIED
+#if 0 
+
 #define HDR_TO_STR(__dest, __hdr) if (__hdr.header_value) {\
-    char nltstr[MSI_MAXMSG_SIZE]; memset(nltstr, '\0', MSI_MAXMSG_SIZE); int i = 0; \
+    char nltstr[MSI_MAXMSG_SIZE]; memset(nltstr+__hdr.size, '\0', MSI_MAXMSG_SIZE-__hdr.size); int i = 0; \
     for ( ; i < __hdr.size; i ++) nltstr[i] = (char)__hdr.header_value[i]; \
     }
 
@@ -452,6 +455,7 @@ int stringify_message(MSIMessage *msg, char *dest)
 //         U8_TO_NLTCHAR(msg->version.header_value, msg->version.size, nltstr, MSI_MAXMSG_SIZE);
 //         sprintf(dest, "Version: %s\n", nltstr);
 //     }
+#endif
 
     return 0;
 }

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -473,16 +473,20 @@ inline__ int toxav_recv_video ( ToxAv *av, int32_t call_index, vpx_image_t **out
     if (cii(call_index, av->msi_session)) return ErrorNoCall;
 
     uint8_t packet [RTP_PAYLOAD_SIZE];
-    int recved_size = 0;
-    int rc;
     CallSpecific *call = &av->calls[call_index];
-
+    
+    int recved_size = 0;
     do {
         recved_size = toxav_recv_rtp_payload(av, call_index, TypeVideo, packet);
 
-        if (recved_size > 0 && ( rc = vpx_codec_decode(&call->cs->v_decoder, packet, recved_size, NULL, 0) ) != VPX_CODEC_OK) {
-            LOGGER_ERROR("Error decoding video: %s\n", vpx_codec_err_to_string(rc));
-            return ErrorInternal;
+        if (recved_size > 0)
+        {
+            int rc = vpx_codec_decode(&call->cs->v_decoder, packet, recved_size, NULL, 0);
+            if (rc != VPX_CODEC_OK)
+            {
+                LOGGER_ERROR("Error decoding video: %s\n", vpx_codec_err_to_string(rc));
+                return ErrorInternal;
+            }
         }
 
     } while (recved_size > 0);

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2221,11 +2221,11 @@ uint16_t random_nodes_path(DHT *dht, Node_format *nodes, uint16_t max_num)
         return 0;
 
     uint16_t count = 0;
-    Client_data *list = NULL;
     uint16_t list_size = 0;
     uint32_t i;
 
     for (i = 0; i < max_num; ++i) {
+        Client_data *list = NULL;
         uint16_t rand_num = rand() % (dht->num_friends);
         list = dht->friends_list[rand_num].client_list;
         list_size = MAX_FRIEND_CLIENTS;

--- a/toxcore/assoc.c
+++ b/toxcore/assoc.c
@@ -886,7 +886,7 @@ void do_Assoc(Assoc *assoc, DHT *dht)
          * send getnode() requests to both */
         uint8_t *target_id = NULL;
         Client_entry *heard = NULL, *seen = NULL;
-        size_t i, k, m, bckt;
+        size_t i, k, m;
 
         for (i = 1; i < assoc->candidates_bucket_count; i++) {
             if (i % 2)
@@ -894,7 +894,7 @@ void do_Assoc(Assoc *assoc, DHT *dht)
             else
                 k = i >> 1;
 
-            bckt = (candidate + k) % assoc->candidates_bucket_count;
+            size_t bckt = (candidate + k) % assoc->candidates_bucket_count;
 
             for (m = 0; m < assoc->candidates_bucket_size; m++)
                 if (assoc->candidates[bckt].list[m].hash) {

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -596,10 +596,10 @@ Networking_Core *new_networking(IP ip, uint16_t port)
      */
     uint16_t port_to_try = port;
     *portptr = htons(port_to_try);
-    int tries, res;
+    int tries;
 
     for (tries = TOX_PORTRANGE_FROM; tries <= TOX_PORTRANGE_TO; tries++) {
-        res = bind(temp->sock, (struct sockaddr *)&addr, addrsize);
+        int res = bind(temp->sock, (struct sockaddr *)&addr, addrsize);
 
         if (!res) {
             temp->port = *portptr;

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -1001,7 +1001,7 @@ static void do_friend(Onion_Client *onion_c, uint16_t friendnum)
             if (count < (uint32_t)rand() % MAX_ONION_CLIENTS) {
                 Node_format nodes_list[MAX_SENT_NODES];
                 uint32_t num_nodes = get_close_nodes(onion_c->dht, onion_c->friends_list[friendnum].real_client_id, nodes_list,
-                                                     rand() % 2 ? AF_INET : AF_INET6, 1, 0);
+                                                     (rand() % 2) ? AF_INET : AF_INET6, 1, 0);
 
                 for (i = 0; i < num_nodes; ++i)
                     client_send_announce_request(onion_c, friendnum + 1, nodes_list[i].ip_port, nodes_list[i].client_id, 0, ~0);
@@ -1083,7 +1083,7 @@ static void do_announce(Onion_Client *onion_c)
         if (count < (uint32_t)rand() % MAX_ONION_CLIENTS) {
             Node_format nodes_list[MAX_SENT_NODES];
             uint32_t num_nodes = get_close_nodes(onion_c->dht, onion_c->c->self_public_key, nodes_list,
-                                                 rand() % 2 ? AF_INET : AF_INET6, 1, 0);
+                                                 (rand() % 2) ? AF_INET : AF_INET6, 1, 0);
 
             for (i = 0; i < num_nodes; ++i) {
                 client_send_announce_request(onion_c, 0, nodes_list[i].ip_port, nodes_list[i].client_id, 0, ~0);


### PR DESCRIPTION
# if 0 the content of toxav/msi.c : int stringify_message(MSIMessage

*msg, char *dest)
This function has no effect and does not seem to be used for actively
waiting.

Fix various other style errors, reduce scope when possible, avoid
redundant writes, clarify operator priorities, etc.
