### PR TITLE
Reduced number of realloc calls bs_list does

### DIFF
--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -915,7 +915,7 @@ TCP_Server *new_TCP_server(uint8_t ipv6_enabled, uint16_t num_sockets, uint16_t 
     memcpy(temp->public_key, public_key, crypto_box_PUBLICKEYBYTES);
     memcpy(temp->secret_key, secret_key, crypto_box_SECRETKEYBYTES);
 
-    bs_list_init(&temp->accepted_key_list, crypto_box_PUBLICKEYBYTES);
+    bs_list_init(&temp->accepted_key_list, crypto_box_PUBLICKEYBYTES, 8);
 
     return temp;
 }

--- a/toxcore/list.c
+++ b/toxcore/list.c
@@ -63,7 +63,7 @@ static int find(const BS_LIST *list, const void *data)
     //closest match is found if we move back to where we have already been
 
     while (1) {
-        int r = memcmp(data, list->data + list->size * i, list->size);
+        int r = memcmp(data, list->data + list->element_size * i, list->element_size);
 
         if (r == 0) {
             return i;
@@ -105,14 +105,52 @@ static int find(const BS_LIST *list, const void *data)
     }
 }
 
+/* Resized the list list
+ *
+ * return value:
+ *  1 : success
+ *  0 : failure
+ */
+static int resize(BS_LIST *list, uint32_t new_size)
+{
+    void *p;
 
-void bs_list_init(BS_LIST *list, uint32_t element_size)
+    p = realloc(list->data, list->element_size * new_size);
+
+    if (!p) {
+        return 0;
+    } else {
+        list->data = p;
+    }
+
+    p = realloc(list->ids, sizeof(int) * new_size);
+
+    if (!p) {
+        return 0;
+    } else {
+        list->ids = p;
+    }
+
+    return 1;
+}
+
+
+int bs_list_init(BS_LIST *list, uint32_t element_size, uint32_t initial_capacity)
 {
     //set initial values
     list->n = 0;
-    list->size = element_size;
-    list->data = NULL;
-    list->ids = NULL;
+    list->element_size = element_size;
+    if (initial_capacity == 0) {
+        list->data = NULL;
+        list->ids = NULL;
+    } else {
+        if (!resize(list, initial_capacity)) {
+            return 0;
+        }
+    }
+    list->capacity = initial_capacity;
+
+    return 1;
 }
 
 void bs_list_free(BS_LIST *list)
@@ -147,28 +185,19 @@ int bs_list_add(BS_LIST *list, const void *data, int id)
 
     i = ~i;
 
-    //increase the size of the arrays by one
-    void *p;
-
-    p = realloc(list->data, list->size * (list->n + 1));
-
-    if (!p) {
-        return 0;
-    } else {
-        list->data = p;
-    }
-
-    p = realloc(list->ids, sizeof(int) * (list->n + 1));
-
-    if (!p) {
-        return 0;
-    } else {
-        list->ids = p;
+    //increase the size of the arrays if needed
+    if (list->n == list->capacity) {
+        // 1.5 * n + 1
+        const uint32_t new_capacity = list->n + list->n/2 + 1;
+        if (!resize(list, new_capacity)) {
+            return 0;
+        }
+        list->capacity = new_capacity;
     }
 
     //insert data to element array
-    memmove(list->data + (i + 1) * list->size, list->data + i * list->size, (list->n - i) * list->size);
-    memcpy(list->data + i * list->size, data, list->size);
+    memmove(list->data + (i + 1) * list->element_size, list->data + i * list->element_size, (list->n - i) * list->element_size);
+    memcpy(list->data + i * list->element_size, data, list->element_size);
 
     //insert id to id array
     memmove(&list->ids[i + 1], &list->ids[i], (list->n - i) * sizeof(int));
@@ -193,10 +222,29 @@ int bs_list_remove(BS_LIST *list, const void *data, int id)
         return 0;
     }
 
+    //decrease the size of the arrays if needed
+    if (list->n < list->capacity/2) {
+        const uint32_t new_capacity = list->capacity/2;
+        if (!resize(list, new_capacity)) {
+            return 0;
+        }
+        list->capacity = new_capacity;
+    }
+
     list->n--;
 
-    memmove(list->data + i * list->size, list->data + (i + 1) * list->size, (list->n - i) * list->size);
+    memmove(list->data + i * list->element_size, list->data + (i + 1) * list->element_size, (list->n - i) * list->element_size);
     memmove(&list->ids[i], &list->ids[i + 1], (list->n - i) * sizeof(int));
 
+    return 1;
+}
+
+int bs_list_trim(BS_LIST *list)
+{
+    if (!resize(list, list->n)) {
+        return 0;
+    }
+
+    list->capacity = list->n;
     return 1;
 }

--- a/toxcore/list.h
+++ b/toxcore/list.h
@@ -32,13 +32,20 @@
 
 typedef struct {
     uint32_t n; //number of elements
-    uint32_t size; //size of the elements
+    uint32_t capacity; //number of elements memory is allocated for
+    uint32_t element_size; //size of the elements
     void *data; //array of elements
     int *ids; //array of element ids
 } BS_LIST;
 
-/* Initialize a list, element_size is the size of the elements in the list */
-void bs_list_init(BS_LIST *list, uint32_t element_size);
+/* Initialize a list, element_size is the size of the elements in the list and
+ * initial_capacity is the number of elements the memory will be initially allocated for
+ *
+ * return value:
+ *  1 : success
+ *  0 : failure
+ */
+int bs_list_init(BS_LIST *list, uint32_t element_size, uint32_t initial_capacity);
 
 /* Free a list initiated with list_init */
 void bs_list_free(BS_LIST *list);
@@ -66,5 +73,13 @@ int bs_list_add(BS_LIST *list, const void *data, int id);
  *  0 : failure (element not found or id does not match)
  */
 int bs_list_remove(BS_LIST *list, const void *data, int id);
+
+/* Removes the memory overhead
+ *
+ * return value:
+ *  1 : success
+ *  0 : failure
+ */
+int bs_list_trim(BS_LIST *list);
 
 #endif

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2507,7 +2507,7 @@ Net_Crypto *new_net_crypto(DHT *dht)
     networking_registerhandler(dht->net, NET_PACKET_CRYPTO_HS, &udp_handle_packet, temp);
     networking_registerhandler(dht->net, NET_PACKET_CRYPTO_DATA, &udp_handle_packet, temp);
 
-    bs_list_init(&temp->ip_port_list, sizeof(IP_Port));
+    bs_list_init(&temp->ip_port_list, sizeof(IP_Port), 8);
     return temp;
 }
 


### PR DESCRIPTION
It's a common practice to allocate a bit more space in dynamic arrays so that new element insertion won't cause the realloc call, which is costly [[1]](http://en.wikipedia.org/wiki/Dynamic_array#Bounded-size_dynamic_arrays_and_capacity), [[2]](http://en.wikipedia.org/wiki/Dynamic_array#Geometric_expansion_and_amortized_cost).
The list now reserves `1.5 * n + 1` when its capacity is reached and deallocates reserved memory when list is more than half empty, so that mixed sequence of insertions and deletions won't cause many realloc calls. `bs_list_trim()` can be used to remove the overhead memory manually.
