### PR TITLE
only allow call cancel during a pending invite

### DIFF
--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -262,6 +262,10 @@ int toxav_cancel ( ToxAv *av, int32_t call_index, int peer_id, const char *reaso
         return ErrorNoCall;
     }
 
+    if ( av->msi_session->calls[call_index]->state != call_inviting ) {
+        return ErrorInvalidState;
+    }
+
     return msi_cancel(av->msi_session, call_index, peer_id, reason);
 }
 


### PR DESCRIPTION
Actions should perform one specific task: hangup for ending active calls, cancel for cancelling pending outgoing calls. Having both actions end an active call is redundant.
