### PR TITLE
Updated Windows installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,23 +1,22 @@
 #Install Instructions
 
 - [Installation](#installation)
-    - [Unix like](#unix)
-    - [OS X](#osx)
-      - [Homebrew](#homebrew)
-      - [Non-Homebrew](#non-homebrew)
-    - [Windows](#windows)
-      - [Cross-Compile](#windows-cross-compile)
-        - [Setting up a VM](#windows-cross-compile-vm)
-        - [Setting up the environment](#windows-cross-compile-environment)
-        - [Compiling](#windows-cross-compile-compiling)
-      - [Native](#windows-native)
-
+  - [Unix like](#unix)
+  - [OS X](#osx)
+    - [Homebrew](#homebrew)
+    - [Non-Homebrew](#non-homebrew)
+  - [Windows](#windows)
+    - [Cross-Compile](#windows-cross-compile)
+      - [Setting up a VM](#windows-cross-compile-vm)
+      - [Setting up the environment](#windows-cross-compile-environment)
+      - [Compiling](#windows-cross-compile-compiling)
+    - [Native](#windows-native)
 - [Additional](#additional)
-    - [Advanced configure options] (#aconf)
-    - [A/V support](#av)
-      - [libtoxav] (#libtoxav)
-    - [Bootstrap daemon] (#bootstrapd)
-    - [nTox] (#ntox)
+  - [Advanced configure options](#aconf)
+  - [A/V support](#av)
+    - [libtoxav](#libtoxav)
+  - [Bootstrap daemon](#bootstrapd)
+  - [nTox](#ntox)
 
 <a name="installation" />
 ##Installation


### PR DESCRIPTION
There were people trying to build Tox unsuccessfully in MinGW+msys environment, when it's easier and less error-prone just to cross-compile it, thus added instructions from cross-compiling.

Tested the instructions, but just for 32-bit Tox though.Can test for 64-bit Tox build if needed.

I placed cross-compile instructions for Windows first over the native instructions because cross-compile ones are more complete (include a/v support) and are likely to work.

@irungentoo the cross-compile produces just a single Tox dll based on Jenkins instructions, since you said that static libraries need to be linked with the same compiler they were built with in order to work, etc, etc. Though, as I can see, MinGW static libraries should be able to link with other MinGW compilers just fine, at least that's what I would assume seeing as everyone produces both static and shared libraries. Here is [sodium](https://download.libsodium.org/libsodium/releases/), for example. It has MinGW both static and shared and msvc 2010, 2012, 2013 both static and shared builds too. So it would be nice to provide static MinGW builds too. Make Tox a single static library, or at least as separate core, av and dns (then do the same with dlls for consistency, instead of one huge dll, though one huge dll has advantages) but without sodium, opus and vpx libs, those should be already patched in.
