### PR TITLE
Move to Alpha

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.65])
-AC_INIT([tox], [0.0.0], [https://tox.im])
+AC_INIT([tox], [0.0.1], [https://tox.im])
 AC_CONFIG_AUX_DIR(configure_aux)
 AC_CONFIG_SRCDIR([toxcore/net_crypto.c])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Ticking the version up promotes stability, and means clients can depend on "being an Alpha core", etc