### PR TITLE
Fixed pointless double assignment of realrate in toxcore/net_crypto.c

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2274,10 +2274,10 @@ static void send_crypto_packets(Net_Crypto *c)
 
                 //calculate the "real" send rate (send rate - drop rate)
                 double r = conn->packet_send_rate;
-                double realrate = (r - (dropped - drop_ignore_new) * 1000.0);
+                double realrate = r;
 
-                if (dropped < drop_ignore_new) {
-                    realrate = r;
+                if (dropped > drop_ignore_new) {
+                    realrate = (r - (dropped - drop_ignore_new) * 1000.0);
                 }
 
                 //calculate exponential increase in rate, triggered when drop rate is below 5% for 5 seconds

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2274,10 +2274,13 @@ static void send_crypto_packets(Net_Crypto *c)
 
                 //calculate the "real" send rate (send rate - drop rate)
                 double r = conn->packet_send_rate;
-                double realrate = r;
+                double realrate;
 
                 if (dropped > drop_ignore_new) {
                     realrate = (r - (dropped - drop_ignore_new) * 1000.0);
+                }
+                else {
+                    realrate = r;
                 }
 
                 //calculate exponential increase in rate, triggered when drop rate is below 5% for 5 seconds


### PR DESCRIPTION
Just fixed this because it came across me while I was looking through the Congestion Control code...