### PR TITLE
Fix win32 mingw native build

### DIFF
--- a/toxdns/Makefile.inc
+++ b/toxdns/Makefile.inc
@@ -25,4 +25,5 @@ libtoxdns_la_LDFLAGS =  $(TOXCORE_LT_LDFLAGS) \
 libtoxdns_la_LIBADD =   $(LIBSODIUM_LIBS) \
                         $(NACL_OBJECTS) \
                         $(NAC_LIBS) \
-                        $(PTHREAD_LIBS)
+                        $(PTHREAD_LIBS) \
+                        libtoxcore.la


### PR DESCRIPTION
toxdns was not linking because of references to functions in crypto_core
