### PR TITLE
declare calculate_sum_sq static inline

### DIFF
--- a/toxav/codec.c
+++ b/toxav/codec.c
@@ -383,7 +383,7 @@ void codec_terminate_session ( CodecState *cs )
     free(cs);
 }
 
-static inline float calculate_sum_sq (int16_t *n, uint16_t k)
+static float calculate_sum_sq (int16_t *n, uint16_t k)
 {
     float result = 0;
     uint16_t i = 0;


### PR DESCRIPTION
not having it breaks xcode 6 linker, don't know why
