### PR TITLE
Improved nospam capabilities with hashcash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ Makefile.in
 # Testing
 testing/data
 *~
+\#*\#
+my_*
+TAGS
 
 # Vim
 *.swp
@@ -54,6 +57,7 @@ libtool
 .libs
 .dirstamp
 build/
+libsodium
 
 #kdevelop
 .kdev/

--- a/INSTALL
+++ b/INSTALL
@@ -309,10 +309,9 @@ causes the specified `gcc' to be used as the C compiler (unless it is
 overridden in the site shell script).
 
 Unfortunately, this technique does not work for `CONFIG_SHELL' due to
-an Autoconf limitation.  Until the limitation is lifted, you can use
-this workaround:
+an Autoconf bug.  Until the bug is fixed you can use this workaround:
 
-     CONFIG_SHELL=/bin/bash ./configure CONFIG_SHELL=/bin/bash
+     CONFIG_SHELL=/bin/bash /bin/bash ./configure CONFIG_SHELL=/bin/bash
 
 `configure' Invocation
 ======================
@@ -368,3 +367,4 @@ operates.
 
 `configure' also accepts some other, not widely useful, options.  Run
 `configure --help' for more details.
+

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -209,7 +209,8 @@ int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, u
 
     int32_t friend_id = getfriend_id(m, client_id);
 
-    if (friend_id != -1) {
+    if (friend_id != -1) 
+    {
         if (m->friendlist[friend_id].status >= FRIEND_CONFIRMED)
             return FAERR_ALREADYSENT;
 
@@ -236,8 +237,10 @@ int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, u
 
     uint32_t i;
 
-    for (i = 0; i <= m->numfriends; ++i)  {
-        if (m->friendlist[i].status == NOFRIEND) {
+    for (i = 0; i <= m->numfriends; ++i)  
+    {
+        if (m->friendlist[i].status == NOFRIEND) 
+        {
             m->friendlist[i].onion_friendnum = onion_friendnum;
             m->friendlist[i].status = FRIEND_ADDED;
             m->friendlist[i].crypt_connection_id = -1;
@@ -739,10 +742,11 @@ void m_set_sends_receipts(Messenger *m, int32_t friendnumber, int yesno)
 
 /* static void (*friend_request)(uint8_t *, uint8_t *, uint16_t); */
 /* Set the function that will be executed when a friend request is received. */
-void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *m, const uint8_t *, const uint8_t *, uint16_t,
-                              void *), void *userdata)
+void m_callback_friendrequest(Messenger *m, 
+                              void (*function)(Messenger *m, const uint8_t*, const uint8_t*, uint16_t, void*), 
+                              void *userdata)
 {
-    void (*handle_friendrequest)(void *, const uint8_t *, const uint8_t *, uint16_t, void *) = (void *)function;
+    void (*handle_friendrequest)(void*, const uint8_t*, const uint8_t*, uint16_t, void*) = (void*)function;
     callback_friendrequest(&(m->fr), handle_friendrequest, m, userdata);
 }
 
@@ -2252,23 +2256,29 @@ void do_friends(Messenger *m)
     uint32_t i;
     uint64_t temp_time = unix_time();
 
-    for (i = 0; i < m->numfriends; ++i) {
-        if (m->friendlist[i].status == FRIEND_ADDED) {
-            int fr = send_friendrequest(m->onion_c, m->friendlist[i].client_id, m->friendlist[i].friendrequest_nospam,
-                                        m->friendlist[i].info,
-                                        m->friendlist[i].info_size);
+    for (i = 0; i < m->numfriends; ++i) 
+    {
+        if (m->friendlist[i].status == FRIEND_ADDED) 
+        {
+            int fr = send_friendrequest(m, m->onion_c, m->friendlist[i].client_id, 
+                                        m->friendlist[i].friendrequest_nospam, 
+                                        m->friendlist[i].info, m->friendlist[i].info_size);
 
-            if (fr >= 0) {
+            if (fr >= 0) 
+            {
                 set_friend_status(m, i, FRIEND_REQUESTED);
                 m->friendlist[i].friendrequest_lastsent = temp_time;
             }
         }
 
         if (m->friendlist[i].status == FRIEND_REQUESTED
-                || m->friendlist[i].status == FRIEND_CONFIRMED) { /* friend is not online. */
-            if (m->friendlist[i].status == FRIEND_REQUESTED) {
-                /* If we didn't connect to friend after successfully sending him a friend request the request is deemed
-                 * unsuccessful so we set the status back to FRIEND_ADDED and try again.
+            || m->friendlist[i].status == FRIEND_CONFIRMED) /* friend is not online. */
+        {
+            if (m->friendlist[i].status == FRIEND_REQUESTED) 
+            {
+                /* If we didn't connect to friend after successfully sending him a friend 
+                 * request the request is deemed unsuccessful so we set the status back 
+                 * to FRIEND_ADDED and try again.
                  */
                 check_friend_request_timed_out(m, i, temp_time);
             }
@@ -2276,25 +2286,37 @@ void do_friends(Messenger *m)
             friend_new_connection(m, i, m->friendlist[i].client_id);
         }
 
-        if (m->friendlist[i].crypt_connection_id != -1) {
+        if (m->friendlist[i].crypt_connection_id != -1) 
+        {
             uint8_t dht_public_key1[crypto_box_PUBLICKEYBYTES];
-            uint64_t timestamp1 = onion_getfriend_DHT_pubkey(m->onion_c, m->friendlist[i].onion_friendnum, dht_public_key1);
+            uint64_t timestamp1 = onion_getfriend_DHT_pubkey(m->onion_c, 
+                                                             m->friendlist[i].onion_friendnum, 
+                                                             dht_public_key1);
             uint8_t dht_public_key2[crypto_box_PUBLICKEYBYTES];
-            uint64_t timestamp2 = get_connection_dht_key(m->net_crypto, m->friendlist[i].crypt_connection_id, dht_public_key2);
+            uint64_t timestamp2 = get_connection_dht_key(m->net_crypto, 
+                                                         m->friendlist[i].crypt_connection_id,
+                                                         dht_public_key2);
 
-            if (timestamp1 > timestamp2) {
-                set_connection_dht_public_key(m->net_crypto, m->friendlist[i].crypt_connection_id, dht_public_key1, timestamp1);
+            if (timestamp1 > timestamp2) 
+            {
+                set_connection_dht_public_key(m->net_crypto, m->friendlist[i].crypt_connection_id, 
+                                              dht_public_key1, timestamp1);
             } else if (timestamp1 < timestamp2) {
-                onion_set_friend_DHT_pubkey(m->onion_c, m->friendlist[i].onion_friendnum, dht_public_key2, timestamp2);
+                onion_set_friend_DHT_pubkey(m->onion_c, m->friendlist[i].onion_friendnum, 
+                                            dht_public_key2, timestamp2);
             }
 
             uint8_t direct_connected;
-            unsigned int status = crypto_connection_status(m->net_crypto, m->friendlist[i].crypt_connection_id, &direct_connected);
+            unsigned int status = crypto_connection_status(m->net_crypto, 
+                                                           m->friendlist[i].crypt_connection_id,
+                                                           &direct_connected);
 
-            if (direct_connected == 0 || status == CRYPTO_CONN_COOKIE_REQUESTING) {
+            if (direct_connected == 0 || status == CRYPTO_CONN_COOKIE_REQUESTING) 
+            {
                 IP_Port friendip;
 
-                if (onion_getfriendip(m->onion_c, m->friendlist[i].onion_friendnum, &friendip) == 1) {
+                if (onion_getfriendip(m->onion_c, m->friendlist[i].onion_friendnum, &friendip) == 1) 
+                {
                     set_direct_ip_port(m->net_crypto, m->friendlist[i].crypt_connection_id, friendip);
                 }
             }
@@ -2525,7 +2547,8 @@ void do_messenger(Messenger *m)
 
 #define SAVED_FRIEND_REQUEST_SIZE 1024
 #define NUM_SAVED_TCP_RELAYS 8
-struct SAVED_FRIEND {
+struct SAVED_FRIEND 
+{
     uint8_t status;
     uint8_t client_id[CLIENT_ID_SIZE];
     uint8_t info[SAVED_FRIEND_REQUEST_SIZE]; // the data that is sent during the friend requests we do.

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -209,8 +209,7 @@ int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, u
 
     int32_t friend_id = getfriend_id(m, client_id);
 
-    if (friend_id != -1) 
-    {
+    if (friend_id != -1) {
         if (m->friendlist[friend_id].status >= FRIEND_CONFIRMED)
             return FAERR_ALREADYSENT;
 
@@ -237,10 +236,8 @@ int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, u
 
     uint32_t i;
 
-    for (i = 0; i <= m->numfriends; ++i)  
-    {
-        if (m->friendlist[i].status == NOFRIEND) 
-        {
+    for (i = 0; i <= m->numfriends; ++i) {
+        if (m->friendlist[i].status == NOFRIEND) {
             m->friendlist[i].onion_friendnum = onion_friendnum;
             m->friendlist[i].status = FRIEND_ADDED;
             m->friendlist[i].crypt_connection_id = -1;
@@ -742,11 +739,11 @@ void m_set_sends_receipts(Messenger *m, int32_t friendnumber, int yesno)
 
 /* static void (*friend_request)(uint8_t *, uint8_t *, uint16_t); */
 /* Set the function that will be executed when a friend request is received. */
-void m_callback_friendrequest(Messenger *m, 
-                              void (*function)(Messenger *m, const uint8_t*, const uint8_t*, uint16_t, void*), 
+void m_callback_friendrequest(Messenger *m,
+                              void (*function)(Messenger *m, const uint8_t *, const uint8_t *, uint16_t, void *),
                               void *userdata)
 {
-    void (*handle_friendrequest)(void*, const uint8_t*, const uint8_t*, uint16_t, void*) = (void*)function;
+    void (*handle_friendrequest)(void *, const uint8_t *, const uint8_t *, uint16_t, void *) = (void *)function;
     callback_friendrequest(&(m->fr), handle_friendrequest, m, userdata);
 }
 
@@ -1597,6 +1594,7 @@ static int handle_filecontrol(const Messenger *m, int32_t friendnumber, uint8_t 
 
         switch (message_id) {
             case FILECONTROL_ACCEPT:
+
                 if (m->friendlist[friendnumber].file_receiving[filenumber].status != FILESTATUS_PAUSED_BY_US) {
                     m->friendlist[friendnumber].file_receiving[filenumber].status = FILESTATUS_TRANSFERRING;
                     return 0;
@@ -1605,6 +1603,7 @@ static int handle_filecontrol(const Messenger *m, int32_t friendnumber, uint8_t 
                 return -1;
 
             case FILECONTROL_PAUSE:
+
                 if (m->friendlist[friendnumber].file_receiving[filenumber].status != FILESTATUS_PAUSED_BY_US) {
                     m->friendlist[friendnumber].file_receiving[filenumber].status = FILESTATUS_PAUSED_BY_OTHER;
                     return 0;
@@ -1628,6 +1627,7 @@ static int handle_filecontrol(const Messenger *m, int32_t friendnumber, uint8_t 
 
         switch (message_id) {
             case FILECONTROL_ACCEPT:
+
                 if (m->friendlist[friendnumber].file_sending[filenumber].status != FILESTATUS_PAUSED_BY_US) {
                     m->friendlist[friendnumber].file_sending[filenumber].status = FILESTATUS_TRANSFERRING;
                     return 0;
@@ -1636,6 +1636,7 @@ static int handle_filecontrol(const Messenger *m, int32_t friendnumber, uint8_t 
                 return -1;
 
             case FILECONTROL_PAUSE:
+
                 if (m->friendlist[friendnumber].file_sending[filenumber].status != FILESTATUS_PAUSED_BY_US) {
                     m->friendlist[friendnumber].file_sending[filenumber].status = FILESTATUS_PAUSED_BY_OTHER;
                 }
@@ -2256,28 +2257,23 @@ void do_friends(Messenger *m)
     uint32_t i;
     uint64_t temp_time = unix_time();
 
-    for (i = 0; i < m->numfriends; ++i) 
-    {
-        if (m->friendlist[i].status == FRIEND_ADDED) 
-        {
-            int fr = send_friendrequest(m, m->onion_c, m->friendlist[i].client_id, 
-                                        m->friendlist[i].friendrequest_nospam, 
+    for (i = 0; i < m->numfriends; ++i) {
+        if (m->friendlist[i].status == FRIEND_ADDED) {
+            int fr = send_friendrequest(m, m->onion_c, m->friendlist[i].client_id,
+                                        m->friendlist[i].friendrequest_nospam,
                                         m->friendlist[i].info, m->friendlist[i].info_size);
 
-            if (fr >= 0) 
-            {
+            if (fr >= 0) {
                 set_friend_status(m, i, FRIEND_REQUESTED);
                 m->friendlist[i].friendrequest_lastsent = temp_time;
             }
         }
 
         if (m->friendlist[i].status == FRIEND_REQUESTED
-            || m->friendlist[i].status == FRIEND_CONFIRMED) /* friend is not online. */
-        {
-            if (m->friendlist[i].status == FRIEND_REQUESTED) 
-            {
-                /* If we didn't connect to friend after successfully sending him a friend 
-                 * request the request is deemed unsuccessful so we set the status back 
+                || m->friendlist[i].status == FRIEND_CONFIRMED) { /* friend is not online. */
+            if (m->friendlist[i].status == FRIEND_REQUESTED) {
+                /* If we didn't connect to friend after successfully sending him a friend
+                 * request the request is deemed unsuccessful so we set the status back
                  * to FRIEND_ADDED and try again.
                  */
                 check_friend_request_timed_out(m, i, temp_time);
@@ -2286,37 +2282,33 @@ void do_friends(Messenger *m)
             friend_new_connection(m, i, m->friendlist[i].client_id);
         }
 
-        if (m->friendlist[i].crypt_connection_id != -1) 
-        {
+        if (m->friendlist[i].crypt_connection_id != -1) {
             uint8_t dht_public_key1[crypto_box_PUBLICKEYBYTES];
-            uint64_t timestamp1 = onion_getfriend_DHT_pubkey(m->onion_c, 
-                                                             m->friendlist[i].onion_friendnum, 
-                                                             dht_public_key1);
+            uint64_t timestamp1 = onion_getfriend_DHT_pubkey(m->onion_c,
+                                  m->friendlist[i].onion_friendnum,
+                                  dht_public_key1);
             uint8_t dht_public_key2[crypto_box_PUBLICKEYBYTES];
-            uint64_t timestamp2 = get_connection_dht_key(m->net_crypto, 
-                                                         m->friendlist[i].crypt_connection_id,
-                                                         dht_public_key2);
+            uint64_t timestamp2 = get_connection_dht_key(m->net_crypto,
+                                  m->friendlist[i].crypt_connection_id,
+                                  dht_public_key2);
 
-            if (timestamp1 > timestamp2) 
-            {
-                set_connection_dht_public_key(m->net_crypto, m->friendlist[i].crypt_connection_id, 
+            if (timestamp1 > timestamp2) {
+                set_connection_dht_public_key(m->net_crypto, m->friendlist[i].crypt_connection_id,
                                               dht_public_key1, timestamp1);
             } else if (timestamp1 < timestamp2) {
-                onion_set_friend_DHT_pubkey(m->onion_c, m->friendlist[i].onion_friendnum, 
+                onion_set_friend_DHT_pubkey(m->onion_c, m->friendlist[i].onion_friendnum,
                                             dht_public_key2, timestamp2);
             }
 
             uint8_t direct_connected;
-            unsigned int status = crypto_connection_status(m->net_crypto, 
-                                                           m->friendlist[i].crypt_connection_id,
-                                                           &direct_connected);
+            unsigned int status = crypto_connection_status(m->net_crypto,
+                                  m->friendlist[i].crypt_connection_id,
+                                  &direct_connected);
 
-            if (direct_connected == 0 || status == CRYPTO_CONN_COOKIE_REQUESTING) 
-            {
+            if (direct_connected == 0 || status == CRYPTO_CONN_COOKIE_REQUESTING) {
                 IP_Port friendip;
 
-                if (onion_getfriendip(m->onion_c, m->friendlist[i].onion_friendnum, &friendip) == 1) 
-                {
+                if (onion_getfriendip(m->onion_c, m->friendlist[i].onion_friendnum, &friendip) == 1) {
                     set_direct_ip_port(m->net_crypto, m->friendlist[i].crypt_connection_id, friendip);
                 }
             }
@@ -2547,8 +2539,7 @@ void do_messenger(Messenger *m)
 
 #define SAVED_FRIEND_REQUEST_SIZE 1024
 #define NUM_SAVED_TCP_RELAYS 8
-struct SAVED_FRIEND 
-{
+struct SAVED_FRIEND {
     uint8_t status;
     uint8_t client_id[CLIENT_ID_SIZE];
     uint8_t info[SAVED_FRIEND_REQUEST_SIZE]; // the data that is sent during the friend requests we do.
@@ -2741,6 +2732,7 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
 
     switch (type) {
         case MESSENGER_STATE_TYPE_NOSPAMKEYS:
+
             if (length == crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES + sizeof(uint32_t)) {
                 set_nospam(&(m->fr), *(uint32_t *)data);
                 load_keys(m->net_crypto, &data[sizeof(uint32_t)]);
@@ -2764,6 +2756,7 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
             break;
 
         case MESSENGER_STATE_TYPE_NAME:
+
             if ((length > 0) && (length < MAX_NAME_LENGTH)) {
                 setname(m, data, length);
             }
@@ -2771,6 +2764,7 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
             break;
 
         case MESSENGER_STATE_TYPE_STATUSMESSAGE:
+
             if ((length > 0) && (length < MAX_STATUSMESSAGE_LENGTH)) {
                 m_set_statusmessage(m, data, length);
             }
@@ -2778,6 +2772,7 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
             break;
 
         case MESSENGER_STATE_TYPE_STATUS:
+
             if (length == 1) {
                 m_set_userstatus(m, *data);
             }

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1878,7 +1878,7 @@ Messenger *new_messenger(uint8_t ipv6enabled)
         return NULL;
     }
 
-    friendreq_init(&(m->fr), m->onion_c);
+    friendreq_init(m, m->onion_c);
     LANdiscovery_init(m->dht);
     set_nospam(&(m->fr), random_int());
     set_filter_function(&(m->fr), &friend_already_added, m);

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -120,12 +120,13 @@ void new_nonce(uint8_t *nonce);
 
 #define MAX_CRYPTO_REQUEST_SIZE 1024
 
-#define CRYPTO_PACKET_FRIEND_REQ    32  /* Friend request crypto packet ID. */
-#define CRYPTO_PACKET_HARDENING     48  /* Hardening crypto packet ID. */
-#define CRYPTO_PACKET_NAT_PING      254 /* NAT ping crypto packet ID. */
-#define CRYPTO_PACKET_GROUP_CHAT_GET_NODES      48 /* Group chat get Nodes packet */
-#define CRYPTO_PACKET_GROUP_CHAT_SEND_NODES     49 /* Group chat send Nodes packet */
-#define CRYPTO_PACKET_GROUP_CHAT_BROADCAST      50 /* Group chat broadcast packet */
+#define CRYPTO_PACKET_FRIEND_REQ                32  /* Friend request crypto packet ID. */
+#define CRYPTO_PACKET_FRIEND_REQ_HASHDATA       33  /* Friend request for hashcash data */
+#define CRYPTO_PACKET_HARDENING                 48  /* Hardening crypto packet ID. */
+#define CRYPTO_PACKET_NAT_PING                  254 /* NAT ping crypto packet ID. */
+#define CRYPTO_PACKET_GROUP_CHAT_GET_NODES      48  /* Group chat get Nodes packet */
+#define CRYPTO_PACKET_GROUP_CHAT_SEND_NODES     49  /* Group chat send Nodes packet */
+#define CRYPTO_PACKET_GROUP_CHAT_BROADCAST      50  /* Group chat broadcast packet */
 
 /* Create a request to peer.
  * send_public_key and send_secret_key are the pub/secret keys of the sender.

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -30,13 +30,12 @@
 #include "util.h"
 
 //The hashdata will include our pubkey ++ the receiver's pubkey ++ the receiver's nospam_num ++ nNonce
-struct __attribute__((__packed__)) hashcash_s
-{
+struct __attribute__((__packed__)) hashcash_s {
     u8int sender_pubkey[crypto_box_PUBLICKEYBYTES];
     u8int receiver_pubkey[crypto_box_PUBLICKEYBYTES];
     u32int receiver_nospam_num;
     uint64 nNonce;
-}; 
+};
 
 inline bool hash_meets_target(u8int hash[static crypto_hash_sha256_BYTES])
 {
@@ -50,7 +49,7 @@ inline bool hash_meets_target(u8int hash[static crypto_hash_sha256_BYTES])
  *  return  0 if it sent the friend request directly to the friend.
  *  return the number of peers it was routed through if it did not send it directly.
  */
-int send_friendrequest(const Messenger *messenger, const Onion_Client *onion_c, const uint8_t *public_key, 
+int send_friendrequest(const Messenger *messenger, const Onion_Client *onion_c, const uint8_t *public_key,
                        uint32_t nospam_num, const uint8_t *data, uint32_t length)
 {
     if (length > MAX_FRIEND_REQUEST_DATA_SIZE || length == 0)
@@ -74,13 +73,13 @@ int send_friendrequest(const Messenger *messenger, const Onion_Client *onion_c, 
 
     //scan for a good hash
     u8int outhash[crypto_hash_sha256_BYTES];
-    for(;; hashdata.nNonce++)
-    {
+
+    for (;; hashdata.nNonce++) {
         //hash the hashdata
-        crypto_hash_sha256(outhash, (const u8int*)&hashdata, sizeof(struct hashcash_s));
+        crypto_hash_sha256(outhash, (const u8int *)&hashdata, sizeof(struct hashcash_s));
 
         //did it meet the target
-        if(hash_meets_target(outhash))
+        if (hash_meets_target(outhash))
             break;
 
         //increment the nNonce if did not meet the target
@@ -118,8 +117,8 @@ uint32_t get_nospam(const Friend_Requests *fr)
 
 
 /* Set the function that will be executed when a friend request is received. */
-void callback_friendrequest(Friend_Requests *fr, 
-                            void (*function)(void *, const uint8_t *, const uint8_t *, uint16_t, void *), 
+void callback_friendrequest(Friend_Requests *fr,
+                            void (*function)(void *, const uint8_t *, const uint8_t *, uint16_t, void *),
                             void *object, void *userdata)
 {
     fr->handle_friendrequest = function;
@@ -179,7 +178,7 @@ int remove_request_received(Friend_Requests *fr, const uint8_t *client_id)
     return -1;
 }
 
-static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, 
+static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey,
                                   const uint8_t *packet, uint32_t length)
 {
     Messenger *messenger = object;
@@ -223,9 +222,9 @@ static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey,
 
     //Hash and check if it meets the target
     u8int outhash[crypto_hash_sha256_BYTES];
-    crypto_hash_sha256(outhash, (const u8int*)&hashdata, sizeof(struct hashcash_s));
+    crypto_hash_sha256(outhash, (const u8int *)&hashdata, sizeof(struct hashcash_s));
 
-    if(!hash_meets_target(outhash))
+    if (!hash_meets_target(outhash))
         return 1;
 
     addto_receivedlist(fr, source_pubkey);
@@ -242,5 +241,5 @@ static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey,
 
 void friendreq_init(Messenger *messenger, Onion_Client *onion_c)
 {
-    oniondata_registerhandler(onion_c, CRYPTO_PACKET_FRIEND_REQ, &friendreq_handlepacket, messenger);    
+    oniondata_registerhandler(onion_c, CRYPTO_PACKET_FRIEND_REQ, &friendreq_handlepacket, messenger);
 }

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -26,7 +26,7 @@
 
 #include "onion_client.h"
 
-//Max data size - (1 (the identifing byte for the data) + sizeof(uint32_t) (the nospam_num) + 
+//Max data size - (1 (the identifing byte for the data) + sizeof(uint32_t) (the nospam_num) +
 // sizeof(uint64_t) (the nonce for the friend request hashcash))
 #define MAX_FRIEND_REQUEST_DATA_SIZE (ONION_CLIENT_MAX_DATA_SIZE - (1 + sizeof(uint32_t) + sizeof(uint64_t)))
 
@@ -54,7 +54,7 @@ typedef struct {
  * Maximum length of data is MAX_FRIEND_REQUEST_DATA_SIZE.
  */
 typedef struct Messenger Messenger;
-int send_friendrequest(const Messenger *messenger, const Onion_Client *onion_c, const uint8_t *public_key, 
+int send_friendrequest(const Messenger *messenger, const Onion_Client *onion_c, const uint8_t *public_key,
                        uint32_t nospam_num, const uint8_t *data, uint32_t length);
 
 /* Set and get the nospam variable used to prevent one type of friend request spam. */

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -54,7 +54,7 @@ typedef struct {
  * Maximum length of data is MAX_FRIEND_REQUEST_DATA_SIZE.
  */
 typedef struct Messenger Messenger;
-int send_friendrequest(const Messenger *m, const Onion_Client *onion_c, const uint8_t *public_key, 
+int send_friendrequest(const Messenger *messenger, const Onion_Client *onion_c, const uint8_t *public_key, 
                        uint32_t nospam_num, const uint8_t *data, uint32_t length);
 
 /* Set and get the nospam variable used to prevent one type of friend request spam. */
@@ -81,7 +81,7 @@ void callback_friendrequest(Friend_Requests *fr, void (*function)(void *, const 
 void set_filter_function(Friend_Requests *fr, int (*function)(const uint8_t *, void *), void *userdata);
 
 /* Sets up friendreq packet handlers. */
-void friendreq_init(Friend_Requests *fr, Onion_Client *onion_c);
+void friendreq_init(Messenger *messenger, Onion_Client *onion_c);
 
 
 #endif

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -26,7 +26,9 @@
 
 #include "onion_client.h"
 
-#define MAX_FRIEND_REQUEST_DATA_SIZE (ONION_CLIENT_MAX_DATA_SIZE - (1 + sizeof(uint32_t)))
+//Max data size - (1 (the identifing byte for the data) + sizeof(uint32_t) (the nospam_num) + 
+// sizeof(uint64_t) (the nonce for the friend request hashcash))
+#define MAX_FRIEND_REQUEST_DATA_SIZE (ONION_CLIENT_MAX_DATA_SIZE - (1 + sizeof(uint32_t) + sizeof(uint64_t)))
 
 typedef struct {
     uint32_t nospam;
@@ -51,8 +53,10 @@ typedef struct {
  * data is the data in the request and length is the length.
  * Maximum length of data is MAX_FRIEND_REQUEST_DATA_SIZE.
  */
-int send_friendrequest(const Onion_Client *onion_c, const uint8_t *public_key, uint32_t nospam_num, const uint8_t *data,
-                       uint32_t length);
+typedef struct Messenger Messenger;
+int send_friendrequest(const Messenger *m, const Onion_Client *onion_c, const uint8_t *public_key, 
+                       uint32_t nospam_num, const uint8_t *data, uint32_t length);
+
 /* Set and get the nospam variable used to prevent one type of friend request spam. */
 void set_nospam(Friend_Requests *fr, uint32_t num);
 uint32_t get_nospam(const Friend_Requests *fr);

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -804,13 +804,14 @@ int onion_addfriend(Onion_Client *onion_c, const uint8_t *client_id)
             return -1;
 
         index = onion_c->num_friends;
-        memset(&(onion_c->friends_list[onion_c->num_friends]), 0, sizeof(Onion_Friend));
+        memset(&(onion_c->friends_list[onion_c->num_friends]), 0x00, sizeof(Onion_Friend));
         ++onion_c->num_friends;
     }
 
     onion_c->friends_list[index].status = 1;
     memcpy(onion_c->friends_list[index].real_client_id, client_id, crypto_box_PUBLICKEYBYTES);
-    crypto_box_keypair(onion_c->friends_list[index].temp_public_key, onion_c->friends_list[index].temp_secret_key);
+    crypto_box_keypair(onion_c->friends_list[index].temp_public_key, 
+                       onion_c->friends_list[index].temp_secret_key);
     return index;
 }
 

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -89,8 +89,8 @@ typedef struct {
     uint64_t last_fakeid_dht_sent;
 
     uint64_t last_noreplay;
-
     uint64_t last_seen;
+    uint64_t last_nNonce; //the nonce for the hashcash in the friend requests once a valid hash is calculated
 
     Onion_Client_Paths onion_paths;
 

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -30,6 +30,17 @@
 
 #define inline__ inline __attribute__((always_inline))
 
+
+typedef unsigned long long  uint64;
+typedef          long long  int64;
+typedef unsigned int        u32int;
+typedef          int        s32int;
+typedef unsigned short      u16int;
+typedef          short      s16int;
+typedef unsigned char       u8int;
+typedef          char       s8int;
+
+
 void unix_time_update();
 uint64_t unix_time();
 int is_timeout(uint64_t timestamp, uint64_t timeout);


### PR DESCRIPTION
Implement a hashcash system that makes it harder for spammers to spam friend requests. Along with the nospam_num implementation, the hashcash proof of work requires the computer of the sender of the friend request to do work. This work is in the form of many sha256 hashes and stops until a valid hash is calculated. For non-spammer users, this work is negligible, < 1 sec, but for spammers, it is a massive setback.