### PR TITLE
Daily OS X fix.

### DIFF
--- a/testing/tox_shell.c
+++ b/testing/tox_shell.c
@@ -33,7 +33,11 @@
 #include "../toxcore/tox.h"
 #include "misc_tools.c"
 
+#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#include <util.h>
+#else
 #include <pty.h>
+#endif
 #include <unistd.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
Patch also fixes NetBSD and OpenBSD, but I can't test that.

<pty.h> is <util.h> on some BSDs.
