### PR TITLE
Instructions how to use ppa:v-2e/tox in Ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,6 +30,16 @@ Note: package fetching commands may vary by OS.
 
 On Ubuntu:
 
+There is an unofficial PPA for libsodium, libtox and uTox. It may be used as follows
+
+```bash
+sudo add-apt-repository ppa:v-2e/tox
+sudo apt-get update
+sudo apt-get install utox
+```
+
+To manually install Tox from the sources the following packages are needed
+
 ```bash
 sudo apt-get install build-essential libtool autotools-dev automake checkinstall check git yasm
 ```


### PR DESCRIPTION
I created an unofficial PPA for Ubuntu users. It contains libsodium, libtox and uTox packages for Ubuntu 14.04 LTS. The new versions may be added along with new Ubuntu releases.