### PR TITLE
Remove unused function in DHT.c

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -65,11 +65,6 @@
 /* Number of get node requests to send to quickly find close nodes. */
 #define MAX_BOOTSTRAP_TIMES 10
 
-Client_data *DHT_get_close_list(DHT *dht)
-{
-    return dht->close_clientlist;
-}
-
 /* Compares client_id1 and client_id2 with client_id.
  *
  *  return 0 if both are same distance.


### PR DESCRIPTION
This function is not part of the interface in DHT.h, and is not used anywhere in the repositery (as shown by "grep -r").
