### PR TITLE
mlock() secret keys

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -482,7 +482,7 @@ if (test "x$WIN32" != "xyes") && (test "x$MACH" != "xyes") && (test "x$DISABLE_R
 fi
 
 LOCK_FUNCS_FOUND="yes"
-AC_CHECK_FUNCS([mlock munlock posix_memalign], [], [LOCK_FUNCS_FOUND="no"; break])
+AC_CHECK_FUNCS([mlock munlock getpagesize posix_memalign], [], [LOCK_FUNCS_FOUND="no"; break])
 if test "x$LOCK_FUNCS_FOUND" != "xyes"; then
   AC_MSG_WARN([not all the functions required to lock memory out of swap were found])
 else

--- a/configure.ac
+++ b/configure.ac
@@ -481,6 +481,13 @@ if (test "x$WIN32" != "xyes") && (test "x$MACH" != "xyes") && (test "x$DISABLE_R
     )
 fi
 
+LOCK_FUNCS_FOUND="yes"
+AC_CHECK_FUNCS([mlock munlock posix_memalign], [], [LOCK_FUNCS_FOUND="no"; break])
+if test "x$LOCK_FUNCS_FOUND" != "xyes"; then
+  AC_MSG_WARN([not all the functions required to lock memory out of swap were found])
+else
+  AC_DEFINE([USE_MLOCK], [], [lock crypto instances out of swap space])
+fi
 
 AX_PTHREAD(
     [],

--- a/configure.ac
+++ b/configure.ac
@@ -482,7 +482,21 @@ if (test "x$WIN32" != "xyes") && (test "x$MACH" != "xyes") && (test "x$DISABLE_R
 fi
 
 LOCK_FUNCS_FOUND="yes"
-AC_CHECK_FUNCS([mlock munlock getpagesize posix_memalign], [], [LOCK_FUNCS_FOUND="no"; break])
+if test "x$WIN32" = "xyes"; then
+  AC_MSG_CHECKING(GetSystemInfo)
+  AC_TRY_LINK([#include <windows.h>], [SYSTEM_INFO si; GetSystemInfo(&si); return 0;], [AC_MSG_RESULT(yes)], [LOCK_FUNCS_FOUND="no"; AC_MSG_RESULT(no)])
+  AC_MSG_CHECKING(_aligned_malloc)
+  AC_TRY_LINK([#include <windows.h>], [void *addr = _aligned_malloc(1024, 1024); return 0;], [AC_MSG_RESULT(yes)], [LOCK_FUNCS_FOUND="no"; AC_MSG_RESULT(no)])
+  AC_MSG_CHECKING(VirtualLock and VirtualUnlock)
+  AC_TRY_LINK([#include <windows.h>],
+    [
+      VirtualLock((void*)0, 1024);
+      VirtualUnlock((void*)0, 1024);
+      return 0;
+    ], [AC_MSG_RESULT(yes)], [LOCK_FUNCS_FOUND="no"; AC_MSG_RESULT(no)])
+else
+  AC_CHECK_FUNCS([getpagesize posix_memalign mlock munlock], [], [LOCK_FUNCS_FOUND="no"; break])
+fi
 if test "x$LOCK_FUNCS_FOUND" != "xyes"; then
   AC_MSG_WARN([not all the functions required to lock memory out of swap were found])
 else

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2197,7 +2197,7 @@ DHT *new_DHT(Networking_Core *net)
         return NULL;
     }
 
-    dht->self_secret_key = locked_alloc(crypto_box_SECRETKEYBYTES);
+    dht->self_secret_key = alloc_secret();
     if (!dht->self_secret_key) {
       kill_DHT(dht);
       return NULL;
@@ -2257,10 +2257,8 @@ void do_DHT(DHT *dht)
 }
 void kill_DHT(DHT *dht)
 {
-    if (dht->self_secret_key) {
-      memset(dht->self_secret_key, 0, crypto_box_SECRETKEYBYTES);
-      locked_free(dht->self_secret_key);
-    }
+    if (dht->self_secret_key)
+      free_secret(dht->self_secret_key);
 #ifdef ENABLE_ASSOC_DHT
     kill_Assoc(dht->assoc);
 #endif

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2197,6 +2197,12 @@ DHT *new_DHT(Networking_Core *net)
         return NULL;
     }
 
+    dht->self_secret_key = locked_alloc(crypto_box_SECRETKEYBYTES);
+    if (!dht->self_secret_key) {
+      kill_DHT(dht);
+      return NULL;
+    }
+
     networking_registerhandler(dht->net, NET_PACKET_GET_NODES, &handle_getnodes, dht);
     networking_registerhandler(dht->net, NET_PACKET_SEND_NODES_IPV6, &handle_sendnodes_ipv6, dht);
     networking_registerhandler(dht->net, NET_PACKET_CRYPTO, &cryptopacket_handle, dht);
@@ -2251,6 +2257,10 @@ void do_DHT(DHT *dht)
 }
 void kill_DHT(DHT *dht)
 {
+    if (dht->self_secret_key) {
+      memset(dht->self_secret_key, 0, crypto_box_SECRETKEYBYTES);
+      locked_free(dht->self_secret_key);
+    }
 #ifdef ENABLE_ASSOC_DHT
     kill_Assoc(dht->assoc);
 #endif

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -194,8 +194,8 @@ typedef struct {
     /* Note: this key should not be/is not used to transmit any sensitive materials */
     uint8_t      secret_symmetric_key[crypto_box_KEYBYTES];
     /* DHT keypair */
-    uint8_t self_public_key[crypto_box_PUBLICKEYBYTES];
-    uint8_t self_secret_key[crypto_box_SECRETKEYBYTES];
+    uint8_t  self_public_key[crypto_box_PUBLICKEYBYTES];
+    uint8_t *self_secret_key;
 
     DHT_Friend    *friends_list;
     uint16_t       num_friends;

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -728,6 +728,13 @@ Group_Chat *new_groupchat(Networking_Core *net)
         return 0;
 
     Group_Chat *chat = calloc(1, sizeof(Group_Chat));
+    if (!chat)
+      return NULL;
+    chat->self_secret_key = locked_alloc(crypto_box_SECRETKEYBYTES);
+    if (!chat->self_secret_key) {
+      free(chat);
+      return NULL;
+    }
     chat->net = net;
     crypto_box_keypair(chat->self_public_key, chat->self_secret_key);
 
@@ -821,6 +828,8 @@ void kill_groupchat(Group_Chat *chat)
 {
     send_data(chat, 0, 0, GROUP_CHAT_QUIT);
     kill_Assoc(chat->assoc);
+    memset(chat->self_secret_key, 0, crypto_box_SECRETKEYBYTES);
+    locked_free(chat->self_secret_key);
     free(chat->group);
     free(chat);
 }

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -730,7 +730,7 @@ Group_Chat *new_groupchat(Networking_Core *net)
     Group_Chat *chat = calloc(1, sizeof(Group_Chat));
     if (!chat)
       return NULL;
-    chat->self_secret_key = locked_alloc(crypto_box_SECRETKEYBYTES);
+    chat->self_secret_key = alloc_secret();
     if (!chat->self_secret_key) {
       free(chat);
       return NULL;
@@ -828,8 +828,7 @@ void kill_groupchat(Group_Chat *chat)
 {
     send_data(chat, 0, 0, GROUP_CHAT_QUIT);
     kill_Assoc(chat->assoc);
-    memset(chat->self_secret_key, 0, crypto_box_SECRETKEYBYTES);
-    locked_free(chat->self_secret_key);
+    free_secret(chat->self_secret_key);
     free(chat->group);
     free(chat);
 }

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -55,7 +55,7 @@ typedef struct {
 typedef struct Group_Chat {
     Networking_Core *net;
     uint8_t     self_public_key[crypto_box_PUBLICKEYBYTES];
-    uint8_t     self_secret_key[crypto_box_SECRETKEYBYTES];
+    uint8_t    *self_secret_key;
 
     Group_Peer *group;
     Group_Close  close[GROUP_CLOSE_CONNECTIONS];

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2642,7 +2642,7 @@ Net_Crypto *new_net_crypto(DHT *dht, TCP_Proxy_Info *proxy_info)
     if (temp == NULL)
         return NULL;
 
-    temp->self_secret_key = locked_alloc(crypto_box_SECRETKEYBYTES);
+    temp->self_secret_key = alloc_secret();
     if (!temp->self_secret_key) {
       free(temp);
       return NULL;
@@ -2754,8 +2754,7 @@ void kill_net_crypto(Net_Crypto *c)
     networking_registerhandler(c->dht->net, NET_PACKET_COOKIE_RESPONSE, NULL, NULL);
     networking_registerhandler(c->dht->net, NET_PACKET_CRYPTO_HS, NULL, NULL);
     networking_registerhandler(c->dht->net, NET_PACKET_CRYPTO_DATA, NULL, NULL);
-    memset(c->self_secret_key, 0, crypto_box_SECRETKEYBYTES);
-    locked_free(c->self_secret_key);
+    free_secret(c->self_secret_key);
     memset(c, 0, sizeof(Net_Crypto));
     free(c);
 }

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -24,6 +24,10 @@
  *
  */
 
+#ifdef USE_MLOCK
+#include <sys/mman.h>
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2627,16 +2627,6 @@ void load_keys(Net_Crypto *c, const uint8_t *keys)
     memcpy(c->self_secret_key, keys + crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES);
 }
 
-/* Get the size of Net_Crypto padded to be a multiple of PAGESIZE
- */
-static size_t sizeof_locked_net_crypto(size_t pagesize)
-{
-  size_t over = sizeof(Net_Crypto) % pagesize;
-  if (over)
-    over = pagesize - over;
-  return sizeof(Net_Crypto) + over;
-}
-
 /* Run this to (re)initialize net_crypto.
  * Sets all the global connection variables to their default values.
  */

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -187,8 +187,8 @@ typedef struct {
     uint32_t crypto_connections_length; /* Length of connections array. */
 
     /* Our public and secret keys. */
-    uint8_t self_public_key[crypto_box_PUBLICKEYBYTES];
-    uint8_t self_secret_key[crypto_box_SECRETKEYBYTES];
+    uint8_t  self_public_key[crypto_box_PUBLICKEYBYTES];
+    uint8_t *self_secret_key;
 
     /* The secret key used for cookies */
     uint8_t secret_symmetric_key[crypto_box_KEYBYTES];

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -293,7 +293,7 @@ static Locked_Map *new_lockedmap()
     free(map);
     goto showerror;
   }
-  if (mlock_impl(map->address, mapsize) != 0) {
+  if (!mlock_impl(map->address, mapsize)) {
     delete_lockedmap(&map);
     goto showerror;
   }

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -244,11 +244,12 @@ static Locked_Map *new_lockedmap()
   if (!map)
     return NULL;
 
-  map->address = calloc(1, pagesize);
+  posix_memalign((void**)&map->address, pagesize, pagesize);
   if (!map->address) {
     delete_lockedmap(&map);
     return NULL;
   }
+  memset(map->address, 0, pagesize);
   if (mlock(map->address, pagesize) != 0) {
     delete_lockedmap(&map);
     return NULL;

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -60,10 +60,7 @@ void U32_to_bytes(uint8_t *dest, uint32_t value);
 void U16_to_bytes(uint8_t *dest, uint16_t value);
 
 /* Secret key allocation */
-void* locked_alloc(size_t bytes);
-/* Since this is not guaranteed to be implemented for every system, this does
- *  not take care of zeroing out the memory!
- */
-void  locked_free(void*);
+void* alloc_secret();
+void  free_secret(void*);
 
 #endif /* __UTIL_H__ */

--- a/toxcore/util.h
+++ b/toxcore/util.h
@@ -59,5 +59,11 @@ void U32_to_bytes(uint8_t *dest, uint32_t value);
 /* Convert uint16_t to byte string of size 2 */
 void U16_to_bytes(uint8_t *dest, uint16_t value);
 
+/* Secret key allocation */
+void* locked_alloc(size_t bytes);
+/* Since this is not guaranteed to be implemented for every system, this does
+ *  not take care of zeroing out the memory!
+ */
+void  locked_free(void*);
 
 #endif /* __UTIL_H__ */


### PR DESCRIPTION
Currently only on unix systms with `mlock`/`munlock` and `posix_memalign` (since `mlock` implementations are allowed to require the region to be page aligned).
Since I don't have a windows with any development environment setup, someone else has to do the windows `VirtualLock` equivalent unless I get excruciatingly bored.