### PR TITLE
Updated cross-compile instructions to include toxencryptsave

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -347,6 +347,7 @@ cd tmp
 $WINDOWS_TOOLCHAIN-ar x ../lib/libtoxcore.a
 $WINDOWS_TOOLCHAIN-ar x ../lib/libtoxav.a
 $WINDOWS_TOOLCHAIN-ar x ../lib/libtoxdns.a
+$WINDOWS_TOOLCHAIN-ar x ../lib/libtoxencryptsave.a
 $WINDOWS_TOOLCHAIN-gcc -Wl,--export-all-symbols -Wl,--out-implib=libtox.dll.a -shared -o libtox.dll *.o ../lib/*.a /usr/$WINDOWS_TOOLCHAIN/lib/libwinpthread.a -liphlpapi -lws2_32 -static-libgcc
 ```
 


### PR DESCRIPTION
Cross-compile instructions for Windows are essentially the same what Jenkins executes when building Windows dlls, just with different paths and using alternative commands.
Long story short -- when updating Windows dll job on Jenkins the cross-compile instructions should also be updated.
