### PR TITLE
ifdef out use of linux/limts.h in test_avatars

### DIFF
--- a/testing/test_avatars.c
+++ b/testing/test_avatars.c
@@ -47,7 +47,11 @@
 #include <unistd.h>
 #include <time.h>
 #include <stdbool.h>
+#ifdef __linux__
 #include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
 #include <sys/stat.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
This fixes building on OS X and other systems whose limits.hs have PATH_MAX.
