### PR TITLE
fix tox-bootstrapd's pidfile

### DIFF
--- a/other/bootstrap_daemon/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/tox-bootstrapd.c
@@ -618,7 +618,7 @@ int main(int argc, char *argv[])
     pid_t pid = fork();
 
     if (pid > 0) {
-        fprintf(pidf, "%d", pid);
+        fprintf(pidf, "%d\n", pid);
         fclose(pidf);
         syslog(LOG_DEBUG, "Forked successfully: PID: %d.\n", pid);
         return 0;


### PR DESCRIPTION
I created a systemd unit file to start `tox-bootstrapd`. `tox-bootstrapd` was started by systemd but ultimately would be killed.

The logs showed:

```
Oct 11 00:04:37 HOSTNAME tox-bootstrapd[22084]: Forked successfully: PID: 22085.
Oct 11 00:04:37 HOSTNAME tox-bootstrapd[22085]: Initialized LAN discovery.
Oct 11 00:04:37 HOSTNAME systemd[1]: Failed to read PID from file /run/tox-bootstrapd/tox-bootstrapd.pid: Invalid argument
Oct 11 00:04:37 HOSTNAME tox-bootstrapd[22085]: Connected to other bootstrap node successfully.
[unrelated stuff snipped]
Oct 11 00:06:07 HOSTNAME systemd[1]: tox-bootstrapd.service start operation timed out. Terminating.
```

The pidfile was being written, tox-bootstrapd was started, but systemd
wasn't "happy". Looking at the pidfile's contents I saw that it
contained the PID with a trailing space. I recompiled toxcore after
changing that space to a newline and after this systemd was happy.

```
* tox-bootstrapd.service - Tox bootstrap daemon
   Loaded: loaded (/lib/systemd/system/tox-bootstrapd.service; enabled)
   Active: active (running) since Sat 2014-10-11 00:15:39 UTC; 15min ago
  Process: 25343 ExecStart=/usr/sbin/tox-bootstrapd /etc/tox-bootstrapd.conf (code=exited, status=0/SUCCESS)
 Main PID: 25344 (tox-bootstrapd)
   CGroup: /system.slice/tox-bootstrapd.service
           `-25344 /usr/sbin/tox-bootstrapd /etc/tox-bootstrapd.conf
```
