### PR TITLE
re-implement copy_chatlist function

### DIFF
--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -1670,25 +1670,24 @@ uint32_t count_chatlist(Group_Chats *g_c)
  * Otherwise, returns the number of elements copied.
  * If the array was too small, the contents
  * of out_list will be truncated to list_size. */
-/*
-uint32_t copy_chatlist(const Messenger *m, int *out_list, uint32_t list_size)
+uint32_t copy_chatlist(Group_Chats *g_c, int32_t *out_list, uint32_t list_size)
 {
-    if (!out_list)
-        return 0;
-
-    if (m->numchats == 0) {
+    if (!out_list) {
         return 0;
     }
 
-    uint32_t i;
-    uint32_t ret = 0;
+    if (g_c->num_chats == 0) {
+        return 0;
+    }
 
-    for (i = 0; i < m->numchats; i++) {
+    uint32_t i, ret = 0;
+
+    for (i = 0; i < g_c->num_chats; ++i) {
         if (ret >= list_size) {
-            break; *//* Abandon ship *//*
+            break;  /* Abandon ship */
         }
 
-        if (m->chats[i]) {
+        if (g_c->chats[i].status > GROUPCHAT_STATUS_NONE) {
             out_list[ret] = i;
             ret++;
         }
@@ -1696,4 +1695,3 @@ uint32_t copy_chatlist(const Messenger *m, int *out_list, uint32_t list_size)
 
     return ret;
 }
-*/

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -214,6 +214,13 @@ int group_names(const Group_Chats *g_c, int groupnumber, uint8_t names[][MAX_NAM
  */
 uint32_t count_chatlist(Group_Chats *g_c);
 
+/* Copy a list of valid chat IDs into the array out_list.
+ * If out_list is NULL, returns 0.
+ * Otherwise, returns the number of elements copied.
+ * If the array was too small, the contents
+ * of out_list will be truncated to list_size. */
+uint32_t copy_chatlist(Group_Chats *g_c, int32_t *out_list, uint32_t list_size);
+
 /* Send current name (set in messenger) to all online groups.
  */
 void send_name_all_groups(Group_Chats *g_c);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -723,11 +723,10 @@ uint32_t tox_count_chatlist(const Tox *tox)
  * Otherwise, returns the number of elements copied.
  * If the array was too small, the contents
  * of out_list will be truncated to list_size. */
-uint32_t tox_get_chatlist(const Tox *tox, int *out_list, uint32_t list_size)
+uint32_t tox_get_chatlist(const Tox *tox, int32_t *out_list, uint32_t list_size)
 {
     const Messenger *m = tox;
-    //return copy_chatlist(m, out_list, list_size);
-    return 0;
+    return copy_chatlist(m->group_chat_object, out_list, list_size);
 }
 
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -537,7 +537,7 @@ uint32_t tox_count_chatlist(const Tox *tox);
  * Otherwise, returns the number of elements copied.
  * If the array was too small, the contents
  * of out_list will be truncated to list_size. */
-uint32_t tox_get_chatlist(const Tox *tox, int *out_list, uint32_t list_size);
+uint32_t tox_get_chatlist(const Tox *tox, int32_t *out_list, uint32_t list_size);
 
 /****************AVATAR FUNCTIONS*****************/
 


### PR DESCRIPTION
It turns out count_chatlist() and count_friendlist() are dangerous without their respective copy functions.
