### PR TITLE
Update to Libsodium 1.0.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,10 +59,10 @@ You should get and install [libsodium](https://github.com/jedisct1/libsodium):
 ```bash
 git clone git://github.com/jedisct1/libsodium.git
 cd libsodium
-git checkout tags/0.7.0
+git checkout tags/1.0.0
 ./autogen.sh
 ./configure && make check
-sudo checkinstall --install --pkgname libsodium --pkgversion 0.7.0 --nodoc
+sudo checkinstall --install --pkgname libsodium --pkgversion 1.0.0 --nodoc
 sudo ldconfig
 cd ..
 ```
@@ -74,7 +74,7 @@ this will install the libs to /usr/local/lib and the headers to /usr/local/inclu
 ```bash
 git clone git://github.com/jedisct1/libsodium.git
 cd libsodium
-git checkout tags/0.7.0
+git checkout tags/1.0.0
 ./autogen.sh
 ./configure
 make check
@@ -137,7 +137,7 @@ brew list libsodium
 
 Configure include and lib folder and build again:
 ```bash
-./configure --with-libsodium-headers=/usr/local/Cellar/libsodium/0.7.0/include/ --with-libsodium-libs=/usr/local/Cellar/libsodium/0.7.0/lib/
+./configure --with-libsodium-headers=/usr/local/Cellar/libsodium/1.0.0/include/ --with-libsodium-libs=/usr/local/Cellar/libsodium/1.0.0/lib/
 make
 make install
 ```
@@ -354,7 +354,7 @@ Now we will build sodium crypto library:
 ```bash
 git clone https://github.com/jedisct1/libsodium/
 cd libsodium
-git checkout tags/0.7.0
+git checkout tags/1.0.0
 ./autogen.sh
 ./configure --host="$WINDOWS_TOOLCHAIN" --prefix="$PREFIX_DIR" --disable-shared --enable-static
 make
@@ -409,10 +409,10 @@ When installing MinGW, make sure to select the MSYS option in the installer.
 MinGW will install an "MinGW shell" (you should get a shortcut for it), make sure to perform all operations (i.e., generating/running configure script, compiling, etc.) from the MinGW shell.
 
 First download the source tarball from https://download.libsodium.org/libsodium/releases/ and build it.
-Assuming that you got the libsodium-0.7.0.tar.gz release:
+Assuming that you got the libsodium-1.0.0.tar.gz release:
 ```cmd
-tar -zxvf libsodium-0.7.0.tar.gz
-cd libsodium-0.7.0
+tar -zxvf libsodium-1.0.0.tar.gz
+cd libsodium-1.0.0
 ./configure
 make
 make install
@@ -536,7 +536,7 @@ OS X homebrew:
 brew install libconfig
 ```
 OS X non-homebrew:
-Grab the following [package] (http://www.hyperrealm.com/libconfig/), uncompress and install
+Grab the following [package](http://www.hyperrealm.com/libconfig/), uncompress and install
 
 See this [readme](other/bootstrap_daemon/README.md) on how to set up the bootstrap daemon.
 


### PR DESCRIPTION
Since backward-compatibility is guaranteed through all the 1.x.y releases.
