### PR TITLE
Fix use-after-free of toxav's TimerHandler

### DIFF
--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -631,6 +631,7 @@ static void *timer_poll( void *arg )
         usleep(handler->resolution);
     }
 
+    free(handler);
     pthread_exit(NULL);
 }
 
@@ -699,8 +700,6 @@ static void timer_terminate_session(TimerHandler *handler)
     free(handler->timers);
 
     pthread_mutex_destroy( &handler->mutex );
-
-    free(handler);
 }
 
 /**


### PR DESCRIPTION
If msi.c:timer_terminate_session frees "handler", then when msi.c:timer_poll's thread resumes, there WILL be a use after free of "handler", with a likely segfault.

This use after free causes a crash in qTox, see tux3/qTox#534
