### PR TITLE
Allows tagging file transfers with MIME-type information

### DIFF
--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -92,7 +92,8 @@ uint8_t filenum;
 uint32_t file_accepted;
 uint64_t file_size;
 void file_request_accept(Tox *m, int friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename,
-                         uint16_t filename_length, void *userdata)
+                         uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length,
+                         void *userdata)
 {
     if (*((uint32_t *)userdata) != 974536)
         return;
@@ -308,7 +309,7 @@ START_TEST(test_few_clients)
     tox_callback_file_control(tox3, file_print_control, &to_compare);
     tox_callback_file_send_request(tox3, file_request_accept, &to_compare);
     uint64_t totalf_size = 100 * 1024 * 1024;
-    int fnum = tox_new_file_sender(tox2, 0, totalf_size, (uint8_t *)"Gentoo.exe", sizeof("Gentoo.exe"));
+    int fnum = tox_new_file_sender(tox2, 0, totalf_size, (uint8_t *)"Gentoo.exe", sizeof("Gentoo.exe"), NULL, 0);
     ck_assert_msg(fnum != -1, "tox_new_file_sender fail");
     int fpiece_size = tox_file_data_size(tox2, 0);
     uint8_t f_data[fpiece_size];

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -92,8 +92,7 @@ uint8_t filenum;
 uint32_t file_accepted;
 uint64_t file_size;
 void file_request_accept(Tox *m, int friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename,
-                         uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length,
-                         void *userdata)
+                         uint16_t filename_length, uint16_t type, void *userdata)
 {
     if (*((uint32_t *)userdata) != 974536)
         return;
@@ -309,7 +308,7 @@ START_TEST(test_few_clients)
     tox_callback_file_control(tox3, file_print_control, &to_compare);
     tox_callback_file_send_request(tox3, file_request_accept, &to_compare);
     uint64_t totalf_size = 100 * 1024 * 1024;
-    int fnum = tox_new_file_sender(tox2, 0, totalf_size, (uint8_t *)"Gentoo.exe", sizeof("Gentoo.exe"), NULL, 0);
+    int fnum = tox_new_file_sender(tox2, 0, totalf_size, (uint8_t *)"Gentoo.exe", sizeof("Gentoo.exe"), 0);
     ck_assert_msg(fnum != -1, "tox_new_file_sender fail");
     int fpiece_size = tox_file_data_size(tox2, 0);
     uint8_t f_data[fpiece_size];

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -161,7 +161,7 @@ int add_filesender(Tox *m, uint16_t friendnum, char *filename)
     fseek(tempfile, 0, SEEK_END);
     uint64_t filesize = ftell(tempfile);
     fseek(tempfile, 0, SEEK_SET);
-    int filenum = tox_new_file_sender(m, friendnum, filesize, (uint8_t *)filename, strlen(filename) + 1, NULL, 0);
+    int filenum = tox_new_file_sender(m, friendnum, filesize, (uint8_t *)filename, strlen(filename) + 1, 0);
 
     if (filenum == -1)
         return -1;
@@ -1120,8 +1120,7 @@ void print_groupnamelistchange(Tox *m, int groupnumber, int peernumber, uint8_t 
     }
 }
 void file_request_accept(Tox *m, int friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename,
-                         uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length,
-                         void *userdata)
+                         uint16_t filename_length, uint16_t type, void *userdata)
 {
     char msg[512];
     sprintf(msg, "[t] %u is sending us: %s of size %llu", friendnumber, filename, (long long unsigned int)filesize);

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -161,7 +161,7 @@ int add_filesender(Tox *m, uint16_t friendnum, char *filename)
     fseek(tempfile, 0, SEEK_END);
     uint64_t filesize = ftell(tempfile);
     fseek(tempfile, 0, SEEK_SET);
-    int filenum = tox_new_file_sender(m, friendnum, filesize, (uint8_t *)filename, strlen(filename) + 1);
+    int filenum = tox_new_file_sender(m, friendnum, filesize, (uint8_t *)filename, strlen(filename) + 1, NULL, 0);
 
     if (filenum == -1)
         return -1;
@@ -1120,7 +1120,8 @@ void print_groupnamelistchange(Tox *m, int groupnumber, int peernumber, uint8_t 
     }
 }
 void file_request_accept(Tox *m, int friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename,
-                         uint16_t filename_length, void *userdata)
+                         uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length,
+                         void *userdata)
 {
     char msg[512];
     sprintf(msg, "[t] %u is sending us: %s of size %llu", friendnumber, filename, (long long unsigned int)filesize);

--- a/testing/tox_sync.c
+++ b/testing/tox_sync.c
@@ -92,7 +92,7 @@ int add_filesender(Tox *m, uint16_t friendnum, char *filename)
     fseek(tempfile, 0, SEEK_END);
     uint64_t filesize = ftell(tempfile);
     fseek(tempfile, 0, SEEK_SET);
-    int filenum = tox_new_file_sender(m, friendnum, filesize, (uint8_t *)filename, strlen(filename) + 1, NULL, 0);
+    int filenum = tox_new_file_sender(m, friendnum, filesize, (uint8_t *)filename, strlen(filename) + 1, 0);
 
     if (filenum == -1)
         return -1;
@@ -131,8 +131,7 @@ int not_sending()
 static char path[1024];
 
 void file_request_accept(Tox *m, int friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename,
-                         uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length,
-                         void *userdata)
+                         uint16_t filename_length, uint8_t type, void *userdata)
 {
     char fullpath[1024];
     uint32_t i;

--- a/testing/tox_sync.c
+++ b/testing/tox_sync.c
@@ -92,7 +92,7 @@ int add_filesender(Tox *m, uint16_t friendnum, char *filename)
     fseek(tempfile, 0, SEEK_END);
     uint64_t filesize = ftell(tempfile);
     fseek(tempfile, 0, SEEK_SET);
-    int filenum = tox_new_file_sender(m, friendnum, filesize, (uint8_t *)filename, strlen(filename) + 1);
+    int filenum = tox_new_file_sender(m, friendnum, filesize, (uint8_t *)filename, strlen(filename) + 1, NULL, 0);
 
     if (filenum == -1)
         return -1;
@@ -131,7 +131,8 @@ int not_sending()
 static char path[1024];
 
 void file_request_accept(Tox *m, int friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename,
-                         uint16_t filename_length, void *userdata)
+                         uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length,
+                         void *userdata)
 {
     char fullpath[1024];
     uint32_t i;

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -190,6 +190,12 @@ enum {
     FILECONTROL_RESUME_BROKEN
 };
 
+enum {
+    FILETYPE_NONE = 0,
+    FILETYPE_AUDIO_CLIP // maybe we should specify raw audio only or something?
+    // , FILETYPE_STICKER // TODO
+};
+
 typedef struct {
     uint8_t client_id[crypto_box_PUBLICKEYBYTES];
     int friendcon_id;
@@ -300,7 +306,7 @@ typedef struct Messenger {
     void (*group_invite)(struct Messenger *m, int32_t, const uint8_t *, uint16_t);
     void (*group_message)(struct Messenger *m, int32_t, const uint8_t *, uint16_t);
 
-    void (*file_sendrequest)(struct Messenger *m, int32_t, uint8_t, uint64_t, const uint8_t *, uint16_t, const uint8_t *, uint16_t, void *);
+    void (*file_sendrequest)(struct Messenger *m, int32_t, uint8_t, uint64_t, const uint8_t *, uint16_t, uint8_t, void *);
     void *file_sendrequest_userdata;
     void (*file_filecontrol)(struct Messenger *m, int32_t, uint8_t, uint8_t, uint8_t, const uint8_t *, uint16_t, void *);
     void *file_filecontrol_userdata;
@@ -756,10 +762,10 @@ int send_group_invite_packet(const Messenger *m, int32_t friendnumber, const uin
 
 /* Set the callback for file send requests.
  *
- *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, uint8_t *filename, uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length, void *userdata)
+ *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, uint8_t *filename, uint16_t filename_length, uint8_t type, void *userdata)
  */
 void callback_file_sendrequest(Messenger *m, void (*function)(Messenger *m, int32_t, uint8_t, uint64_t, const uint8_t *,
-                               uint16_t, const uint8_t *, uint16_t, void *), void *userdata);
+                               uint16_t, uint8_t, void *), void *userdata);
 
 /* Set the callback for file control requests.
  *
@@ -779,21 +785,19 @@ void callback_file_data(Messenger *m, void (*function)(Messenger *m, int32_t, ui
 
 /* Send a file send request.
  * Maximum filename length is 255 bytes.
- * Maximum mimetype length is 255 bytes.
  *  return 1 on success
  *  return 0 on failure
  */
 int file_sendrequest(const Messenger *m, int32_t friendnumber, uint8_t filenumber, uint64_t filesize,
-                     const uint8_t *filename, uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length);
+                     const uint8_t *filename, uint16_t filename_length, uint8_t type);
 
 /* Send a file send request.
  * Maximum filename length is 255 bytes.
- * Maximum mime type length is 255 bytes.
  *  return file number on success
  *  return -1 on failure
  */
 int new_filesender(const Messenger *m, int32_t friendnumber, uint64_t filesize, const uint8_t *filename,
-                   uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length);
+                   uint16_t filename_length, uint8_t type);
 
 /* Send a file control request.
  * send_receive is 0 if we want the control packet to target a sending file, 1 if it targets a receiving file.

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -56,9 +56,10 @@
 #define PACKET_ID_MESSAGE 64
 #define PACKET_ID_ACTION 65
 #define PACKET_ID_MSI 69
-#define PACKET_ID_FILE_SENDREQUEST 80
+/* Packet number 80 was the old file send request. Should not be used for a while */
 #define PACKET_ID_FILE_CONTROL 81
 #define PACKET_ID_FILE_DATA 82
+#define PACKET_ID_FILE_SENDREQUEST 83
 #define PACKET_ID_INVITE_GROUPCHAT 96
 #define PACKET_ID_ONLINE_PACKET 97
 #define PACKET_ID_DIRECT_GROUPCHAT 98
@@ -299,7 +300,7 @@ typedef struct Messenger {
     void (*group_invite)(struct Messenger *m, int32_t, const uint8_t *, uint16_t);
     void (*group_message)(struct Messenger *m, int32_t, const uint8_t *, uint16_t);
 
-    void (*file_sendrequest)(struct Messenger *m, int32_t, uint8_t, uint64_t, const uint8_t *, uint16_t, void *);
+    void (*file_sendrequest)(struct Messenger *m, int32_t, uint8_t, uint64_t, const uint8_t *, uint16_t, const uint8_t *, uint16_t, void *);
     void *file_sendrequest_userdata;
     void (*file_filecontrol)(struct Messenger *m, int32_t, uint8_t, uint8_t, uint8_t, const uint8_t *, uint16_t, void *);
     void *file_filecontrol_userdata;
@@ -755,10 +756,10 @@ int send_group_invite_packet(const Messenger *m, int32_t friendnumber, const uin
 
 /* Set the callback for file send requests.
  *
- *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, uint8_t *filename, uint16_t filename_length, void *userdata)
+ *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, uint8_t *filename, uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length, void *userdata)
  */
 void callback_file_sendrequest(Messenger *m, void (*function)(Messenger *m, int32_t, uint8_t, uint64_t, const uint8_t *,
-                               uint16_t, void *), void *userdata);
+                               uint16_t, const uint8_t *, uint16_t, void *), void *userdata);
 
 /* Set the callback for file control requests.
  *
@@ -778,19 +779,21 @@ void callback_file_data(Messenger *m, void (*function)(Messenger *m, int32_t, ui
 
 /* Send a file send request.
  * Maximum filename length is 255 bytes.
+ * Maximum mimetype length is 255 bytes.
  *  return 1 on success
  *  return 0 on failure
  */
 int file_sendrequest(const Messenger *m, int32_t friendnumber, uint8_t filenumber, uint64_t filesize,
-                     const uint8_t *filename, uint16_t filename_length);
+                     const uint8_t *filename, uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length);
 
 /* Send a file send request.
  * Maximum filename length is 255 bytes.
+ * Maximum mime type length is 255 bytes.
  *  return file number on success
  *  return -1 on failure
  */
 int new_filesender(const Messenger *m, int32_t friendnumber, uint64_t filesize, const uint8_t *filename,
-                   uint16_t filename_length);
+                   uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length);
 
 /* Send a file control request.
  * send_receive is 0 if we want the control packet to target a sending file, 1 if it targets a receiving file.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -734,10 +734,10 @@ uint32_t tox_get_chatlist(const Tox *tox, int32_t *out_list, uint32_t list_size)
 
 /* Set the callback for file send requests.
  *
- *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, uint8_t *filename, uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length, void *userdata)
+ *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, uint8_t *filename, uint16_t filename_length, uint8_t type, void *userdata)
  */
 void tox_callback_file_send_request(Tox *tox, void (*function)(Messenger *tox, int32_t, uint8_t, uint64_t,
-                                    const uint8_t *, uint16_t, const uint8_t *, uint16_t, void *), void *userdata)
+                                    const uint8_t *, uint16_t, uint8_t, void *), void *userdata)
 {
     Messenger *m = tox;
     callback_file_sendrequest(m, function, userdata);
@@ -767,15 +767,14 @@ void tox_callback_file_data(Tox *tox, void (*function)(Messenger *tox, int32_t, 
 }
 /* Send a file send request.
  * Maximum filename length is 255 bytes.
- * Maximum mime type length is 255 bytes.
  *  return file number on success
  *  return -1 on failure
  */
 int tox_new_file_sender(Tox *tox, int32_t friendnumber, uint64_t filesize, const uint8_t *filename,
-                        uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length)
+                        uint16_t filename_length, uint8_t type)
 {
     Messenger *m = tox;
-    return new_filesender(m, friendnumber, filesize, filename, filename_length, mimetype, mimetype_length);
+    return new_filesender(m, friendnumber, filesize, filename, filename_length, type);
 }
 /* Send a file control request.
  * send_receive is 0 if we want the control packet to target a sending file, 1 if it targets a receiving file.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -734,10 +734,10 @@ uint32_t tox_get_chatlist(const Tox *tox, int32_t *out_list, uint32_t list_size)
 
 /* Set the callback for file send requests.
  *
- *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, uint8_t *filename, uint16_t filename_length, void *userdata)
+ *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, uint8_t *filename, uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length, void *userdata)
  */
 void tox_callback_file_send_request(Tox *tox, void (*function)(Messenger *tox, int32_t, uint8_t, uint64_t,
-                                    const uint8_t *, uint16_t, void *), void *userdata)
+                                    const uint8_t *, uint16_t, const uint8_t *, uint16_t, void *), void *userdata)
 {
     Messenger *m = tox;
     callback_file_sendrequest(m, function, userdata);
@@ -767,14 +767,15 @@ void tox_callback_file_data(Tox *tox, void (*function)(Messenger *tox, int32_t, 
 }
 /* Send a file send request.
  * Maximum filename length is 255 bytes.
+ * Maximum mime type length is 255 bytes.
  *  return file number on success
  *  return -1 on failure
  */
 int tox_new_file_sender(Tox *tox, int32_t friendnumber, uint64_t filesize, const uint8_t *filename,
-                        uint16_t filename_length)
+                        uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length)
 {
     Messenger *m = tox;
-    return new_filesender(m, friendnumber, filesize, filename, filename_length);
+    return new_filesender(m, friendnumber, filesize, filename, filename_length, mimetype, mimetype_length);
 }
 /* Send a file control request.
  * send_receive is 0 if we want the control packet to target a sending file, 1 if it targets a receiving file.

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -724,10 +724,10 @@ enum {
 };
 /* Set the callback for file send requests.
  *
- *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename, uint16_t filename_length, void *userdata)
+ *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename, uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length, void *userdata)
  */
 void tox_callback_file_send_request(Tox *tox, void (*function)(Tox *m, int32_t, uint8_t, uint64_t, const uint8_t *,
-                                    uint16_t, void *), void *userdata);
+                                    uint16_t, const uint8_t *, uint16_t, void *), void *userdata);
 
 /* Set the callback for file control requests.
  *
@@ -751,11 +751,12 @@ void tox_callback_file_data(Tox *tox, void (*function)(Tox *m, int32_t, uint8_t,
 
 /* Send a file send request.
  * Maximum filename length is 255 bytes.
+ * Maximum mime type length is 255 bytes.
  *  return file number on success
  *  return -1 on failure
  */
 int tox_new_file_sender(Tox *tox, int32_t friendnumber, uint64_t filesize, const uint8_t *filename,
-                        uint16_t filename_length);
+                        uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length);
 
 /* Send a file control request.
  *

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -722,12 +722,19 @@ enum {
     TOX_FILECONTROL_FINISHED,
     TOX_FILECONTROL_RESUME_BROKEN
 };
+
+enum {
+    TOX_FILETYPE_NONE = 0, // standard file, ask user where to save
+    TOX_FILETYPE_AUDIO_CLIP // maybe we should specify raw audio only or something?
+    // , FILETYPE_STICKER // TODO
+};
+
 /* Set the callback for file send requests.
  *
- *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename, uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length, void *userdata)
+ *  Function(Tox *tox, int32_t friendnumber, uint8_t filenumber, uint64_t filesize, const uint8_t *filename, uint16_t filename_length, uint8_t type, void *userdata)
  */
 void tox_callback_file_send_request(Tox *tox, void (*function)(Tox *m, int32_t, uint8_t, uint64_t, const uint8_t *,
-                                    uint16_t, const uint8_t *, uint16_t, void *), void *userdata);
+                                    uint16_t, uint8_t, void *), void *userdata);
 
 /* Set the callback for file control requests.
  *
@@ -751,12 +758,11 @@ void tox_callback_file_data(Tox *tox, void (*function)(Tox *m, int32_t, uint8_t,
 
 /* Send a file send request.
  * Maximum filename length is 255 bytes.
- * Maximum mime type length is 255 bytes.
  *  return file number on success
  *  return -1 on failure
  */
 int tox_new_file_sender(Tox *tox, int32_t friendnumber, uint64_t filesize, const uint8_t *filename,
-                        uint16_t filename_length, const uint8_t *mimetype, uint16_t mimetype_length);
+                        uint16_t filename_length, uint8_t type);
 
 /* Send a file control request.
  *


### PR DESCRIPTION
To start with, **this change breaks both the API and the file transfer protocol**

Rationale:  To implement this feature, it was necessary to change the format of the file send request and the related API calls and callbacks. It would be easy to avoid the breakage by aliasing the old packet IDs and API calls to the new ones, but this would create some bloat in the library and in the protocol. As we are alpha, I suppose it's better break the protocol and keep the things elegant. An input from the Tox developer community is required here and, ideally, code should be readied to fix this in the major clients before this branch is merged (If there is interest on this, I'm ready to submit fixes to uTox and Toxic).




This commit adds support for tagging file transfers with MIME type information, as proposed in issue #1084, allowing clients to implement some features which need reliable background transfer of arbitrary data. This effectively creates a RPC sub-protocol in Tox, with all features and options defined at client level and without more changes to the Tox core protocol. Typical applications are support for WhatsApp-like voice clips (issue #1080), better handling of inline images, and customized stickers (issue #1106). Other applications may include automatic synchronization of node lists, etc.

For this feature be useful, client developers must agree in some standardized MIME types, which rules should be applied, and how to handle unsupported message types. For example, Speex-encoded short audio messages may be send as a file transfer tagged with the type "message/x-tox-short-message-speex" and the client may accept it automatically if they come from authorized friends and are within some limits (e.g. each friend can send up to x messages of at most y KB each).

Ideally, receiving clients should reject ANY file transfer tagged with "message/x-tox-*" unless they support that specific feature and sending clients should behave accordingly (e.g. showing the error message "Your friend's client does not accept recorded audio messages" instead of "File transfer rejected").
