### PR TITLE
group peer identification

### DIFF
--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -727,6 +727,31 @@ int group_peername(const Group_Chats *g_c, int groupnumber, int peernumber, uint
     return g->group[peernumber].nick_len;
 }
 
+/* Get a unique* integer to describe the peer. It is deterministically derived from
+ * the peer's Tox ID public key.
+ * *Unique here means several billion possible numbers per person on Earth. While
+ * "not as unique" as the full Tox ID, it is more convenient for group chat purposes.
+ *
+ * returns 0 on failure
+ */
+uint64_t group_peer_unique_num(const Group_Chats *g_c, int groupnumber, int peernumber)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g)
+        return 0;
+
+    if ((uint32_t)peernumber >= g->numpeers)
+        return 0;
+
+    uint64_t out = 0;
+    int i = 0;
+    while (i < 8)
+        out = (out << 8) | g->group[peernumber].real_pk[i++];
+
+    return out;
+}
+
 /* List all the peers in the group chat.
  *
  * Copies the names of the peers to the name[length][MAX_NAME_LENGTH] array.

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -175,6 +175,15 @@ int del_groupchat(Group_Chats *g_c, int groupnumber);
  */
 int group_peername(const Group_Chats *g_c, int groupnumber, int peernumber, uint8_t *name);
 
+/* Get a unique* integer to describe the peer. It is deterministically derived from
+ * the peer's Tox ID public key.
+ * *Unique here means several billion possible numbers per person on Earth. While
+ * "not as unique" as the full Tox ID, it is more convenient for group chat purposes.
+ *
+ * returns 0 on failure
+ */
+uint64_t group_peer_unique_num(const Group_Chats *g_c, int groupnumber, int peernumber);
+
 /* invite friendnumber to groupnumber
  * return 0 on success
  * return -1 on failure

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -641,6 +641,19 @@ int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t 
     return group_peername(m->group_chat_object, groupnumber, peernumber, name);
 }
 
+/* Get a unique* integer to describe the peer. It is deterministically derived from
+ * the peer's Tox ID public key.
+ * *Unique here means several billion possible numbers per person on Earth. While
+ * "not as unique" as the full Tox ID, it is more convenient for group chat purposes.
+ *
+ * returns 0 on failure
+ */
+uint64_t tox_group_peer_unique_num(const Tox *tox, int groupnumber, int peernumber)
+{
+    const Messenger *m = tox;
+    return group_peer_unique_num(m->group_chat_object, groupnumber, peernumber);
+}
+
 /* invite friendnumber to groupnumber
  * return 0 on success
  * return -1 on failure

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -484,6 +484,15 @@ int tox_del_groupchat(Tox *tox, int groupnumber);
  */
 int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t *name);
 
+/* Get a unique* integer to describe the peer. It is deterministically derived from
+ * the peer's Tox ID public key.
+ * *Unique here means several billion possible numbers per person on Earth. While
+ * "not as unique" as the full Tox ID, it is more convenient for group chat purposes.
+ *
+ * returns 0 on failure
+ */
+uint64_t tox_group_peer_unique_num(const Tox *tox, int groupnumber, int peernumber);
+
 /* invite friendnumber to groupnumber
  * return 0 on success
  * return -1 on failure


### PR DESCRIPTION
clients can get group peer pub key (sorta, enough for identing messages), as requested by @tux3 

It's built off of the titles branch, since that will be merged
