### PR TITLE
Group peer friend requests

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -31,7 +31,6 @@
 
 #include "logger.h"
 #include "Messenger.h"
-#include "group.h"
 #include "assoc.h"
 #include "network.h"
 #include "util.h"
@@ -187,6 +186,63 @@ static int handle_status(void *object, int i, uint8_t status);
 static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len);
 static int handle_custom_lossy_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length);
 
+/* This is used by the various add_friend functions to init the friend obj
+ *
+ * returns friendnum on success
+ * returns -1 or FAERR_NOMEM or FAERR_UNKNOWN, as m_addfriend does/used to do
+ */
+int32_t init_new_friend(Messenger *m, const uint8_t *client_id)
+{
+    /* Resize the friend list if necessary. */
+    if (realloc_friendlist(m, m->numfriends + 1) != 0)
+        return FAERR_NOMEM;
+
+    memset(&(m->friendlist[m->numfriends]), 0, sizeof(Friend));
+
+    int friendcon_id = new_friend_connection(m->fr_c, client_id);
+
+    if (friendcon_id == -1)
+        return -1;
+
+    int32_t i;
+
+    for (i = 0; i <= m->numfriends; ++i)  {
+        if (m->friendlist[i].status == NOFRIEND) {
+            m->friendlist[i].status = FRIEND_ADDED;
+            m->friendlist[i].friendcon_id = friendcon_id;
+            m->friendlist[i].friendrequest_lastsent = 0;
+            m->friendlist[i].friendrequest_timeout = FRIENDREQUEST_TIMEOUT;
+            id_copy(m->friendlist[i].client_id, client_id);
+            m->friendlist[i].statusmessage = calloc(1, 1);
+            m->friendlist[i].statusmessage_length = 1;
+            m->friendlist[i].userstatus = USERSTATUS_NONE;
+            m->friendlist[i].avatar_info_sent = 0;
+            m->friendlist[i].avatar_recv_data = NULL;
+            m->friendlist[i].avatar_send_data.bytes_sent = 0;
+            m->friendlist[i].avatar_send_data.last_reset = 0;
+            m->friendlist[i].is_typing = 0;
+            m->friendlist[i].message_id = 0;
+            m->friendlist[i].receives_read_receipts = 1; /* Default: YES. */
+            m->friendlist[i].friendrequest_nospam = 0;
+            m->friendlist[i].groupnumber = -1;
+            m->friendlist[i].peerindex = -1;
+            friend_connection_callbacks(m->fr_c, friendcon_id, MESSENGER_CALLBACK_INDEX, &handle_status, &handle_packet,
+                                        &handle_custom_lossy_packet, m, i);
+
+            if (m->numfriends == i)
+                ++m->numfriends;
+
+            if (friend_con_connected(m->fr_c, friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
+                send_online_packet(m, i);
+            }
+
+            return i;
+        }
+    }
+
+    return FAERR_UNKNOWN;
+}
+
 /*
  * Add a friend.
  * Set the data that will be sent along with friend request.
@@ -243,139 +299,15 @@ int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, u
         return FAERR_SETNEWNOSPAM;
     }
 
-    /* Resize the friend list if necessary. */
-    if (realloc_friendlist(m, m->numfriends + 1) != 0)
-        return FAERR_NOMEM;
+    int32_t friendnumber = init_new_friend(m, client_id);
 
-    memset(&(m->friendlist[m->numfriends]), 0, sizeof(Friend));
-
-    int friendcon_id = new_friend_connection(m->fr_c, client_id);
-
-    if (friendcon_id == -1)
-        return -1;
-
-    uint32_t i;
-
-    for (i = 0; i <= m->numfriends; ++i)  {
-        if (m->friendlist[i].status == NOFRIEND) {
-            m->friendlist[i].status = FRIEND_ADDED;
-            m->friendlist[i].friendcon_id = friendcon_id;
-            m->friendlist[i].friendrequest_lastsent = 0;
-            m->friendlist[i].friendrequest_timeout = FRIENDREQUEST_TIMEOUT;
-            id_copy(m->friendlist[i].client_id, client_id);
-            m->friendlist[i].statusmessage = calloc(1, 1);
-            m->friendlist[i].statusmessage_length = 1;
-            m->friendlist[i].userstatus = USERSTATUS_NONE;
-            m->friendlist[i].avatar_info_sent = 0;
-            m->friendlist[i].avatar_recv_data = NULL;
-            m->friendlist[i].avatar_send_data.bytes_sent = 0;
-            m->friendlist[i].avatar_send_data.last_reset = 0;
-            m->friendlist[i].is_typing = 0;
-            memcpy(m->friendlist[i].info, data, length);
-            m->friendlist[i].info_size = length;
-            m->friendlist[i].message_id = 0;
-            m->friendlist[i].receives_read_receipts = 1; /* Default: YES. */
-            memcpy(&(m->friendlist[i].friendrequest_nospam), address + crypto_box_PUBLICKEYBYTES, sizeof(uint32_t));
-            friend_connection_callbacks(m->fr_c, friendcon_id, MESSENGER_CALLBACK_INDEX, &handle_status, &handle_packet,
-                                        &handle_custom_lossy_packet, m, i);
-
-            if (m->numfriends == i)
-                ++m->numfriends;
-
-            if (friend_con_connected(m->fr_c, friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
-                send_online_packet(m, i);
-            }
-
-            return i;
-        }
+    if (friendnumber >= 0) {
+        memcpy(&(m->friendlist[friendnumber].friendrequest_nospam), address + crypto_box_PUBLICKEYBYTES, sizeof(uint32_t));
+        memcpy(m->friendlist[friendnumber].info, data, length);
+        m->friendlist[friendnumber].info_size = length;
     }
 
-    return FAERR_UNKNOWN;
-}
-
-/*
- * Add a groupchat peer as a friend.
- * Set the data that will be sent along with friend request.
- * data is the data and length is the length.
- *
- *  return the friend number if success.
- *  returns the same errors as m_addfriend on error
- */
-int32_t m_add_group_peer_friend(Messenger *m, int groupnumber, int peerindex, const uint8_t *data, uint16_t length)
-{
-    if (length > MAX_FRIEND_REQUEST_DATA_SIZE)
-        return FAERR_TOOLONG;
-
-    Group_c *g = get_group_c(m->group_chat_object, groupnumber);
-
-    uint8_t client_id[crypto_box_PUBLICKEYBYTES];
-    id_copy(client_id, g->group[peerindex].real_pk);
-
-    if (!public_key_valid(client_id))
-        return FAERR_BADCHECKSUM;
-
-    if (length < 1)
-        return FAERR_NOMESSAGE;
-
-    if (id_equal(client_id, m->net_crypto->self_public_key))
-        return FAERR_OWNKEY;
-
-    int32_t friend_id = getfriend_id(m, client_id);
-
-    if (friend_id != -1) {
-        return FAERR_ALREADYSENT;
-    }
-
-    /* Resize the friend list if necessary. */
-    if (realloc_friendlist(m, m->numfriends + 1) != 0)
-        return FAERR_NOMEM;
-
-    memset(&(m->friendlist[m->numfriends]), 0, sizeof(Friend));
-
-    int friendcon_id = new_friend_connection(m->fr_c, client_id);
-
-    if (friendcon_id == -1)
-        return -1;
-
-    uint32_t i;
-
-    for (i = 0; i <= m->numfriends; ++i)  {
-        if (m->friendlist[i].status == NOFRIEND) {
-            m->friendlist[i].status = FRIEND_ADDED;
-            m->friendlist[i].friendcon_id = friendcon_id;
-            m->friendlist[i].friendrequest_lastsent = 0;
-            m->friendlist[i].friendrequest_timeout = FRIENDREQUEST_TIMEOUT;
-            id_copy(m->friendlist[i].client_id, client_id);
-            m->friendlist[i].statusmessage = calloc(1, 1);
-            m->friendlist[i].statusmessage_length = 1;
-            m->friendlist[i].userstatus = USERSTATUS_NONE;
-            m->friendlist[i].avatar_info_sent = 0;
-            m->friendlist[i].avatar_recv_data = NULL;
-            m->friendlist[i].avatar_send_data.bytes_sent = 0;
-            m->friendlist[i].avatar_send_data.last_reset = 0;
-            m->friendlist[i].is_typing = 0;
-            memcpy(m->friendlist[i].info, data, length);
-            m->friendlist[i].info_size = length;
-            m->friendlist[i].message_id = 0;
-            m->friendlist[i].receives_read_receipts = 1; /* Default: YES. */
-            m->friendlist[i].friendrequest_nospam = 0;
-            m->friendlist[i].groupnumber = groupnumber;
-            m->friendlist[i].peerindex = peerindex;
-            friend_connection_callbacks(m->fr_c, friendcon_id, MESSENGER_CALLBACK_INDEX, &handle_status, &handle_packet,
-                                        &handle_custom_lossy_packet, m, i);
-
-            if (m->numfriends == i)
-                ++m->numfriends;
-
-            if (friend_con_connected(m->fr_c, friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
-                send_online_packet(m, i);
-            }
-
-            return i;
-        }
-    }
-
-    return FAERR_UNKNOWN;
+    return friendnumber;
 }
 
 int32_t m_addfriend_norequest(Messenger *m, const uint8_t *client_id)
@@ -386,53 +318,16 @@ int32_t m_addfriend_norequest(Messenger *m, const uint8_t *client_id)
     if (!public_key_valid(client_id))
         return -1;
 
-    /* Resize the friend list if necessary. */
-    if (realloc_friendlist(m, m->numfriends + 1) != 0)
-        return -1;
-
     if (id_equal(client_id, m->net_crypto->self_public_key))
         return -1;
 
-    memset(&(m->friendlist[m->numfriends]), 0, sizeof(Friend));
+    int32_t friendnum = init_new_friend(m, client_id);
 
-    int friendcon_id = new_friend_connection(m->fr_c, client_id);
-
-    if (friendcon_id == -1)
-        return -1;
-
-    uint32_t i;
-
-    for (i = 0; i <= m->numfriends; ++i) {
-        if (m->friendlist[i].status == NOFRIEND) {
-            m->friendlist[i].status = FRIEND_CONFIRMED;
-            m->friendlist[i].friendcon_id = friendcon_id;
-            m->friendlist[i].friendrequest_lastsent = 0;
-            id_copy(m->friendlist[i].client_id, client_id);
-            m->friendlist[i].statusmessage = calloc(1, 1);
-            m->friendlist[i].statusmessage_length = 1;
-            m->friendlist[i].userstatus = USERSTATUS_NONE;
-            m->friendlist[i].avatar_info_sent = 0;
-            m->friendlist[i].avatar_recv_data = NULL;
-            m->friendlist[i].avatar_send_data.bytes_sent = 0;
-            m->friendlist[i].avatar_send_data.last_reset = 0;
-            m->friendlist[i].is_typing = 0;
-            m->friendlist[i].message_id = 0;
-            m->friendlist[i].receives_read_receipts = 1; /* Default: YES. */
-            friend_connection_callbacks(m->fr_c, friendcon_id, MESSENGER_CALLBACK_INDEX, &handle_status, &handle_packet,
-                                        &handle_custom_lossy_packet, m, i);
-
-            if (m->numfriends == i)
-                ++m->numfriends;
-
-            if (friend_con_connected(m->fr_c, friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
-                send_online_packet(m, i);
-            }
-
-            return i;
-        }
-    }
-
-    return -1;
+    if (friendnum >= 0) {
+        m->friendlist[friendnum].status = FRIEND_CONFIRMED;
+        return friendnum;
+    } else
+        return -1; // maintain compat
 }
 
 /* Remove a friend.

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2267,13 +2267,13 @@ void do_friends(Messenger *m)
 
     for (i = 0; i < m->numfriends; ++i) {
         if (m->friendlist[i].status == FRIEND_ADDED) {
-            int fr;
+            int fr = -1;
             if (m->friendlist[i].friendrequest_nospam)
                 fr = send_friend_request_packet(m->fr_c, m->friendlist[i].friendcon_id,
                                                 m->friendlist[i].friendrequest_nospam,
                                                 m->friendlist[i].info,
                                                 m->friendlist[i].info_size);
-            else
+            else if (m->friendlist[i].groupnumber >= 0 && m->friendlist[i].peerindex >= 0)
                 fr = send_group_peer_friend_request_packet(m, m->friendlist[i].friendcon_id,
                                                            m->friendlist[i].groupnumber,
                                                            m->friendlist[i].peerindex,

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1712,6 +1712,7 @@ Messenger *new_messenger(Messenger_Options *options)
 
     m->options = *options;
     friendreq_init(&(m->fr), m->fr_c);
+    m->fr.m = m;
     LANdiscovery_init(m->dht);
     set_nospam(&(m->fr), random_int());
     set_filter_function(&(m->fr), &friend_already_added, m);

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -213,6 +213,7 @@ typedef struct {
     uint32_t message_id; // a semi-unique id used in read receipts.
     uint8_t receives_read_receipts; // shall we send read receipts to this person?
     uint32_t friendrequest_nospam; // The nospam number used in the friend request.
+    int groupnumber; int peerindex; // these can be ignored, except for sending group peer friend request
     uint64_t ping_lastrecv;//TODO remove
     uint64_t share_relays_lastsent;
     struct File_Transfers file_sending[MAX_CONCURRENT_FILE_PIPES];

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -261,7 +261,7 @@ typedef struct Messenger {
     uint8_t avatar_hash[AVATAR_HASH_LENGTH];
 
     Friend *friendlist;
-    uint32_t numfriends;
+    int32_t numfriends;
 
     uint32_t numonline_friends;
 
@@ -319,6 +319,13 @@ typedef struct Messenger {
  */
 void getaddress(const Messenger *m, uint8_t *address);
 
+/* This is used by the various add_friend functions to init the friend obj
+ *
+ * returns friendnum on success
+ * returns -1 or FAERR_NOMEM or FAERR_UNKNOWN, as m_addfriend does/used to do
+ */
+int32_t init_new_friend(Messenger *m, const uint8_t *client_id);
+
 /* Add a friend.
  * Set the data that will be sent along with friend request.
  * address is the address of the friend (returned by getaddress of the friend you wish to add) it must be FRIEND_ADDRESS_SIZE bytes.
@@ -336,16 +343,6 @@ void getaddress(const Messenger *m, uint8_t *address);
  *  return -8 if increasing the friend list size fails.
  */
 int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, uint16_t length);
-
-/*
- * Add a groupchat peer as a friend.
- * Set the data that will be sent along with friend request.
- * data is the data and length is the length.
- *
- *  return the friend number if success.
- *  returns the same errors as m_addfriend on error
- */
-int32_t m_add_group_peer_friend(Messenger *m, int groupnumber, int peerindex, const uint8_t *data, uint16_t length);
 
 /* Add a friend without sending a friendrequest.
  *  return the friend number if success.

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -321,7 +321,7 @@ void getaddress(const Messenger *m, uint8_t *address);
 
 /* Add a friend.
  * Set the data that will be sent along with friend request.
- * address is the address of the friend (returned by getaddress of the friend you wish to add) it must be FRIEND_ADDRESS_SIZE bytes. TODO: add checksum.
+ * address is the address of the friend (returned by getaddress of the friend you wish to add) it must be FRIEND_ADDRESS_SIZE bytes.
  * data is the data and length is the length.
  *
  *  return the friend number if success.
@@ -337,6 +337,15 @@ void getaddress(const Messenger *m, uint8_t *address);
  */
 int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, uint16_t length);
 
+/*
+ * Add a groupchat peer as a friend.
+ * Set the data that will be sent along with friend request.
+ * data is the data and length is the length.
+ *
+ *  return the friend number if success.
+ *  returns the same errors as m_addfriend on error
+ */
+int32_t m_add_group_peer_friend(Messenger *m, int groupnumber, int peerindex, const uint8_t *data, uint16_t length);
 
 /* Add a friend without sending a friendrequest.
  *  return the friend number if success.

--- a/toxcore/crypto_core.h
+++ b/toxcore/crypto_core.h
@@ -121,6 +121,7 @@ void new_nonce(uint8_t *nonce);
 #define MAX_CRYPTO_REQUEST_SIZE 1024
 
 #define CRYPTO_PACKET_FRIEND_REQ    32  /* Friend request crypto packet ID. */
+#define CRYPTO_PACKET_GROUP_FRIEND_REQ 33 /* Group peer friend request crypto packet ID */
 #define CRYPTO_PACKET_HARDENING     48  /* Hardening crypto packet ID. */
 #define CRYPTO_PACKET_NAT_PING      254 /* NAT ping crypto packet ID. */
 #define CRYPTO_PACKET_GROUP_CHAT_GET_NODES      48 /* Group chat get Nodes packet */

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -254,15 +254,10 @@ static int handle_packet(void *object, int number, uint8_t *data, uint16_t lengt
     Friend_Connections *fr_c = object;
     Friend_Conn *friend_con = get_conn(fr_c, number);
 
-    if (data[0] == PACKET_ID_FRIEND_REQUESTS) {
+    if (data[0] == PACKET_ID_FRIEND_REQUESTS || data[0] == PACKET_ID_GROUP_FRIEND_REQUESTS) {
         if (fr_c->fr_request_callback)
             fr_c->fr_request_callback(fr_c->fr_request_object, friend_con->real_public_key, data, length);
 
-        return 0;
-    }
-
-    if (data[0] == PACKET_ID_GROUP_FRIEND_REQUESTS) {
-        
         return 0;
     }
 

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -556,6 +556,7 @@ void set_friend_request_callback(Friend_Connections *fr_c, int (*fr_request_call
     fr_c->fr_request_callback = fr_request_callback;
     fr_c->fr_request_object = object;
     oniondata_registerhandler(fr_c->onion_c, CRYPTO_PACKET_FRIEND_REQ, fr_request_callback, object);
+    oniondata_registerhandler(fr_c->onion_c, CRYPTO_PACKET_GROUP_FRIEND_REQ, fr_request_callback, object);
 }
 
 /* Send a Friend request packet.

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -37,6 +37,7 @@
 
 #define PACKET_ID_ALIVE 16
 #define PACKET_ID_FRIEND_REQUESTS 18
+#define PACKET_ID_GROUP_FRIEND_REQUESTS 19
 
 /* Interval between the sending of ping packets. */
 #define FRIEND_PING_INTERVAL 7
@@ -168,6 +169,15 @@ int kill_friend_connection(Friend_Connections *fr_c, int friendcon_id);
  */
 int send_friend_request_packet(Friend_Connections *fr_c, int friendcon_id, uint32_t nospam_num, const uint8_t *data,
                                uint16_t length);
+
+/* Send a group peer friend request packet.
+ *
+ *  return -1 if failure.
+ *  return  0 if it sent the friend request directly to the friend.
+ *  return the number of peers it was routed through if it did not send it directly.
+ */
+int send_group_peer_friend_request_packet(void *m, int friendcon_id, int groupnumber, int peerindex,
+                                          const uint8_t *data, uint16_t length);
 
 /* Set friend request callback.
  *

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -30,6 +30,7 @@
 
 typedef struct {
     uint32_t nospam;
+    void *m; // used for group peer friend request confirmations
     void (*handle_friendrequest)(void *, const uint8_t *, const uint8_t *, uint16_t, void *);
     uint8_t handle_friendrequest_isset;
     void *handle_friendrequest_object;

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -758,6 +758,50 @@ int group_peername(const Group_Chats *g_c, int groupnumber, int peernumber, uint
     return g->group[peernumber].nick_len;
 }
 
+/* Add a groupchat peer as a friend.
+ * Set the data that will be sent along with friend request.
+ * data is the data and length is the length.
+ *
+ *  return the friend number if success.
+ *  returns the same errors as m_addfriend on error
+ */
+int32_t m_group_add_peer_friend(Messenger *m, int groupnumber, int peerindex, const uint8_t *data, uint16_t length)
+{
+    if (length > MAX_FRIEND_REQUEST_DATA_SIZE)
+        return FAERR_TOOLONG;
+
+    Group_c *g = get_group_c(m->group_chat_object, groupnumber);
+
+    uint8_t client_id[crypto_box_PUBLICKEYBYTES];
+    id_copy(client_id, g->group[peerindex].real_pk);
+
+    if (!public_key_valid(client_id))
+        return FAERR_BADCHECKSUM;
+
+    if (length < 1)
+        return FAERR_NOMESSAGE;
+
+    if (id_equal(client_id, m->net_crypto->self_public_key))
+        return FAERR_OWNKEY;
+
+    int32_t friend_id = getfriend_id(m, client_id);
+
+    if (friend_id != -1) {
+        return FAERR_ALREADYSENT;
+    }
+
+    int32_t friendnum = init_new_friend(m, client_id);
+
+    if (friendnum >= 0) {
+        m->friendlist[friendnum].groupnumber = groupnumber;
+        m->friendlist[friendnum].peerindex = peerindex;
+        memcpy(m->friendlist[friendnum].info, data, length);
+        m->friendlist[friendnum].info_size = length;
+    }
+
+    return friendnum;
+}
+
 /* List all the peers in the group chat.
  *
  * Copies the names of the peers to the name[length][MAX_NAME_LENGTH] array.

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -121,7 +121,7 @@ static int wipe_group_chat(Group_Chats *g_c, int groupnumber)
     return 0;
 }
 
-static Group_c *get_group_c(const Group_Chats *g_c, int groupnumber)
+Group_c *get_group_c(const Group_Chats *g_c, int groupnumber)
 {
     if (groupnumber_not_valid(g_c, groupnumber))
         return 0;

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -722,6 +722,17 @@ int del_groupchat(Group_Chats *g_c, int groupnumber)
     return wipe_group_chat(g_c, groupnumber);
 }
 
+int group_set_ban_friend_requests(const Group_Chats *g_c, int groupnumber, uint8_t boolean)
+{
+    Group_c *g = get_group_c(g_c, groupnumber);
+
+    if (!g)
+        return -1;
+
+    g->ban_frs = boolean;
+    return 0;
+}
+
 /* Copy the name of peernumber who is in groupnumber to name.
  * name must be at least MAX_NAME_LENGTH long.
  *

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -138,7 +138,7 @@ Group_c *get_group_c(const Group_Chats *g_c, int groupnumber)
  * TODO: make this more efficient.
  */
 
-static int peer_in_chat(const Group_c *chat, const uint8_t *real_pk)
+int peer_in_chat(const Group_c *chat, const uint8_t *real_pk)
 {
     uint32_t i;
 
@@ -157,7 +157,7 @@ static int peer_in_chat(const Group_c *chat, const uint8_t *real_pk)
  *
  * TODO: make this more efficient and maybe use constant time comparisons?
  */
-static int get_group_num(const Group_Chats *g_c, const uint8_t *identifier)
+int get_group_num(const Group_Chats *g_c, const uint8_t *identifier)
 {
     uint32_t i;
 

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -251,6 +251,15 @@ int group_title_get(const Group_Chats *g_c, int groupnumber, uint8_t *title, uin
  */
 int group_set_ban_friend_requests(const Group_Chats *g_c, int groupnumber, uint8_t boolean);
 
+/* Add a groupchat peer as a friend.
+ * Set the data that will be sent along with friend request.
+ * data is the data and length is the length.
+ *
+ *  return the friend number if success.
+ *  returns the same errors as m_addfriend on error
+ */
+int32_t m_group_add_peer_friend(Messenger *m, int groupnumber, int peerindex, const uint8_t *data, uint16_t length);
+
 /* Return the number of peers in the group chat on success.
  * return -1 on failure
  */

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -243,6 +243,14 @@ int group_title_send(const Group_Chats *g_c, int groupnumber, const uint8_t *tit
  */
 int group_title_get(const Group_Chats *g_c, int groupnumber, uint8_t *title, uint32_t max_length);
 
+
+/* 1 to disable, 0 to enable (default) friend requests from peers in this group
+ *
+ * returns 0 on success
+ * returns -1 on failure
+ */
+int group_set_ban_friend_requests(const Group_Chats *g_c, int groupnumber, uint8_t boolean);
+
 /* Return the number of peers in the group chat on success.
  * return -1 on failure
  */

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -369,4 +369,7 @@ void do_groupchats(Group_Chats *g_c);
 /* Free everything related with group chats. */
 void kill_groupchats(Group_Chats *g_c);
 
+/* Internal only function, but it is used outside of group.c */
+Group_c *get_group_c(const Group_Chats *g_c, int groupnumber);
+
 #endif

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -70,6 +70,7 @@ enum {
 
 typedef struct {
     uint8_t status;
+    uint8_t ban_frs; // ignore any friend requests from peers in this group
 
     Group_Peer *group;
     uint32_t numpeers;
@@ -369,7 +370,11 @@ void do_groupchats(Group_Chats *g_c);
 /* Free everything related with group chats. */
 void kill_groupchats(Group_Chats *g_c);
 
-/* Internal only function, but it is used outside of group.c */
+/* Internal only functions, but they are used outside of group.c */
 Group_c *get_group_c(const Group_Chats *g_c, int groupnumber);
+
+int get_group_num(const Group_Chats *g_c, const uint8_t *identifier);
+
+int peer_in_chat(const Group_c *chat, const uint8_t *real_pk);
 
 #endif

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -641,6 +641,20 @@ int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t 
     return group_peername(m->group_chat_object, groupnumber, peernumber, name);
 }
 
+/*
+ * Add a groupchat peer as a friend.
+ * Set the data that will be sent along with friend request.
+ * data is the data and length is the length.
+ *
+ *  return the friend number if success.
+ *  returns the same errors as tox_add_friend on error
+ */
+int32_t tox_group_add_peer_friend(Tox *tox, int groupnumber, int peerindex, const uint8_t *data, uint16_t length)
+{
+    Messenger *m = tox;
+    return m_add_group_peer_friend(m, groupnumber, peerindex, data, length);
+}
+
 /* invite friendnumber to groupnumber
  * return 0 on success
  * return -1 on failure
@@ -667,9 +681,9 @@ int tox_join_groupchat(Tox *tox, int32_t friendnumber, const uint8_t *data, uint
  * return 0 on success
  * return -1 on failure
  */
-int tox_group_message_send(Tox *tox, int groupnumber, const uint8_t *message, uint16_t length)
+int tox_group_message_send(const Tox *tox, int groupnumber, const uint8_t *message, uint16_t length)
 {
-    Messenger *m = tox;
+    const Messenger *m = tox;
     return group_message_send(m->group_chat_object, groupnumber, message, length);
 }
 
@@ -677,9 +691,9 @@ int tox_group_message_send(Tox *tox, int groupnumber, const uint8_t *message, ui
  * return 0 on success
  * return -1 on failure
  */
-int tox_group_action_send(Tox *tox, int groupnumber, const uint8_t *action, uint16_t length)
+int tox_group_action_send(const Tox *tox, int groupnumber, const uint8_t *action, uint16_t length)
 {
-    Messenger *m = tox;
+    const Messenger *m = tox;
     return group_action_send(m->group_chat_object, groupnumber, action, length);
 }
 
@@ -703,6 +717,17 @@ int tox_group_get_title(Tox *tox, int groupnumber, uint8_t *title, uint32_t max_
 {
     Messenger *m = tox;
     return group_title_get(m->group_chat_object, groupnumber, title, max_length);
+}
+
+/* 1 to disable, 0 to enable (default) friend requests from peers in this group
+ *
+ * returns 0 on success
+ * returns -1 on failure
+ */
+int tox_group_set_ban_friend_requests(const Tox *tox, int groupnumber, uint8_t boolean)
+{
+    const Messenger *m = tox;
+    return group_set_ban_friend_requests(m->group_chat_object, groupnumber, boolean);
 }
 
 /* Check if the current peernumber corresponds to ours.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -641,8 +641,7 @@ int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t 
     return group_peername(m->group_chat_object, groupnumber, peernumber, name);
 }
 
-/*
- * Add a groupchat peer as a friend.
+/* Add a groupchat peer as a friend.
  * Set the data that will be sent along with friend request.
  * data is the data and length is the length.
  *
@@ -652,7 +651,7 @@ int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t 
 int32_t tox_group_add_peer_friend(Tox *tox, int groupnumber, int peerindex, const uint8_t *data, uint16_t length)
 {
     Messenger *m = tox;
-    return m_add_group_peer_friend(m, groupnumber, peerindex, data, length);
+    return m_group_add_peer_friend(m, groupnumber, peerindex, data, length);
 }
 
 /* invite friendnumber to groupnumber

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -496,8 +496,7 @@ int tox_del_groupchat(Tox *tox, int groupnumber);
  */
 int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t *name);
 
-/*
- * Add a groupchat peer as a friend.
+/* Add a groupchat peer as a friend.
  * Set the data that will be sent along with friend request.
  * data is the data and length is the length.
  *

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -496,6 +496,16 @@ int tox_del_groupchat(Tox *tox, int groupnumber);
  */
 int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t *name);
 
+/*
+ * Add a groupchat peer as a friend.
+ * Set the data that will be sent along with friend request.
+ * data is the data and length is the length.
+ *
+ *  return the friend number if success.
+ *  returns the same errors as tox_add_friend on error
+ */
+int32_t tox_group_add_peer_friend(Tox *tox, int groupnumber, int peernumber, const uint8_t *data, uint16_t length);
+
 /* invite friendnumber to groupnumber
  * return 0 on success
  * return -1 on failure
@@ -514,13 +524,20 @@ int tox_join_groupchat(Tox *tox, int32_t friendnumber, const uint8_t *data, uint
  * return 0 on success
  * return -1 on failure
  */
-int tox_group_message_send(Tox *tox, int groupnumber, const uint8_t *message, uint16_t length);
+int tox_group_message_send(const Tox *tox, int groupnumber, const uint8_t *message, uint16_t length);
 
 /* send a group action
  * return 0 on success
  * return -1 on failure
  */
-int tox_group_action_send(Tox *tox, int groupnumber, const uint8_t *action, uint16_t length);
+int tox_group_action_send(const Tox *tox, int groupnumber, const uint8_t *action, uint16_t length);
+
+/* 1 to disable, 0 to enable (default) friend requests from peers in this group
+ *
+ * returns 0 on success
+ * returns -1 on failure
+ */
+int tox_group_set_ban_friend_requests(const Tox *tox, int groupnumber, uint8_t boolean);
 
 /* set the group's title, limited to MAX_NAME_LENGTH
  * return 0 on success


### PR DESCRIPTION
As requested by @zetok 

You can disable/ignore requests on a per group basis.

I'm rather less confident about code correctness here as opposed to titles (which are both simpler and have been tested). Unfortunately, it's not easy to design a UI for qTox, so there's no particular way to test this at the moment. I guess I could add some `check` tests, but I'd still like a code review from @irungentoo in any case.