### PR TITLE
Fedora package name correction

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -477,7 +477,7 @@ There are 2 dependencies required for libtoxav: libopus and libvpx. If they are 
 
 Install on fedora:
 ```bash
-yum install libopus-devel libvpx-devel
+yum install opus-devel libvpx-devel
 ```
 
 Install on ubuntu:


### PR DESCRIPTION
I hadn't found `libopus-devel`, but there is `opus-devel` instead.

@mannol, @cebe here is the correction as suggested at https://github.com/irungentoo/toxcore/commit/186c852aa646367e3965729333288f33f6146da7#commitcomment-8755216
