### PR TITLE
pass request_id as pointer to decrypt function

### DIFF
--- a/toxdns/toxdns.c
+++ b/toxdns/toxdns.c
@@ -207,7 +207,7 @@ static int decode(uint8_t *dest, uint8_t *src)
  *
  */
 int tox_decrypt_dns3_TXT(void *dns3_object, uint8_t *tox_id, uint8_t *id_record, uint32_t id_record_len,
-                         uint32_t request_id)
+                         uint32_t *request_id)
 {
     DNS_Object *d = dns3_object;
 
@@ -227,7 +227,7 @@ int tox_decrypt_dns3_TXT(void *dns3_object, uint8_t *tox_id, uint8_t *id_record,
         return -1;
 
     uint8_t nonce[crypto_box_NONCEBYTES] = {0};
-    memcpy(nonce, &request_id, sizeof(uint32_t));
+    memcpy(nonce, request_id, sizeof(uint32_t));
     nonce[sizeof(uint32_t)] = 1;
     int len = decrypt_data_symmetric(d->shared_key, nonce, data, length, tox_id);
 

--- a/toxdns/toxdns.h
+++ b/toxdns/toxdns.h
@@ -87,7 +87,7 @@ int tox_generate_dns3_string(void *dns3_object, uint8_t *string, uint16_t string
  *
  */
 int tox_decrypt_dns3_TXT(void *dns3_object, uint8_t *tox_id, uint8_t *id_record, uint32_t id_record_len,
-                         uint32_t request_id);
+                         uint32_t *request_id);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I know this is incredibly selfish to make a PR to the core so I can get my client and wrapper to work, but I've tried everything else and this is the solution I've come up with. `request_id` is being passed as a pointer during the encryption phase, which makes me have to create a byte string of length 4 (which is functionally the same as an array) and then pass it to the function. During decryption, however, the function wants me to pass an integer, but when I grab the integer from the byte string and pass it, the function returns -1.
