### PR TITLE
Added cscope.files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ nbproject
 # Android buildscript
 android-toolchain-*
 toxcore-android-*
+
+# cscope files list
+cscope.files


### PR DESCRIPTION
Added the file list cscope.files to .gitignore. This is used by cscope to build its symbol database.
