### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -482,7 +482,7 @@ yum install opus-devel libvpx-devel
 
 Install on ubuntu:
 ```bash
-sudo apt-get install libopus-dev libvpx-dev
+sudo apt-get install libopus-dev libvpx-dev pkg-config
 ```
 If you get the "Unable to locate package libopus-dev" message, add the following ppa and try again:
 ```bash


### PR DESCRIPTION
pkg-config is required for proper autodetection of opus and vpx,
without it they are not detected by ./configure on Debian 7.
