### PR TITLE
Properly fix logging on Windows

### DIFF
--- a/toxcore/logger.c
+++ b/toxcore/logger.c
@@ -1,6 +1,6 @@
 /*  logger.c
  *
- *  Copyright (C) 2013 Tox project All Rights Reserved.
+ *  Copyright (C) 2013, 2015 Tox project All Rights Reserved.
  *
  *  This file is part of Tox.
  *

--- a/toxcore/logger.c
+++ b/toxcore/logger.c
@@ -37,8 +37,10 @@
 #if defined(_WIN32) || defined(__WIN32__) || defined (WIN32)
 #   define getpid() ((unsigned) GetCurrentProcessId())
 #   define SFILE(FILE__M) (strrchr(FILE__M, '\\') ? strrchr(FILE__M, '\\') + 1 : FILE__M)
+#   define WIN_CR "\r"
 #else
 #   define SFILE(FILE__M) (strrchr(FILE__M, '/') ? strrchr(FILE__M, '/') + 1 : FILE__M)
+#   define WIN_CR ""
 #endif
 
 
@@ -100,7 +102,7 @@ Logger *logger_new (const char *file_name, LOG_LEVEL level, const char *id)
     }
 
     if (!(retu->log_file = fopen(file_name, "ab"))) {
-        fprintf(stderr, "Error opening logger file: %s; info: %s\n", file_name, strerror(errno));
+        fprintf(stderr, "Error opening logger file: %s; info: %s" WIN_CR "\n", file_name, strerror(errno));
         free(retu);
         pthread_mutex_destroy(retu->mutex);
         return NULL;
@@ -126,13 +128,13 @@ Logger *logger_new (const char *file_name, LOG_LEVEL level, const char *id)
     retu->level = level;
     retu->start_time = current_time_monotonic();
 
-    fprintf(retu->log_file, "Successfully created and running logger id: %s; time: %s\n",
+    fprintf(retu->log_file, "Successfully created and running logger id: %s; time: %s" WIN_CR "\n",
             retu->id, strtime(retu->tstr, 16));
 
     return retu;
 
 FAILURE:
-    fprintf(stderr, "Failed to create logger!\n");
+    fprintf(stderr, "Failed to create logger!" WIN_CR "\n");
     pthread_mutex_destroy(retu->mutex);
     fclose(retu->log_file);
     free(retu->tstr);
@@ -204,7 +206,7 @@ void logger_write (Logger *log, LOG_LEVEL level, const char *file, int line, con
         "%-5s  " /* Logger lever string */
         "%-20s " /* File:line string */
         "- %s"   /* Output message */
-        "\n";    /* Every new print new line */
+        WIN_CR "\n";    /* Every new print new line */
 
 
     Logger *this_log = log ? log : global;


### PR DESCRIPTION
If on Windows, compile logging to output with "\r\n" instead of "\n".