### PR TITLE
Fix heap corruptions in tox_save functions

### DIFF
--- a/auto_tests/encryptsave_test.c
+++ b/auto_tests/encryptsave_test.c
@@ -67,7 +67,7 @@ START_TEST(test_save_friend)
 
     uint32_t size = tox_encrypted_size(tox1);
     uint8_t data[size];
-    test = tox_encrypted_save(tox1, data, "correcthorsebatterystaple", 25);
+    test = tox_encrypted_save(tox1, data, size, "correcthorsebatterystaple", 25);
     ck_assert_msg(test == 0, "failed to encrypted save");
     ck_assert_msg(tox_is_save_encrypted(data) == 1, "magic number missing");
 
@@ -84,7 +84,7 @@ START_TEST(test_save_friend)
     uint8_t key[32 + crypto_box_BEFORENMBYTES];
     memcpy(key, salt, 32);
     memcpy(key + 32, known_key2, crypto_box_BEFORENMBYTES);
-    test = tox_encrypted_key_save(tox3, data2, key);
+    test = tox_encrypted_key_save(tox3, data2, size, key);
     ck_assert_msg(test == 0, "failed to encrypted save the second");
     ck_assert_msg(tox_is_save_encrypted(data2) == 1, "magic number the second missing");
 

--- a/auto_tests/messenger_test.c
+++ b/auto_tests/messenger_test.c
@@ -270,7 +270,7 @@ START_TEST(test_messenger_state_saveloadsave)
     uint8_t buffer[size + 2 * extra];
     memset(buffer, 0xCD, extra);
     memset(buffer + extra + size, 0xCD, extra);
-    messenger_save(m, buffer + extra);
+    messenger_save(m, buffer + extra, size);
 
     for (i = 0; i < extra; i++) {
         ck_assert_msg(buffer[i] == 0xCD, "Buffer underwritten from messenger_save() @%u", i);
@@ -294,7 +294,7 @@ START_TEST(test_messenger_state_saveloadsave)
     ck_assert_msg(size == size2, "Messenger \"grew\" in size from a store/load cycle: %u -> %u", size, size2);
 
     uint8_t buffer2[size2];
-    messenger_save(m, buffer2);
+    messenger_save(m, buffer2, size2);
 
     ck_assert_msg(!memcmp(buffer + extra, buffer2, size), "Messenger state changed by store/load/store cycle");
 }

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -178,7 +178,7 @@ START_TEST(test_one)
 
     size_t save_size = tox_size(tox1);
     uint8_t data[save_size];
-    tox_save(tox1, data);
+    tox_save(tox1, data, save_size);
 
     tox_kill(tox2);
     tox2 = tox_new(0);

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -193,11 +193,15 @@ int main(int argc, char *argv[])
             return 1;
         }
 
-        uint8_t *buffer = malloc(messenger_size(m));
-        messenger_save(m, buffer);
-        size_t write_result = fwrite(buffer, 1, messenger_size(m), file);
+        uint32_t size = messenger_size(m);
+        uint8_t *buffer = malloc(size);
+        if (messenger_save(m, buffer, size) < 0) {
+            return 1;
+        }
 
-        if (write_result < messenger_size(m)) {
+        size_t write_result = fwrite(buffer, 1, size, file);
+
+        if (write_result < size) {
             return 1;
         }
 

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -962,7 +962,7 @@ static int save_data(Tox *m)
     int res = 1;
     size_t size = tox_size(m);
     uint8_t data[size];
-    tox_save(m, data);
+    tox_save(m, data, size);
 
     if (fwrite(data, sizeof(uint8_t), size, data_file) != size) {
         fputs("[!] could not write data file (1)!", stderr);

--- a/testing/test_avatars.c
+++ b/testing/test_avatars.c
@@ -632,7 +632,7 @@ static int save_bootstrap_data(Tox *tox, const char *base_dir)
         return -1;
     }
 
-    tox_save(tox, buf);
+    tox_save(tox, buf, len);
 
     FILE *fp = fopen(path_tmp, "wb");
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -898,8 +898,10 @@ uint32_t messenger_run_interval(Messenger *m);
 /* return size of the messenger data (for saving). */
 uint32_t messenger_size(const Messenger *m);
 
-/* Save the messenger in data (must be allocated memory of size Messenger_size()) */
-void messenger_save(const Messenger *m, uint8_t *data);
+/* Save the messenger in data (must be allocated memory of size Messenger_size())
+ * Returns -1 if the buffer is not large enough, 0 on success
+ */
+int messenger_save(const Messenger *m, uint8_t *data, uint32_t bufsize);
 
 /* Load the messenger from data of size length. */
 int messenger_load(Messenger *m, const uint8_t *data, uint32_t length);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1088,11 +1088,13 @@ uint32_t tox_size(const Tox *tox)
     return messenger_size(m);
 }
 
-/* Save the messenger in data (must be allocated memory of size Messenger_size()). */
-void tox_save(const Tox *tox, uint8_t *data)
+/* Save the messenger in data (must be allocated memory of size Messenger_size()).
+ * Returns -1 if the buffer is not large enough, 0 on success
+ */
+int tox_save(const Tox *tox, uint8_t *data, uint32_t bufsize)
 {
     const Messenger *m = tox;
-    messenger_save(m, data);
+    return messenger_save(m, data, bufsize);
 }
 
 /* Load the messenger from data of size length. */

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -930,8 +930,10 @@ void tox_do(Tox *tox);
 /*  return size of messenger data (for saving). */
 uint32_t tox_size(const Tox *tox);
 
-/* Save the messenger in data (must be allocated memory of size Messenger_size()). */
-void tox_save(const Tox *tox, uint8_t *data);
+/* Save the messenger in data (must be allocated memory of size Messenger_size()).
+ * Returns -1 if the buffer is not large enough, 0 on success
+ */
+int tox_save(const Tox *tox, uint8_t *data, uint32_t bufsize);
 
 /* Load the messenger from data of size length.
  * NOTE: The Tox save format isn't stable yet meaning this function sometimes

--- a/toxencryptsave/toxencryptsave.c
+++ b/toxencryptsave/toxencryptsave.c
@@ -200,12 +200,16 @@ int tox_pass_encrypt(const uint8_t *data, uint32_t data_len, uint8_t *passphrase
  * returns 0 on success
  * returns -1 on failure
  */
-int tox_encrypted_save(const Tox *tox, uint8_t *data, uint8_t *passphrase, uint32_t pplength)
+int tox_encrypted_save(const Tox *tox, uint8_t *data, uint32_t buflen, uint8_t *passphrase, uint32_t pplength)
 {
     /* first get plain save data */
     uint32_t temp_size = tox_size(tox);
+    if (temp_size + TOX_PASS_ENCRYPTION_EXTRA_LENGTH > buflen)
+        return -1;
     uint8_t temp_data[temp_size];
-    tox_save(tox, temp_data);
+    int ret = tox_save(tox, temp_data, temp_size);
+    if (ret<0)
+        return ret;
 
     /* now encrypt */
     return tox_pass_encrypt(temp_data, temp_size, passphrase, pplength, data);
@@ -217,12 +221,16 @@ int tox_encrypted_save(const Tox *tox, uint8_t *data, uint8_t *passphrase, uint3
  * returns 0 on success
  * returns -1 on failure
  */
-int tox_encrypted_key_save(const Tox *tox, uint8_t *data, uint8_t *key)
+int tox_encrypted_key_save(const Tox *tox, uint8_t *data, uint32_t buflen, uint8_t *key)
 {
     /* first get plain save data */
     uint32_t temp_size = tox_size(tox);
+    if (temp_size + TOX_PASS_ENCRYPTION_EXTRA_LENGTH > buflen)
+        return -1;
     uint8_t temp_data[temp_size];
-    tox_save(tox, temp_data);
+    int ret = tox_save(tox, temp_data, temp_size);
+    if (ret<0)
+        return ret;
 
     /* encrypt */
     return tox_pass_key_encrypt(temp_data, temp_size, key, data);

--- a/toxencryptsave/toxencryptsave.h
+++ b/toxencryptsave/toxencryptsave.h
@@ -91,7 +91,7 @@ int tox_pass_encrypt(const uint8_t *data, uint32_t data_len, uint8_t *passphrase
  * returns 0 on success
  * returns -1 on failure
  */
-int tox_encrypted_save(const Tox *tox, uint8_t *data, uint8_t *passphrase, uint32_t pplength);
+int tox_encrypted_save(const Tox *tox, uint8_t *data, uint32_t buflen, uint8_t *passphrase, uint32_t pplength);
 
 /* Decrypts the given data with the given passphrase. The output array must be
  * at least data_len - tox_pass_encryption_extra_length() bytes long. This delegates
@@ -164,7 +164,7 @@ int tox_pass_key_encrypt(const uint8_t *data, uint32_t data_len, const uint8_t *
  * returns 0 on success
  * returns -1 on failure
  */
-int tox_encrypted_key_save(const Tox *tox, uint8_t *data, uint8_t *key);
+int tox_encrypted_key_save(const Tox *tox, uint8_t *data, uint32_t buflen, uint8_t *key);
 
 /* This is the inverse of tox_pass_key_encrypt, also using only keys produced by
  * tox_derive_key_from_pass.


### PR DESCRIPTION
Fix several heap corruption bugs due to tox_size changing right before a call to tox_save, resulting in trying to call tox_save with a buffer not large enough. The various tox_save functions now check that the buffer is large enough before writing to it.

We now assume that tox_size is essentially volatile, it can change at any time. This fixes a crash while saving found in qTox.