### PR TITLE
Replace hardcoded nodes with examples

### DIFF
--- a/other/bootstrap_daemon/tox-bootstrapd.conf
+++ b/other/bootstrap_daemon/tox-bootstrapd.conf
@@ -24,8 +24,8 @@ enable_lan_discovery = true
 
 enable_tcp_relay = true
 
-// Tox uses 443, 3389 and 33445 ports by default, so it's highly encouraged to keep
-// them.
+// While Tox uses 33445 port by default, 443 (https) and 3389 (rdp) ports are very
+// common among nodes, so it's encouraged to keep them in place.
 tcp_relay_ports = [443, 3389, 33445]
 
 // Reply to MOTD (Message Of The Day) requests.
@@ -45,48 +45,21 @@ motd = "tox-bootstrapd"
 // in both cases this will be interpreted as if you don't want to bootstrap
 // from anyone.
 //
-// address = any ipv4 or ipv6 address and also any US-ASCII domain name.
+// address = any IPv4 or IPv6 address and also any US-ASCII domain name.
 bootstrap_nodes = (
-  {   
-    // NikolaiToryzin - US
-    address = "192.254.75.98"
+  { // Example Node 1 (IPv4)
+    address = "127.0.0.1"
     port = 33445
-    public_key = "951C88B7E75C867418ACDB5D273821372BB5BD652740BCDF623A4FA293E75D2F"
+    public_key = "728925473812C7AAC482BE7250BCCAD0B8CB9F737BF3D42ABD34459C1768F854"
   },
-  { 
-    // Proplex - US
-    address = "107.161.17.51"
+  { // Example Node 2 (IPv6)
+    address = "::1/128"
     port = 33445
-    public_key = "7BE3951B97CA4B9ECDDA768E8C52BA19E9E2690AB584787BF4C90E04DBB75111"
+    public_key = "3E78BACF0F84235B30054B54898F56793E1DEF8BD46B1038B9D822E8460FAB67"
   },
-  { 
-    // SonOfRa - DE
-    address = "144.76.60.215"
+  { // Example Node 3 (US-ASCII domain name)
+    address = "example.org"
     port = 33445
-    public_key = "04119E835DF3E78BACF0F84235B300546AF8B936F035185E2A8E9E0A67C8924F"
-  },
-  { 
-    // Astonex - FR
-    address = "37.59.102.176"
-    port = 33445
-    public_key = "B98A2CEAA6C6A2FADC2C3632D284318B60FE5375CCB41EFA081AB67F500C1B0B"
-  },
-  { 
-    // SylvieLorxu - NL
-    address = "178.21.112.187"
-    port = 33445
-    public_key = "4B2C19E924972CB9B57732FB172F8A8604DE13EEDA2A6234E348983344B23057"
-  },
-  { 
-    // aitjcize  - JP
-    address = "54.199.139.199"
-    port = 33445
-    public_key = "7F9C31FE850E97CEFD4C4591DF93FC757C7C12549DDD55F8EEAECC34FE76C029"
-  },
-  { 
-    // NikolaiToryzin - CH
-    address = "31.7.57.236"
-    port = 443
-    public_key = "2A4B50D1D525DA2E669592A20C327B5FAD6C7E5962DC69296F9FEC77C4436E4E"
+    public_key = "8CD5A9BF0A6CE358BA36F7A653F99FA6B258FF756E490F52C1F98CC420F78858"
   }
 )


### PR DESCRIPTION
Reverts Proplex'es change, which was made solely for Tox packaging purposes, which I didn't agree with. Packaging should be kept away from toxcore repo.