### PR TITLE
Fixed incompatible pointer type warning

### DIFF
--- a/other/bootstrap_node_packets.c
+++ b/other/bootstrap_node_packets.c
@@ -34,7 +34,7 @@ static uint16_t bootstrap_motd_length;
 /* To request this packet just send a packet of length INFO_REQUEST_PACKET_LENGTH
  * with the first byte being BOOTSTRAP_INFO_PACKET_ID
  */
-static int handle_info_request(void *object, IP_Port source, const uint8_t *packet, uint32_t length)
+static int handle_info_request(void *object, IP_Port source, const uint8_t *packet, uint16_t length)
 {
     if (length != INFO_REQUEST_PACKET_LENGTH)
         return 1;


### PR DESCRIPTION
Fixed [a warning](https://travis-ci.org/irungentoo/toxcore/jobs/49821892#L532), caused by `packet_handler_callback` signature change.
```
$make

...

  CC       ../other/bootstrap_daemon/tox_bootstrapd-tox-bootstrapd.o
In file included from ../other/bootstrap_daemon/tox-bootstrapd.c:51:0:
../other/bootstrap_daemon/../bootstrap_node_packets.c: In function ‘bootstrap_set_callbacks’:
../other/bootstrap_daemon/../bootstrap_node_packets.c:63:63: warning: passing argument 3 of ‘networking_registerhandler’ from incompatible pointer type
     networking_registerhandler(net, BOOTSTRAP_INFO_PACKET_ID, &handle_info_request, net);
                                                               ^
In file included from ../other/bootstrap_daemon/../../toxcore/crypto_core.h:26:0,
                 from ../other/bootstrap_daemon/../../toxcore/DHT.h:27,
                 from ../other/bootstrap_daemon/../../toxcore/LAN_discovery.h:29,
                 from ../other/bootstrap_daemon/tox-bootstrapd.c:45:
../other/bootstrap_daemon/../../toxcore/network.h:353:6: note: expected ‘packet_handler_callback’ but argument is of type ‘int (*)(void *, struct IP_Port,  const uint8_t *, uint32_t)’
 void networking_registerhandler(Networking_Core *net, uint8_t byte, packet_handler_callback cb, void *object);
      ^
  CCLD     tox-bootstrapd
```