### PR TITLE
Define EPOLLRDHUP for Android

### DIFF
--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -29,6 +29,11 @@
 
 #ifdef TCP_SERVER_USE_EPOLL
 #include "sys/epoll.h"
+
+/* Android may not defined EPOLLRDHUP */
+#if !defined(EPOLLRDHUP)
+#define EPOLLRDHUP 0x2000
+#endif
 #endif
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(__MACH__)


### PR DESCRIPTION
In some Android SDKs, EPOLLRDHUP is not defined but is actually supported by the kernel. This patch fixes a build breakage of toxcore on Android