### PR TITLE
Allow for specifying the port range to use in Tox_Options

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1484,7 +1484,7 @@ Messenger *new_messenger(Messenger_Options *options)
     } else {
         IP ip;
         ip_init(&ip, options->ipv6enabled);
-        m->net = new_networking(ip, TOX_PORT_DEFAULT);
+        m->net = new_networking_ex(ip, options->port_range[0], options->port_range[1]);
     }
 
     if (m->net == NULL) {

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -69,6 +69,7 @@ typedef struct {
     uint8_t ipv6enabled;
     uint8_t udp_disabled;
     TCP_Proxy_Info proxy_info;
+    uint16_t port_range[2];
 } Messenger_Options;
 
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -467,6 +467,14 @@ static void at_shutdown(void)
 */
 
 /* Initialize networking.
+ * Added for reverse compatibility with old new_networking calls.
+ */
+Networking_Core *new_networking(IP ip, uint16_t port)
+{
+    return new_networking_ex(ip, port, port + (TOX_PORTRANGE_TO - TOX_PORTRANGE_FROM));
+}
+
+/* Initialize networking.
  * Bind to ip and port.
  * ip must be in network order EX: 127.0.0.1 = (7F000001).
  * port is in host byte order (this means don't worry about it).
@@ -474,8 +482,28 @@ static void at_shutdown(void)
  *  return Networking_Core object if no problems
  *  return NULL if there are problems.
  */
-Networking_Core *new_networking(IP ip, uint16_t port)
+Networking_Core *new_networking_ex(IP ip, uint16_t port_from, uint16_t port_to)
 {
+    /* If both from and to are 0, use default port range
+     * If one is 0 and the other is non-0, use the non-0 value as only port
+     * If from > to, swap
+     */
+    if(port_from == 0 && port_to == 0) {
+        port_from = TOX_PORTRANGE_FROM;
+        port_to = TOX_PORTRANGE_TO;
+    }
+    else if(port_from == 0 && port_to != 0) {
+        port_from = port_to;
+    }
+    else if(port_from != 0 && port_to == 0) {
+        port_to = port_from;
+    }
+    else if(port_from > port_to) {
+        uint16_t temp = port_from;
+        port_from = port_to;
+        port_to = temp;
+    }
+
     /* maybe check for invalid IPs like 224+.x.y.z? if there is any IP set ever */
     if (ip.family != AF_INET && ip.family != AF_INET6) {
 #ifdef DEBUG
@@ -600,11 +628,11 @@ Networking_Core *new_networking(IP ip, uint16_t port)
      *   some clients might not test return of tox_new(), blindly assuming that
      *   it worked ok (which it did previously without a successful bind)
      */
-    uint16_t port_to_try = port;
+    uint16_t port_to_try = port_from;
     *portptr = htons(port_to_try);
     int tries;
 
-    for (tries = TOX_PORTRANGE_FROM; tries <= TOX_PORTRANGE_TO; tries++) {
+    for (tries = port_from; tries <= port_to; tries++) {
         int res = bind(temp->sock, (struct sockaddr *)&addr, addrsize);
 
         if (!res) {
@@ -623,8 +651,8 @@ Networking_Core *new_networking(IP ip, uint16_t port)
 
         port_to_try++;
 
-        if (port_to_try > TOX_PORTRANGE_TO)
-            port_to_try = TOX_PORTRANGE_FROM;
+        if (port_to_try > port_to)
+            port_to_try = port_from;
 
         *portptr = htons(port_to_try);
     }

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -364,6 +364,7 @@ void networking_poll(Networking_Core *net);
  * return NULL if there are problems.
  */
 Networking_Core *new_networking(IP ip, uint16_t port);
+Networking_Core *new_networking_ex(IP ip, uint16_t port_from, uint16_t port_to);
 
 /* Function to cleanup networking stuff (doesn't do much right now). */
 void kill_networking(Networking_Core *net);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -107,6 +107,8 @@ Tox *tox_new(const struct Tox_Options *options, const uint8_t *data, size_t leng
     } else {
         m_options.ipv6enabled = options->ipv6_enabled;
         m_options.udp_disabled = !options->udp_enabled;
+        m_options.port_range[0] = options->start_port;
+        m_options.port_range[1] = options->end_port;
 
         switch (options->proxy_type) {
             case TOX_PROXY_TYPE_HTTP:

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -353,6 +353,25 @@ struct Tox_Options {
      * proxy_enabled is false.
      */
     uint16_t proxy_port;
+
+    /**
+     * The start port of the inclusive port range to attempt to use.
+     *
+     * If both start_port and end_port are 0, the default port range will be
+     * used: [33445, 33545].
+     *
+     * If either start_port or end_port is 0 while the other is non-zero, the
+     * non-zero port will be the only port in the range.
+     *
+     * Having start_port > end_port will yield the same behavior as if start_port
+     * and end_port were swapped.
+     */
+    uint16_t start_port;
+
+    /**
+     * The end port of the inclusive port range to attempt to use.
+     */
+    uint16_t end_port;
 };
 
 


### PR DESCRIPTION
Related to issue #1266.

Because of the multitude of `new_networking` calls in test and bootstrapd related files, I kept a `new_networking` that calls `new_networking_ex`.

This hasn't been tested as I don't know of any way to test new_api yet.