### PR TITLE
add spec file for rpm packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ toxcore-android-*
 
 # cscope files list
 cscope.files
+
+# rpm
+tox.spec

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ CLEANFILES = $(top_builddir)/libtoxcore.pc
 EXTRA_DIST = \
 	README.md \
 	libtoxcore.pc.in \
+	tox.spec \
 	dist-build/android-arm.sh \
 	dist-build/android-armv7.sh \
 	dist-build/android-x86.sh \

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ CLEANFILES = $(top_builddir)/libtoxcore.pc
 
 
 EXTRA_DIST = \
+	README.md \
 	libtoxcore.pc.in \
 	dist-build/android-arm.sh \
 	dist-build/android-armv7.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -693,6 +693,7 @@ AM_CONDITIONAL(WIN32, test "x$WIN32" = "xyes")
 AC_CONFIG_FILES([Makefile
                  build/Makefile
                  libtoxcore.pc
+                 tox.spec
                 ])
 
 AM_COND_IF(BUILD_AV,

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_INIT([tox], [0.0.0], [https://tox.im])
 AC_CONFIG_AUX_DIR(configure_aux)
 AC_CONFIG_SRCDIR([toxcore/net_crypto.c])
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([1.10 -Wall subdir-objects])
+AM_INIT_AUTOMAKE([1.10 -Wall subdir-objects tar-ustar])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/tox.spec.in
+++ b/tox.spec.in
@@ -1,0 +1,67 @@
+Name:           @PACKAGE_NAME@
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        All-in-one secure communication platform
+
+License:        GPLv3
+URL:            https://github.com/irungentoo/toxcore
+Source0:        https://github.com/irungentoo/toxcore/releases/tox-%{version}.tar.gz
+
+BuildRequires:  autoconf automake libtool libvpx-devel opus-devel
+BuildRequires:  libsodium-devel libconfig-devel
+
+%description
+With the rise of governmental monitoring programs, Tox, a FOSS initiative, aims to be an easy to use, all-in-one communication platform that ensures their users full privacy and secure message delivery.
+
+%package devel
+Summary:        Development files for @PACKAGE_NAME@
+Requires:       %{name} = %{version}-%{release}
+
+%description devel
+Development package for @PACKAGE_NAME@
+
+%prep
+%setup -q
+
+
+%build
+%configure \
+    --enable-shared \
+    --disable-static \
+    --enable-av \
+    --disable-ntox \
+    --disable-daemon \
+    --disable-testing
+
+make %{?_smp_mflags}
+
+
+%install
+%make_install
+
+# remove la files
+find %{buildroot} -name '*.la' -delete -print
+
+# not handling DHT_bootstrap yet
+rm -f %{buildroot}%{_bindir}/DHT_bootstrap
+
+%post
+/sbin/ldconfig
+
+%postun
+/sbin/ldconfig
+
+%files
+%defattr(-,root,root)
+%doc COPYING README.md
+%{_libdir}/libtox*.so.*
+
+%files devel
+%defattr(-, root, root)
+%{_includedir}/tox/
+%{_libdir}/libtox*.so
+%{_libdir}/pkgconfig/libtox*.pc
+
+%changelog
+* Tue Mar  3 2015 Sergey 'Jin' Bostandzhyan <jin@mediatomb.cc> - 0.0.0-1
+- initial package


### PR DESCRIPTION
    The spec file gets processed by configure, the version will be filled
    in automatically.
    
    To generate an rpm make sure to install rpm-build, then "configure" as you
    would usually do, run "make dist", then process the generated tarball
    with rpmbuild:
    
    rpmbuild -tb tox-0.0.0.tar.gz

    This will produce a tox and tox-devel package.

    I did not handle the DHT daemon yet but I can add it if needed.
    
    Tested on Fedora 22.
