### PR TITLE
Fix handling of empty status messages

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2009,7 +2009,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
         }
 
         case PACKET_ID_STATUSMESSAGE: {
-            if (data_length == 0 || data_length > MAX_STATUSMESSAGE_LENGTH)
+            if (data_length > MAX_STATUSMESSAGE_LENGTH)
                 break;
 
             /* Make sure the NULL terminator is present. */


### PR DESCRIPTION
Hi,
this fixes #1235. Empty status messages were sent, but got rejected by ToxCore.
It works well with qTox now, but it's not possible to clear the status with uTox because an empty status entry is simply ignored.