### PR TITLE
Added ability to send metadata as a simple msg to a client/friend

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -511,7 +511,7 @@ int m_sendaction(Messenger *m, int32_t friendnumber, const uint8_t *action, uint
     return send_message_generic(m, friendnumber, action, length, PACKET_ID_ACTION, message_id);
 }
 
-int m_sendaction(Messenger *m, int32_t friendnumber, const uint8_t *metadata, uint32_t length, uint32_t *message_id)
+int m_sendmetadata(Messenger *m, int32_t friendnumber, const uint8_t *metadata, uint32_t length, uint32_t *message_id)
 {
     return send_message_generic(m, friendnumber, metadata, length, PACKET_ID_METADATA, message_id);
 }

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -47,6 +47,9 @@
 #define PACKET_ID_TYPING 51
 #define PACKET_ID_MESSAGE 64
 #define PACKET_ID_ACTION 65
+/* Packet used to send meta data between clients */
+#define PACKET_ID_METADATA 66
+/* Packet ID used for sending/receiving calls */
 #define PACKET_ID_MSI 69
 #define PACKET_ID_FILE_SENDREQUEST 80
 #define PACKET_ID_FILE_CONTROL 81
@@ -236,6 +239,8 @@ struct Messenger {
     void *friend_message_userdata;
     void (*friend_action)(struct Messenger *m, uint32_t, const uint8_t *, size_t, void *);
     void *friend_action_userdata;
+    void (*friend_metadata)(struct Messenger *m, uint32_t, const uint8_t *, size_t, void *);
+    void *friend_metadata_userdata;
     void (*friend_namechange)(struct Messenger *m, uint32_t, const uint8_t *, size_t, void *);
     void *friend_namechange_userdata;
     void (*friend_statusmessagechange)(struct Messenger *m, uint32_t, const uint8_t *, size_t, void *);
@@ -377,6 +382,18 @@ int m_sendmessage(Messenger *m, int32_t friendnumber, const uint8_t *message, ui
  *  the value in message_id will be passed to your read_receipt callback when the other receives the message.
  */
 int m_sendaction(Messenger *m, int32_t friendnumber, const uint8_t *action, uint32_t length, uint32_t *message_id);
+
+/* Send meta data to an online friend/client.
+ *
+ * return -1 if friend is not valid.
+ * return -2 if data is too large.
+ * return -3 if friend/client not online.
+ * return -4 if send failed (because queue is full).
+ * return 0 if success.
+ *
+ *  the value in message_id will be passed to your read_receipt callback when the other receives the message.
+ */
+int m_sendmetadata(Messenger *m, int32_t friendnumber, const uint8_t *metadata, uint32_t length, uint32_t *message_id);
 
 /* Set the name and name_length of a friend.
  * name must be a string of maximum MAX_NAME_LENGTH length.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -823,6 +823,12 @@ void tox_callback_friend_action(Tox *tox, tox_friend_action_cb *function, void *
     m_callback_action(m, function, user_data);
 }
 
+void tox_callback_friend_metadata(Tox *tox, tox_friend_action_cb *function, void *user_data)
+{
+    Messenger *m = tox;
+    m_callback_metadata(m, function, user_data);
+}
+
 bool tox_hash(uint8_t *hash, const uint8_t *data, size_t length)
 {
     if (!hash || !data) {

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -799,6 +799,25 @@ uint32_t tox_friend_send_action(Tox *tox, uint32_t friend_number, const uint8_t 
     return message_id;
 }
 
+uint32_t tox_friend_send_metadata(Tox *tox, uint32_t friend_number, const uint8_t *metadata, size_t length,
+                                TOX_ERR_FRIEND_SEND_MESSAGE *error)
+{
+    if (!action) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_SEND_MESSAGE_NULL);
+        return 0;
+    }
+
+    if (!length) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_SEND_MESSAGE_EMPTY);
+        return 0;
+    }
+
+    Messenger *m = tox;
+    uint32_t message_id = 0;
+    set_message_error(m_sendmetadata(m, friend_number, metadata, length, &message_id), error);
+    return message_id;
+}
+
 void tox_callback_friend_read_receipt(Tox *tox, tox_friend_read_receipt_cb *function, void *user_data)
 {
     Messenger *m = tox;

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -802,7 +802,7 @@ uint32_t tox_friend_send_action(Tox *tox, uint32_t friend_number, const uint8_t 
 uint32_t tox_friend_send_metadata(Tox *tox, uint32_t friend_number, const uint8_t *metadata, size_t length,
                                 TOX_ERR_FRIEND_SEND_MESSAGE *error)
 {
-    if (!action) {
+    if (!metadata) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_SEND_MESSAGE_NULL);
         return 0;
     }

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -1278,13 +1278,28 @@ uint32_t tox_friend_send_message(Tox *tox, uint32_t friend_number, const uint8_t
  *
  * This is similar to /me (CTCP ACTION) on IRC.
  *
- * Message ID space is shared between tox_send_message and tox_send_action. This
- * means that sending a message will cause the next message ID from sending an
- * action will be incremented.
+ * Message ID space is shared between tox_send_message, tox_send_action, and
+ * tox_send_meta. This means that sending a message will cause the next message
+ * ID from sending an action will be incremented.
  *
  * @see tox_friend_send_message for more details.
  */
 uint32_t tox_friend_send_action(Tox *tox, uint32_t friend_number, const uint8_t *action, size_t length,
+                                TOX_ERR_FRIEND_SEND_MESSAGE *error);
+
+/**
+ * Send Meta Data to an online friend.
+ *
+ * This is similar to a notice (CTCP NOTICE) on IRC. But should be information
+ * for the tox client, not the user.
+ *
+ * Message ID space is shared between tox_send_message, tox_send_action, and
+ * tox_send_meta. This means that sending a message will cause the next message
+ * ID from sending meta will be incremented.
+ *
+ * @see tox_friend_send_message for more details.
+ */
+uint32_t tox_friend_send_metadata(Tox *tox, uint32_t friend_number, const uint8_t *metadata, size_t length,
                                 TOX_ERR_FRIEND_SEND_MESSAGE *error);
 
 
@@ -1379,6 +1394,26 @@ typedef void tox_friend_action_cb(Tox *tox, uint32_t friend_number, /*uint32_t t
  * This event is triggered when an action from a friend is received.
  */
 void tox_callback_friend_action(Tox *tox, tox_friend_action_cb *function, void *user_data);
+
+/**
+ * The function type for the `friend_metadata` callback.
+ *
+ * @param friend_number The friend number of the friend who sent the metadata.
+ * @param time_delta Time between composition and sending.
+ * @param metadata The meta data they sent.
+ * @param length The size of the metadata byte array.
+ *
+ * @see tox_friend_request_cb for more information on time_delta.
+ */
+typedef void tox_friend_metadata_cb(Tox *tox, uint32_t friend_number, /*uint32_t time_delta, */const uint8_t *metadata,
+                                  size_t length, void *user_data);
+
+/**
+ * Set the callback for the `friend_metadata` event. Pass NULL to unset.
+ *
+ * This event is triggered when an metadata from a friend is received.
+ */
+void tox_callback_friend_metadata(Tox *tox, tox_friend_metadata_cb *function, void *user_data);
 
 
 


### PR DESCRIPTION
toxcore didn't have an obvious way to send general metadata between clients, such as client versions or version requests. So I added a way for clients to send/receive messages marked as data, instead of as a message/action. 

One such usage would be the ability to advertize client information to a friend's client allowing clients to implement additional features would otherwise break the tox protocol or previous versions. 

E.g. a user may encrypt a profile with password with a prefix. If the prefix is changed, the profile would still decrypt, but it would send a message to all friends that this profile was decrypted under duress, and that any information sent / received is not to be trusted.