### PR TITLE
Initialize Tox_Options with default values in tox_options_new

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -75,6 +75,8 @@ struct Tox_Options *tox_options_new(TOX_ERR_OPTIONS_NEW *error)
     struct Tox_Options *options = calloc(sizeof(struct Tox_Options), 1);
 
     if (options) {
+        tox_options_default(options);
+
         SET_ERROR_PARAMETER(error, TOX_ERR_OPTIONS_NEW_OK);
         return options;
     }


### PR DESCRIPTION
According to the documentation, tox_options_new is supposed to initialize Tox_Options with default values but that doesn't actually happen.
This patch fixes that.
