### PR TITLE
callback_file_request_chunk -> callback_file_chunk_request

### DIFF
--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -184,7 +184,7 @@ void file_print_control(Tox *tox, uint32_t friend_number, uint32_t file_number, 
 
 uint8_t sending_num;
 _Bool file_sending_done;
-void tox_file_request_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, size_t length,
+void tox_file_chunk_request(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, size_t length,
                             void *user_data)
 {
     if (*((uint32_t *)user_data) != 974536)
@@ -555,7 +555,7 @@ START_TEST(test_few_clients)
     long long unsigned int f_time = time(NULL);
     tox_callback_file_recv_chunk(tox3, write_file, &to_compare);
     tox_callback_file_recv_control(tox2, file_print_control, &to_compare);
-    tox_callback_file_request_chunk(tox2, tox_file_request_chunk, &to_compare);
+    tox_callback_file_chunk_request(tox2, tox_file_chunk_request, &to_compare);
     tox_callback_file_recv_control(tox3, file_print_control, &to_compare);
     tox_callback_file_recv(tox3, tox_file_receive, &to_compare);
     uint64_t totalf_size = 100 * 1024 * 1024;

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -121,7 +121,7 @@ typedef struct {
 File_Sender file_senders[NUM_FILE_SENDERS];
 uint8_t numfilesenders;
 
-void tox_file_request_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, size_t length,
+void tox_file_chunk_request(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, size_t length,
                             void *user_data)
 {
     unsigned int i;
@@ -1289,7 +1289,7 @@ int main(int argc, char *argv[])
     tox_callback_file_recv_chunk(m, write_file, NULL);
     tox_callback_file_recv_control(m, file_print_control, NULL);
     tox_callback_file_recv(m, file_request_accept, NULL);
-    tox_callback_file_request_chunk(m, tox_file_request_chunk, NULL);
+    tox_callback_file_chunk_request(m, tox_file_chunk_request, NULL);
     tox_callback_group_namelist_change(m, print_groupnamelistchange, NULL);
     tox_callback_friend_connection_status(m, print_online, NULL);
 

--- a/testing/tox_sync.c
+++ b/testing/tox_sync.c
@@ -53,7 +53,7 @@ File_t file_senders[NUM_FILE_SENDERS];
 File_t file_recv[NUM_FILE_SENDERS];
 uint8_t numfilesenders;
 
-void tox_file_request_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, size_t length,
+void tox_file_chunk_request(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, size_t length,
                             void *user_data)
 {
     unsigned int i;
@@ -247,7 +247,7 @@ int main(int argc, char *argv[])
     tox_callback_file_recv_chunk(tox, write_file, NULL);
     tox_callback_file_recv_control(tox, file_print_control, NULL);
     tox_callback_file_recv(tox, file_request_accept, NULL);
-    tox_callback_file_request_chunk(tox, tox_file_request_chunk, NULL);
+    tox_callback_file_chunk_request(tox, tox_file_chunk_request, NULL);
     tox_callback_friend_connection_status(tox, print_online, NULL);
 
     uint16_t port = atoi(argv[argvoffset + 2]);

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1051,7 +1051,7 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
     return 0;
 }
 
-void tox_callback_file_request_chunk(Tox *tox, tox_file_request_chunk_cb *function, void *user_data)
+void tox_callback_file_chunk_request(Tox *tox, tox_file_chunk_request_cb *function, void *user_data)
 {
     Messenger *m = tox;
     callback_file_reqchunk(m, function, user_data);

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -1621,7 +1621,7 @@ typedef enum TOX_ERR_FILE_SEND {
  * data of unknown size.
  *
  * File transmission occurs in chunks, which are requested through the
- * `file_request_chunk` event.
+ * `file_chunk_request` event.
  *
  * When a friend goes offline, all file transfers associated with the friend are
  * purged from core.
@@ -1633,7 +1633,7 @@ typedef enum TOX_ERR_FILE_SEND {
  * - If the file size was increased
  *   - and sending mode was streaming (file_size = 0), the behaviour will be as
  *     expected.
- *   - and sending mode was file (file_size != 0), the file_request_chunk
+ *   - and sending mode was file (file_size != 0), the file_chunk_request
  *     callback will receive length = 0 when Core thinks the file transfer has
  *     finished. If the client remembers the file size as it was when sending
  *     the request, it will terminate the transfer normally. If the client
@@ -1713,7 +1713,7 @@ typedef enum TOX_ERR_FILE_SEND_CHUNK {
 /**
  * Send a chunk of file data to a friend.
  *
- * This function is called in response to the `file_request_chunk` callback. The
+ * This function is called in response to the `file_chunk_request` callback. The
  * length parameter should be equal to the one received though the callback.
  * If it is zero, the transfer is assumed complete. For files with known size,
  * Core will know that the transfer is complete after the last byte has been
@@ -1728,7 +1728,7 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
 
 
 /**
- * The function type for the `file_request_chunk` callback.
+ * The function type for the `file_chunk_request` callback.
  *
  * If the length parameter is 0, the file transfer is finished, and the client's
  * resources associated with the file number should be released. After a call
@@ -1751,13 +1751,13 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
  * @param position The file or stream position from which to continue reading.
  * @param length The number of bytes requested for the current chunk.
  */
-typedef void tox_file_request_chunk_cb(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position,
+typedef void tox_file_chunk_request_cb(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position,
                                        size_t length, void *user_data);
 
 /**
- * Set the callback for the `file_request_chunk` event. Pass NULL to unset.
+ * Set the callback for the `file_chunk_request` event. Pass NULL to unset.
  */
-void tox_callback_file_request_chunk(Tox *tox, tox_file_request_chunk_cb *function, void *user_data);
+void tox_callback_file_chunk_request(Tox *tox, tox_file_chunk_request_cb *function, void *user_data);
 
 
 /*******************************************************************************


### PR DESCRIPTION
A couple of minor reasons, combined warrant a PR imo:
a) fileChunkRequested is a better signal name than fileRequestChunkReceived, and I don't want to break consistency by reordering words for just this signal
b) "request chunk" is parsed by English speakers as a verb-object combination,
   implying sending the request, not receiving, whereas "chunk requested" is
   parsed (more correctly) as an adjective-noun combo (in particular, request is
   a noun not a verb), and thus reads far more like "hey heads up we just got a request"

For instance some tests/testing code had some callbacks to *receive* chunk requests, and they were called "tox_file_request_chunk"... to receive a chunk, not request it. Now they're called "tox_file_chunk_request".
So yeah...

@irungentoo @iphydf