### PR TITLE
If length is 0, data should be ignored.

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -131,7 +131,7 @@ Tox *tox_new(const struct Tox_Options *options, const uint8_t *data, size_t leng
         return NULL;
     }
 
-    if (data) {
+    if (data && length) {
         if (length < TOX_ENC_SAVE_MAGIC_LENGTH) {
             SET_ERROR_PARAMETER(error, TOX_ERR_NEW_LOAD_BAD_FORMAT);
             return NULL;


### PR DESCRIPTION
According to description of tox_new in tox.h, if length is 0, data should be ignored.
Before this fix tox_new returned error 10.