### PR TITLE
The documentation was fixed to reflect the new API the day it was merged, revert e294fae

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ The goal of this project is to create a configuration-free P2P Skype replacement
 - [DHT Protocol](/docs/updates/DHT.md)<br />
 - [Crypto](/docs/updates/Crypto.md)<br />
 
-Additional developer documentation can be found in [tox.h.](/toxcore/tox.h)
+Additional developer documentation can be found at [Libtoxcore.so](https://libtoxcore.so/)
 
 [String]: https://en.wikipedia.org/wiki/String_(computer_science)


### PR DESCRIPTION
This reverts commit e294faeb4d94d38ead63246127e7691bad0a4cd5 that @urras submitted without actually realizing it was totally incorrect and unnecessary.

The documentation on libtoxcore.so was updated to reflect the new API in the tutorial perfectly in hours and the doxygen part is totally automated so it was technically up to date within about a minute of the new API being merged.