### PR TITLE
Additional description for tox_friend_delete.

### DIFF
--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -936,6 +936,8 @@ typedef enum TOX_ERR_FRIEND_DELETE {
 
 /**
  * Remove a friend from the friend list.
+ * Other friend numbers are unchanged.
+ * The friend_number can be reused by toxcore as a friend number for a new friend.
  *
  * This does not notify the friend of their deletion. After calling this
  * function, this client will appear offline to the friend and no communication
@@ -944,6 +946,7 @@ typedef enum TOX_ERR_FRIEND_DELETE {
  * @friend_number Friend number for the friend to be deleted.
  *
  * @return true on success.
+ * @see tox_friend_add for detailed description of friend numbers.
  */
 bool tox_friend_delete(Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_DELETE *error);
 


### PR DESCRIPTION
There is no information in tox_friend_delete description about the behavior of friend numbers when this function is used.  But there is quite complex information in tox_firend_add description that includes deletion behavior. Reference to tox_friend_add  and basic ideas are added.