### PR TITLE
Fix DNS naming | 'tox#' → 'toxdns#'

### DIFF
--- a/toxdns/toxdns.h
+++ b/toxdns/toxdns.h
@@ -43,7 +43,7 @@ extern "C" {
  * 4. take the string and use it for your DNS request like this:
  * _4haaaaipr1o3mz0bxweox541airydbovqlbju51mb4p0ebxq.rlqdj4kkisbep2ks3fj2nvtmk4daduqiueabmexqva1jc._tox.utox.org
  * 5. The TXT in the DNS you receive should look like this:
- * v=tox3;id=2vgcxuycbuctvauik3plsv3d3aadv4zfjfhi3thaizwxinelrvigchv0ah3qjcsx5qhmaksb2lv2hm5cwbtx0yp
+ * v=toxdns3;id=2vgcxuycbuctvauik3plsv3d3aadv4zfjfhi3thaizwxinelrvigchv0ah3qjcsx5qhmaksb2lv2hm5cwbtx0yp
  * 6. Take the id string and use it with tox_decrypt_dns3_TXT() and the request_id corresponding to the
  * request we stored earlier to get the Tox id returned by the DNS server.
  */


### PR DESCRIPTION
Depends on:

* toxme.se PR: https://github.com/Tox/toxme.se/pull/26
* utox.org PR: https://github.com/notsecure/tox-dns/pull/1
* Tox-QuickDNS PR: https://github.com/Tox/Tox-QuickDNS/pull/2

* STS PR: https://github.com/Tox/Tox-STS/pull/48