### PR TITLE
Amend comments to reflect undefined filenumber and friendnumber behavior

### DIFF
--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -881,7 +881,8 @@ typedef enum TOX_ERR_FRIEND_ADD {
  * friends. Once added, a friend number is stable for the lifetime of the Tox
  * object. After saving the state and reloading it, the friend numbers may not
  * be the same as before. Deleting a friend creates a gap in the friend number
- * set, which is filled by the next adding of a friend.
+ * set, which is filled by the next adding of a friend. Any pattern in friend
+ * numbers should not be relied on.
  *
  * If more than INT32_MAX friends are added, this function causes undefined
  * behaviour.
@@ -1660,7 +1661,8 @@ typedef enum TOX_ERR_FILE_SEND {
  *
  * @return A file number used as an identifier in subsequent callbacks. This
  *   number is per friend. File numbers are reused after a transfer terminates.
- *   on failure, this function returns UINT32_MAX.
+ *   on failure, this function returns UINT32_MAX. Any pattern in file numbers
+ *   should not be relied on.
  */
 uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t file_size, const uint8_t *file_id,
                        const uint8_t *filename, size_t filename_length, TOX_ERR_FILE_SEND *error);


### PR DESCRIPTION
This is to make explicit the fact that any properties of filenumbers and friendnumbers may change at any time without notice, and should therefore be treated as an unknown random number.