### PR TITLE
Multiple no spam functionality.

### DIFF
--- a/auto_tests/encryptsave_test.c
+++ b/auto_tests/encryptsave_test.c
@@ -29,7 +29,7 @@ unsigned char known_key2[crypto_box_BEFORENMBYTES] = {0x7a, 0xfa, 0x95, 0x45, 0x
 // same as above, except standard opslimit instead of extra ops limit for test_known_kdf, and hash pw before kdf for compat
 
 /* cause I'm shameless */
-void accept_friend_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)
+void accept_friend_request(Tox *m, const uint8_t *public_key, uint32_t nospam, const uint8_t *data, size_t length, void *userdata)
 {
     if (*((uint32_t *)userdata) != 974536)
         return;

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -22,7 +22,7 @@
 #endif
 
 
-void accept_friend_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)
+void accept_friend_request(Tox *m, const uint8_t *public_key, uint32_t nospam, const uint8_t *data, size_t length, void *userdata)
 {
     if (*((uint32_t *)userdata) != 974536)
         return;
@@ -811,7 +811,7 @@ END_TEST
 
 #define NUM_GROUP_TOX 32
 
-void g_accept_friend_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)
+void g_accept_friend_request(Tox *m, const uint8_t *public_key, uint32_t nospam, const uint8_t *data, size_t length, void *userdata)
 {
     if (*((uint32_t *)userdata) != 234212)
         return;

--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -55,7 +55,7 @@ typedef struct _Status {
 /* My default settings */
 static ToxAvCSettings muhcaps;
 
-void accept_friend_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)
+void accept_friend_request(Tox *m, const uint8_t *public_key, uint32_t nospam, const uint8_t *data, size_t length, void *userdata)
 {
     if (length == 7 && memcmp("gentoo", data, 7) == 0) {
         tox_friend_add_norequest(m, public_key, 0);

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -58,7 +58,7 @@ typedef struct _Status {
 
 Status status_control;
 
-void accept_friend_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)
+void accept_friend_request(Tox *m, const uint8_t *public_key, uint32_t nospam, const uint8_t *data, size_t length, void *userdata)
 {
     if (length == 7 && memcmp("gentoo", data, 7) == 0) {
         tox_friend_add_norequest(m, public_key, 0);

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -868,7 +868,7 @@ void do_refresh()
     refresh();
 }
 
-void print_request(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length, void *userdata)
+void print_request(Tox *m, const uint8_t *public_key, uint32_t nospam, const uint8_t *data, size_t length, void *userdata)
 {
     new_lines("[i] received friend request with message:");
     new_lines((char *)data);

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -155,11 +155,45 @@ static uint16_t address_checksum(const uint8_t *address, uint32_t len)
  */
 void getaddress(const Messenger *m, uint8_t *address)
 {
-    id_copy(address, m->net_crypto->self_public_key);
     uint32_t nospam = get_nospam(&(m->fr));
+    getaddress_nospam(m, nospam, address);
+}
+
+void getaddress_nospam(const Messenger *m, uint32_t nospam, uint8_t *address)
+{
+    id_copy(address, m->net_crypto->self_public_key);
     memcpy(address + crypto_box_PUBLICKEYBYTES, &nospam, sizeof(nospam));
     uint16_t checksum = address_checksum(address, FRIEND_ADDRESS_SIZE - sizeof(checksum));
     memcpy(address + crypto_box_PUBLICKEYBYTES + sizeof(nospam), &checksum, sizeof(checksum));
+}
+
+NSERR m_nospam_update(Messenger *m, uint32_t num, uint32_t new_num)
+{
+    return nospam_update(&(m->fr), num, new_num);
+}
+
+NSERR m_nospam_descr_update(Messenger *m, uint32_t num, const uint8_t *descr, size_t descr_length)
+{
+    return nospam_descr_update(&(m->fr), num, descr, descr_length);
+}
+
+size_t m_nospam_descr_length(const Messenger *m, uint32_t num, NSERR *nserr)
+{
+    return nospam_descr_length(&(m->fr), num, nserr);
+}
+
+NSERR m_nospam_descr(const Messenger *m, uint32_t num, uint8_t *descr)
+{
+    return nospam_descr(&(m->fr), num, descr);
+}
+
+size_t m_nospam_count(const Messenger *m)
+{
+    return nospam_count(&(m->fr));
+}
+void m_nospam_list(const Messenger *m, uint32_t *ns_list)
+{
+    nospam_list(&(m->fr), ns_list);
 }
 
 static int send_online_packet(Messenger *m, int32_t friendnumber)
@@ -798,10 +832,10 @@ static void set_friend_typing(const Messenger *m, int32_t friendnumber, uint8_t 
 }
 
 /* Set the function that will be executed when a friend request is received. */
-void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *m, const uint8_t *, const uint8_t *, size_t,
+void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *m, const uint8_t *, uint32_t, const uint8_t *, size_t,
                               void *), void *userdata)
 {
-    void (*handle_friendrequest)(void *, const uint8_t *, const uint8_t *, size_t, void *) = (void *)function;
+    void (*handle_friendrequest)(void *, const uint8_t *, uint32_t, const uint8_t *, size_t, void *) = (void *)function;
     callback_friendrequest(&(m->fr), handle_friendrequest, m, userdata);
 }
 
@@ -2444,6 +2478,7 @@ void do_messenger(Messenger *m)
 #define MESSENGER_STATE_TYPE_NAME          4
 #define MESSENGER_STATE_TYPE_STATUSMESSAGE 5
 #define MESSENGER_STATE_TYPE_STATUS        6
+#define MESSENGER_STATE_TYPE_NOSPAMS       7
 #define MESSENGER_STATE_TYPE_TCP_RELAY     10
 #define MESSENGER_STATE_TYPE_PATH_NODE     11
 
@@ -2555,12 +2590,13 @@ uint32_t messenger_size(const Messenger *m)
 {
     uint32_t size32 = sizeof(uint32_t), sizesubhead = size32 * 2;
     return   size32 * 2                                      // global cookie
-             + sizesubhead + sizeof(uint32_t) + crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES
+             + sizesubhead + crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES
              + sizesubhead + DHT_size(m->dht)                  // DHT
              + sizesubhead + saved_friendslist_size(m)         // Friendlist itself.
              + sizesubhead + m->name_length                    // Own nickname.
              + sizesubhead + m->statusmessage_length           // status message
              + sizesubhead + 1                                 // status
+             + sizesubhead + nospam_saved_list_size(&(m->fr))   //No Spams
              + sizesubhead + NUM_SAVED_TCP_RELAYS * sizeof(Node_format) //TCP relays
              + sizesubhead + NUM_SAVED_PATH_NODES * sizeof(Node_format) //saved path nodes
              ;
@@ -2590,11 +2626,10 @@ void messenger_save(const Messenger *m, uint8_t *data)
 #ifdef DEBUG
     assert(sizeof(get_nospam(&(m->fr))) == sizeof(uint32_t));
 #endif
-    len = size32 + crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES;
+    len = crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES;
     type = MESSENGER_STATE_TYPE_NOSPAMKEYS;
     data = z_state_save_subheader(data, len, type);
-    *(uint32_t *)data = get_nospam(&(m->fr));
-    save_keys(m->net_crypto, data + size32);
+    save_keys(m->net_crypto, data);
     data += len;
 
     len = DHT_size(m->dht);
@@ -2627,6 +2662,12 @@ void messenger_save(const Messenger *m, uint8_t *data)
     *data = m->userstatus;
     data += len;
 
+    len = nospam_saved_list_size(&(m->fr));
+    type = MESSENGER_STATE_TYPE_NOSPAMS;
+    data = z_state_save_subheader(data, len, type);
+    nospam_list_save(&(m->fr), data);
+    data += len;
+
     Node_format relays[NUM_SAVED_TCP_RELAYS];
     len = sizeof(relays);
     type = MESSENGER_STATE_TYPE_TCP_RELAY;
@@ -2651,17 +2692,26 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
 
     switch (type) {
         case MESSENGER_STATE_TYPE_NOSPAMKEYS:
+
             if (length == crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES + sizeof(uint32_t)) {
+                //Single nospam save file
+                printf("Loading file warning: old tox save file format.\n"
+                       "File will be saved in new format.\n");
                 set_nospam(&(m->fr), *(uint32_t *)data);
-                load_keys(m->net_crypto, &data[sizeof(uint32_t)]);
+                data += sizeof(uint32_t);
+            } else if (length != crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES) {
+                //Invalid file
+                return -1; /* critical */
+            }
+
+            load_keys(m->net_crypto, data);
+
 #ifdef ENABLE_ASSOC_DHT
 
-                if (m->dht->assoc)
-                    Assoc_self_client_id_changed(m->dht->assoc, m->net_crypto->self_public_key);
+            if (m->dht->assoc)
+                Assoc_self_client_id_changed(m->dht->assoc, m->net_crypto->self_public_key);
 
 #endif
-            } else
-                return -1;    /* critical */
 
             break;
 
@@ -2692,6 +2742,10 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
                 m_set_userstatus(m, *data);
             }
 
+            break;
+
+        case MESSENGER_STATE_TYPE_NOSPAMS:
+            nospam_list_load(&(m->fr), data, length);
             break;
 
         case MESSENGER_STATE_TYPE_TCP_RELAY: {

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -299,6 +299,59 @@ struct Messenger {
  */
 void getaddress(const Messenger *m, uint8_t *address);
 
+/*
+ * Returns address with nospam passed to function.
+ */
+void getaddress_nospam(const Messenger *m, uint32_t nospam, uint8_t *address);
+
+/*
+ * This function updates the nospam set. If num is in nospam set, then new_num will replace num.
+ * If new_num == 0, then num value will be removed from nospam set.
+ * If num == 0, then new_num will be added to nospam set.
+ * Passing num == 0 and new_num == 0 will return NSERR_SUCCESS and result no effect.
+ *
+ * Return: NSERR_SUCCESS on success, or NSERR_* on falure.
+ * If the call fails, the nospam set is unchanged.
+ */
+NSERR m_nospam_update(Messenger *m, uint32_t num, uint32_t new_num);
+
+/*
+ * Set description for num. Description in utf8 string.
+ * Passing 0 as descr_length will result no effect and NSERR_SUCCESS will be returned.
+ * Passing descr == 0 and descr_length != 0 will erase the description.
+ * Passing descr_length > MAX_NOSPAM_DESCRIPTION_LENGTH will result and error;
+ * If error happens then nothing is changed.
+ * On success description for nospam num is changed.
+ */
+NSERR m_nospam_descr_update(Messenger *m, uint32_t num, const uint8_t *descr, size_t descr_length);
+
+/*
+ * Returns nospam value and set nserr to NSERR_SUCCESS on success.
+ * Returns 0 and set nserr on failure.
+ */
+size_t m_nospam_descr_length(const Messenger *m, uint32_t num, NSERR *nserr);
+
+/*
+ * Copy description to descr for num.
+ * If no description exists, then descr is unchanged.
+ * returns NSERR_SUCCESS or NSERR_* on failure.
+ */
+NSERR m_nospam_descr(const Messenger *m, uint32_t num, uint8_t *descr);
+
+/*
+ * Returns the amount of entries on nospam set.
+ * Call can't fail.
+ */
+size_t m_nospam_count(const Messenger *m);
+
+/*
+ * Write to ns_list all nospams in nospam set.
+ * The size of ns_list is given with nospam_count function.
+ * Call can't fail.
+ */
+void m_nospam_list(const Messenger *m, uint32_t *ns_list);
+
+
 /* Add a friend.
  * Set the data that will be sent along with friend request.
  * address is the address of the friend (returned by getaddress of the friend you wish to add) it must be FRIEND_ADDRESS_SIZE bytes. TODO: add checksum.
@@ -483,7 +536,7 @@ int m_get_istyping(const Messenger *m, int32_t friendnumber);
 /* Set the function that will be executed when a friend request is received.
  *  Function format is function(uint8_t * public_key, uint8_t * data, size_t length)
  */
-void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *m, const uint8_t *, const uint8_t *, size_t,
+void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *m, const uint8_t *, uint32_t, const uint8_t *, size_t,
                               void *), void *userdata);
 
 /* Set the function that will be executed when a message from a friend is received.

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -276,7 +276,7 @@ uint32_t nospam_saved_list_size(const Friend_Requests *fr)
 
 void nospam_list_save(const Friend_Requests *fr, uint8_t *data)
 {
-    int i = 0;
+    size_t i = 0;
 
     for (i = 0; i < fr->nospam_amount; ++i) {
         const No_Spam *ns = fr->nospam + i;

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -28,21 +28,275 @@
 #include "friend_requests.h"
 #include "util.h"
 
+#include <assert.h>
+
+//No Spam functions
+void fr_nospam_init(No_Spam *ns)
+{
+    memset(ns, 0, sizeof(No_Spam));
+}
+
+bool fr_nospam_set(No_Spam *ns, uint32_t value, const uint8_t *description, size_t description_length)
+{
+
+    if (description_length > MAX_NOSPAM_DESCRIPTION_LENGTH)
+        return false;
+
+    ns->nospam = value;
+
+    if (value == 0) {
+        ns->description_length = 0;
+        return true;
+    }
+
+    if (description_length == 0)
+        return true;
+    if (description == 0) {
+        ns->description_length = 0;
+        return true;
+    }
+
+    ns->description_length = description_length;
+    memcpy(ns->description, description, ns->description_length);
+
+    return true;
+}
+
+uint32_t fr_nospam_value(const No_Spam *ns)
+{
+    return ns->nospam;
+}
+
+bool fr_nospam_valid(const No_Spam *ns)
+{
+    return (fr_nospam_value(ns) != NOSPAM_SPAM);
+}
+
+size_t fr_nospam_description_length(const No_Spam *ns)
+{
+    return ns->description_length;
+}
+
+void fr_nospam_description(const No_Spam *ns, uint8_t *buffer)
+{
+    memcpy(buffer, ns->description, ns->description_length);
+}
+
+size_t fr_nospam_saved_size(const No_Spam *ns)
+{
+    return sizeof(No_Spam);
+}
+
+void fr_nospam_save(const No_Spam *ns, uint8_t *buffer)
+{
+    memcpy(buffer, ns, sizeof(No_Spam));
+}
+
+void fr_nospam_load(No_Spam *ns, const uint8_t *buffer)
+{
+    memcpy(ns, buffer, sizeof(No_Spam));
+}
+
+uint32_t fr_packet_nospam_extract(const uint8_t *packet)
+{
+    return *(uint32_t*)(packet);
+}
+
+size_t fr_nospam_find_id(const Friend_Requests *fr, uint32_t num)
+{
+    size_t i = 0;
+    for (i = 0; i < fr->nospam_amount; ++i) {
+        const No_Spam *ns = fr->nospam + i;
+        if (fr_nospam_value(ns) == num)
+            return i;
+    }
+
+    if ((fr->nospam_amount < MAX_NOSPAM_AMOUNT) &&
+        (num == NOSPAM_SPAM))
+        return fr->nospam_amount;
+
+    return MAX_NOSPAM_AMOUNT;
+}
+
+No_Spam *fr_nospam_find(Friend_Requests *fr, uint32_t num)
+{
+    size_t id = fr_nospam_find_id(fr, num);
+
+    if (id >= MAX_NOSPAM_AMOUNT)
+        return 0;
+
+    return fr->nospam + id;
+}
+
+uint32_t fr_filter_spam(const Friend_Requests *fr, uint32_t num)
+{
+    size_t id = fr_nospam_find_id(fr, num);
+
+    if (id < MAX_NOSPAM_AMOUNT)
+        return num;
+
+    return NOSPAM_SPAM;
+}
 
 /* Set and get the nospam variable used to prevent one type of friend request spam. */
 void set_nospam(Friend_Requests *fr, uint32_t num)
 {
-    fr->nospam = num;
+    if (fr->nospam_amount == 0) {
+        fr->nospam_amount = 1;
+    }
+    fr_nospam_set(&(fr->nospam[0]), num, 0, 0);
 }
 
 uint32_t get_nospam(const Friend_Requests *fr)
 {
-    return fr->nospam;
+    return fr_nospam_value(&(fr->nospam[0]));
 }
 
+/* NSERR nospam_add(Friend_Requests *fr, uint32_t num, const uint8_t *descr, size_t descr_length) { */
+/*     No_Spam *ns = 0; */
+
+/*     if (num == NOSPAM_SPAM) */
+/*         return NSERR_SUCCESS; */
+
+/*     ns = fr_nospam_find(fr, NOSPAM_SPAM); */
+
+/*     if (!ns) */
+/*         return NSERR_TOO_MANY; */
+
+/*     fr_nospam_set(ns, num, descr, descr_length); */
+
+/*     if (ns == fr->nospam + fr->nospam_amount) */
+/*         ++(fr->nospam_amount); */
+
+/*     return NSERR_SUCCESS; */
+/* } */
+
+NSERR nospam_update(Friend_Requests *fr, uint32_t num, uint32_t new_num)
+{
+    No_Spam *ns = fr_nospam_find(fr, num);
+    No_Spam *new_ns = fr_nospam_find(fr, new_num);
+    bool last_id = false;
+
+    if ((num == 0) && (new_num == 0))
+        return NSERR_SUCCESS;
+    if ((num != 0) && (ns == 0))
+        return NSERR_NOT_FOUND;
+    if (num == new_num)
+        return NSERR_SUCCESS;
+    if ((new_num != 0) && (new_ns))
+        return NSERR_ALREADY_EXISTS;
+    if ((num == 0) && (ns == 0))
+        return NSERR_TOO_MANY;
+
+    fr_nospam_set(ns, new_num, 0, 0);
+
+    if (ns == fr->nospam + fr->nospam_amount) {
+        if (new_num == 0) {
+            assert(fr->nospam_amount != 0);
+            --(fr->nospam_amount);
+        }
+        else {
+            ++(fr->nospam_amount);
+        }
+    }
+
+    return NSERR_SUCCESS;
+}
+
+NSERR nospam_descr_update(Friend_Requests *fr, uint32_t num, const uint8_t *descr, size_t descr_length)
+{
+    if (num == NOSPAM_SPAM)
+        return NSERR_SUCCESS;
+
+    No_Spam *ns = fr_nospam_find(fr, num);
+    if (ns == 0)
+        return NSERR_NOT_FOUND;
+
+    if (fr_nospam_set(ns, num, descr, descr_length))
+        return NSERR_SUCCESS;
+    return NSERR_DESCRIPTION_TOO_LONG;
+}
+
+size_t nospam_descr_length(const Friend_Requests *fr, uint32_t num, NSERR *nserr)
+{
+    size_t id = fr_nospam_find_id(fr, num);
+    if (id == MAX_NOSPAM_AMOUNT) {
+        if (nserr)
+            *nserr = NSERR_NOT_FOUND;
+        return 0;
+    }
+    return fr_nospam_description_length(fr->nospam + id);
+}
+
+NSERR nospam_descr(const Friend_Requests *fr, uint32_t num, uint8_t *descr)
+{
+    size_t id = fr_nospam_find_id(fr, num);
+    if (id == MAX_NOSPAM_AMOUNT)
+        return NSERR_NOT_FOUND;
+    fr_nospam_description(fr->nospam + id, descr);
+    return NSERR_SUCCESS;
+}
+
+size_t nospam_count(const Friend_Requests *fr)
+{
+    size_t i = 0;
+    size_t result = 0;
+    for (i = 0; i < fr->nospam_amount; ++i) {
+        if (fr_nospam_valid(fr->nospam + i)) {
+            ++result;
+        }
+    }
+    return result;
+}
+
+void nospam_list(const Friend_Requests *fr, uint32_t *ns_list)
+{
+    size_t id = 0;
+    for (id = 0; id < fr->nospam_amount; ++id) {
+        const No_Spam *ns = fr->nospam + id;
+        if (fr_nospam_valid(ns)) {
+            *ns_list = fr_nospam_value(ns);
+            ++ns_list;
+        }
+    }
+}
+
+uint32_t nospam_saved_list_size(const Friend_Requests *fr)
+{
+    size_t i = 0;
+    uint32_t size = 0;
+    for (i = 0; i < fr->nospam_amount; ++i) {
+        const No_Spam *ns = fr->nospam + i;
+        if (fr_nospam_valid(ns)){
+            size += fr_nospam_saved_size(ns);
+        }
+    }
+    return size;
+}
+
+void nospam_list_save(const Friend_Requests *fr, uint8_t *data)
+{
+    int i = 0;
+
+    for (i = 0; i < fr->nospam_amount; ++i) {
+        const No_Spam *ns = fr->nospam + i;
+        if (fr_nospam_valid(ns)) {
+            fr_nospam_save(ns, data);
+            data += fr_nospam_saved_size(ns);
+        }
+    }
+}
+
+void nospam_list_load(Friend_Requests *fr, const uint8_t *data, uint32_t size)
+{
+    size_t sz = (sizeof(fr->nospam) > size)?size:sizeof(fr->nospam);
+    memset(&(fr->nospam), 0, sizeof(fr->nospam));
+    memcpy(&(fr->nospam), data, sz);
+    fr->nospam_amount = sz/sizeof(No_Spam);
+}
 
 /* Set the function that will be executed when a friend request is received. */
-void callback_friendrequest(Friend_Requests *fr, void (*function)(void *, const uint8_t *, const uint8_t *, size_t,
+void callback_friendrequest(Friend_Requests *fr, void (*function)(void *, const uint8_t *, uint32_t, const uint8_t *, size_t,
                             void *), void *object, void *userdata)
 {
     fr->handle_friendrequest = function;
@@ -106,8 +360,9 @@ int remove_request_received(Friend_Requests *fr, const uint8_t *real_pk)
 static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, const uint8_t *packet, uint16_t length)
 {
     Friend_Requests *fr = object;
+    uint32_t nospam = 0;
 
-    if (length <= 1 + sizeof(fr->nospam) || length > ONION_CLIENT_MAX_DATA_SIZE)
+    if (length <= 1 + NOSPAM_SIZE || length > ONION_CLIENT_MAX_DATA_SIZE)
         return 1;
 
     ++packet;
@@ -119,7 +374,7 @@ static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, co
     if (request_received(fr, source_pubkey))
         return 1;
 
-    if (memcmp(packet, &fr->nospam, sizeof(fr->nospam)) != 0)
+    if ((nospam = fr_filter_spam(fr, fr_packet_nospam_extract(packet))) == NOSPAM_SPAM)
         return 1;
 
     if (fr->filter_function)
@@ -128,12 +383,12 @@ static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, co
 
     addto_receivedlist(fr, source_pubkey);
 
-    uint32_t message_len = length - sizeof(fr->nospam);
+    uint32_t message_len = length - NOSPAM_SIZE;
     uint8_t message[message_len + 1];
-    memcpy(message, packet + sizeof(fr->nospam), message_len);
+    memcpy(message, packet + NOSPAM_SIZE, message_len);
     message[sizeof(message) - 1] = 0; /* Be sure the message is null terminated. */
 
-    (*fr->handle_friendrequest)(fr->handle_friendrequest_object, source_pubkey, message, message_len,
+    (*fr->handle_friendrequest)(fr->handle_friendrequest_object, source_pubkey, nospam, message, message_len,
                                 fr->handle_friendrequest_userdata);
     return 0;
 }

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -25,12 +25,38 @@
 #define FRIEND_REQUESTS_H
 
 #include "friend_connection.h"
+#include <stdbool.h>
 
 #define MAX_FRIEND_REQUEST_DATA_SIZE (ONION_CLIENT_MAX_DATA_SIZE - (1 + sizeof(uint32_t)))
 
-typedef struct {
+/* Maximum nospam amount should be quite small to be effective against spam.
+ * Maximum allowed amount is given by MAX_NOSPAM_AMOUNT.
+ */
+
+#define MAX_NOSPAM_AMOUNT 16
+#define MAX_NOSPAM_DESCRIPTION_LENGTH 128
+#define NOSPAM_SIZE sizeof(uint32_t)
+#define NOSPAM_SPAM 0
+
+typedef enum NSERR {
+    NSERR_SUCCESS = 0,
+    NSERR_NOT_FOUND = 1,
+    NSERR_TOO_MANY = 2,
+    NSERR_ALREADY_EXISTS = 3,
+    NSERR_DESCRIPTION_TOO_LONG
+} NSERR;
+
+typedef struct No_Spam {
     uint32_t nospam;
-    void (*handle_friendrequest)(void *, const uint8_t *, const uint8_t *, size_t, void *);
+    uint8_t  description[MAX_NOSPAM_DESCRIPTION_LENGTH];
+    size_t description_length;
+} No_Spam;
+
+typedef struct {
+    No_Spam nospam[MAX_NOSPAM_AMOUNT];
+    uint32_t nospam_amount;
+
+    void (*handle_friendrequest)(void *, const uint8_t *, uint32_t, const uint8_t *, size_t, void *);
     uint8_t handle_friendrequest_isset;
     void *handle_friendrequest_object;
     void *handle_friendrequest_userdata;
@@ -47,9 +73,62 @@ typedef struct {
     uint16_t received_requests_index;
 } Friend_Requests;
 
-/* Set and get the nospam variable used to prevent one type of friend request spam. */
+/* Set and get the nospam variable used to prevent one type of friend request spam.
+ * This is old API.
+ */
 void set_nospam(Friend_Requests *fr, uint32_t num);
 uint32_t get_nospam(const Friend_Requests *fr);
+
+/*
+ * This function updates the nospam set. If num is in nospam set, then new_num will replace num.
+ * If new_num == NOSPAM_SPAM, which is 0, then num value will be removed from nospam set.
+ * If num == NOSPAM_SPAM, which is 0, then new_num will be added to nospam set.
+ * Passing num == 0 and new_num == 0 will return NSERR_SUCCESS and result no effect.
+ *
+ * Return: NSERR_SUCCESS on success, or NSERR_* on falure.
+ * If the call fails, the nospam set is unchanged.
+ */
+NSERR nospam_update(Friend_Requests *fr, uint32_t num, uint32_t new_num);
+
+/*
+ * Set description for num. Description in utf8 string.
+ * Passing 0 as descr_length will result no effect and NSERR_SUCCESS will be returned.
+ * Passing descr == 0 and descr_length != 0 will erase the description.
+ * Passing descr_length > MAX_NOSPAM_DESCRIPTION_LENGTH will result and error;
+ * If error happens then nothing is changed.
+ * On success description for nospam num is changed.
+ */
+NSERR nospam_descr_update(Friend_Requests *fr, uint32_t num, const uint8_t *descr, size_t descr_length);
+
+/*
+ * Returns nospam value and set nserr to NSERR_SUCCESS on success.
+ * Returns 0 and set nserr on failure.
+ */
+size_t nospam_descr_length(const Friend_Requests *fr, uint32_t num, NSERR *nserr);
+
+/*
+ * Copy description to descr for num.
+ * If no description exists, then descr is unchanged.
+ * returns NSERR_SUCCESS or NSERR_* on failure.
+ */
+NSERR nospam_descr(const Friend_Requests *fr, uint32_t num, uint8_t *descr);
+
+/*
+ * Returns the amount of nospams.
+ * Call can't fail.
+ */
+size_t nospam_count(const Friend_Requests *fr);
+
+/*
+ * Write to ns_list all nospams in nospam set.
+ * The size of ns_list is given with nospam_count function.
+ * Call can't fail.
+ */
+void nospam_list(const Friend_Requests *fr, uint32_t *ns_list);
+
+uint32_t nospam_saved_list_size(const Friend_Requests *fr);
+void nospam_list_save(const Friend_Requests *fr, uint8_t *data);
+void nospam_list_load(Friend_Requests *fr, const uint8_t *data, uint32_t size);
 
 /* Remove real_pk from received_requests list.
  *
@@ -61,7 +140,7 @@ int remove_request_received(Friend_Requests *fr, const uint8_t *real_pk);
 /* Set the function that will be executed when a friend request for us is received.
  *  Function format is function(uint8_t * public_key, uint8_t * data, size_t length, void * userdata)
  */
-void callback_friendrequest(Friend_Requests *fr, void (*function)(void *, const uint8_t *, const uint8_t *, size_t,
+void callback_friendrequest(Friend_Requests *fr, void (*function)(void *, const uint8_t *, uint32_t, const uint8_t *, size_t,
                             void *), void *object, void *userdata);
 
 /* Set the function used to check if a friend request should be displayed to the user or not.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -354,12 +354,90 @@ void tox_iterate(Tox *tox)
     do_groupchats(m->group_chat_object);
 }
 
+bool set_nospam_error(NSERR err_code, TOX_ERR_NOSPAM *error)
+{
+    switch (err_code){
+    case NSERR_SUCCESS:
+        SET_ERROR_PARAMETER(error, TOX_ERR_NOSPAM_OK);
+        break;
+    case NSERR_NOT_FOUND:
+        SET_ERROR_PARAMETER(error, TOX_ERR_NOSPAM_NOT_FOUND);
+        break;
+    case NSERR_TOO_MANY:
+        SET_ERROR_PARAMETER(error, TOX_ERR_NOSPAM_TOO_MANY);
+        break;
+    case NSERR_ALREADY_EXISTS:
+        SET_ERROR_PARAMETER(error, TOX_ERR_NOSPAM_ALREADY_EXISTS);
+        break;
+    case NSERR_DESCRIPTION_TOO_LONG:
+        SET_ERROR_PARAMETER(error, TOX_ERR_NOSPAM_DESCRIPTION_TOO_LONG);
+        break;
+    }
+
+    if (err_code != NSERR_SUCCESS)
+        return false;
+    return true;
+}
+
 void tox_self_get_address(const Tox *tox, uint8_t *address)
 {
     if (address) {
         const Messenger *m = tox;
         getaddress(m, address);
     }
+}
+
+uint32_t tox_self_generate_nospam(const Tox *tox)
+{
+    uint32_t result = 0;
+    while (result == 0) {
+        result = random_int();
+    }
+    return result;
+}
+
+void tox_self_get_address_nospam(const Tox *tox, uint32_t nospam, uint8_t *address)
+{
+    if (address) {
+        const Messenger *m = tox;
+        getaddress_nospam(m, nospam, address);
+    }
+}
+
+bool tox_self_update_nospam(Tox *tox, uint32_t nospam, uint32_t new_nospam, TOX_ERR_NOSPAM *error)
+{
+    return set_nospam_error(m_nospam_update(tox, nospam, new_nospam), error);
+}
+
+bool tox_self_set_nospam_description(Tox *tox, uint32_t nospam, const uint8_t *description, size_t length,
+                                     TOX_ERR_NOSPAM *error)
+{
+    return set_nospam_error(m_nospam_descr_update(tox, nospam, description, length), error);
+}
+
+bool tox_self_get_nospam_description(const Tox *tox, uint32_t nospam,
+                                        uint8_t *description, TOX_ERR_NOSPAM *error)
+{
+    return set_nospam_error(m_nospam_descr(tox, nospam, description), error);
+}
+
+size_t tox_self_get_nospam_description_length(const Tox *tox, uint32_t nospam, TOX_ERR_NOSPAM *error)
+{
+    NSERR err = 0;
+    size_t result = 0;
+    result = m_nospam_descr_length(tox, nospam, &err);
+    set_nospam_error(err, error);
+    return result;
+}
+
+void tox_self_get_nospam_list(const Tox *tox, uint32_t *nospams)
+{
+    m_nospam_list(tox, nospams);
+}
+
+size_t tox_self_get_nospam_list_length(const Tox *tox)
+{
+    return m_nospam_count(tox);
 }
 
 void tox_self_set_nospam(Tox *tox, uint32_t nospam)

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -226,6 +226,11 @@ bool tox_version_is_compatible(uint32_t major, uint32_t minor, uint32_t patch);
 #define TOX_ADDRESS_SIZE                (TOX_PUBLIC_KEY_SIZE + sizeof(uint32_t) + sizeof(uint16_t))
 
 /**
+ * Maximim length of nospam description in bytes.
+ */
+#define TOX_MAX_NOSPAM_DESCRIPTION_LENGTH 128
+
+/**
  * Maximum length of a nickname in bytes.
  */
 #define TOX_MAX_NAME_LENGTH             128
@@ -680,11 +685,52 @@ void tox_iterate(Tox *tox);
  *
  ******************************************************************************/
 
+/**
+ * Multiple nospam values can be used to have different addresses at the same time.
+ * This can help to block friend request spam for one address
+ * leaving other addresses valid.
+ * Also this can help to distinguish friend requests by nospam values they used.
+ *
+ * Every non zero 32-bit unsigned integer can be used as nospam value.
+ *
+ * It's also possible to block all friend requests by
+ * removing all nospam values from nospam set.
+ *
+ * Each nospam value can have a description, that can help
+ * user to distinguish friend requests.
+ */
+
+typedef enum TOX_ERR_NOSPAM {
+    TOX_ERR_NOSPAM_OK,
+
+    /**
+     * Nospam number is not in nospam set.
+     */
+    TOX_ERR_NOSPAM_NOT_FOUND,
+
+    /**
+     * Impossible to add new nospam value to nospam set.
+     */
+    TOX_ERR_NOSPAM_TOO_MANY,
+
+    /**
+     * Nospam value is already in nospam set.
+     */
+    TOX_ERR_NOSPAM_ALREADY_EXISTS,
+
+    /**
+     * Description is greater then TOX_MAX_NOSPAM_DESCRIPTION_LENGTH.
+     */
+    TOX_ERR_NOSPAM_DESCRIPTION_TOO_LONG
+} TOX_ERR_NOSPAM;
 
 /**
  * Writes the Tox friend address of the client to a byte array. The address is
  * not in human-readable format. If a client wants to display the address,
  * formatting is required.
+ *
+ * This is old API function and can write an address that will not pass
+ * antispam check. This function will work correctly if only old API is used.
  *
  * @param address A memory region of at least TOX_ADDRESS_SIZE bytes. If this
  *   parameter is NULL, this function has no effect.
@@ -692,18 +738,95 @@ void tox_iterate(Tox *tox);
  */
 void tox_self_get_address(const Tox *tox, uint8_t *address);
 
+/**
+ * Writes the Tox friend address of the client with nospam value to a byte array.
+ * If nospam is not in registered nospam set then behaviour is undefined.
+ *
+ * @param address A memory region of at least TOX_ADDRESS_SIZE bytes. If this
+ *   parameter is NULL, this function has no effect.
+ * @param nospam a 32bit unsigned non zero integer that will be used as nospam value.
+ * @see TOX_ADDRESS_SIZE for the address format.
+ */
+void tox_self_get_address_nospam(const Tox *tox, uint32_t nospam, uint8_t *address);
 
 /**
  * Set the 4-byte nospam part of the address.
  *
- * @param nospam Any 32 bit unsigned integer.
+ * This is old API function and will set only one nospam.
+ *
+ * @param nospam Any 32-bit unsigned integer.
  */
 void tox_self_set_nospam(Tox *tox, uint32_t nospam);
 
 /**
  * Get the 4-byte nospam part of the address.
+ *
+ * This is old API function and can return nospam value that will not pass
+ * antispam check. This function will work correctly if only old API is used.
  */
 uint32_t tox_self_get_nospam(const Tox *tox);
+
+
+/**
+ * Can be used to generate random nospam numbers.
+ * @return random non-zero unsigned 32-bit integer.
+ */
+uint32_t tox_self_generate_nospam(const Tox *tox);
+
+/**
+ * Updates nospam set.
+ * Zero can't be used as nospam value to filter spam.
+ * If nospam is 0 then new_nospam is added to nospam set.
+ * If nospam is not 0 then the nospam value is changed to new_nospam.
+ * If new_nospam is 0 then nospam is removed from nospam set.
+ *
+ * @param nospam Any 32-bit unsigned integer.
+ * @param new_nospam Any-32 bit unsigned integer.
+ * @returns true on success and false on failure. error is set according to result.
+ */
+bool tox_self_update_nospam(Tox *tox, uint32_t nospam, uint32_t new_nospam, TOX_ERR_NOSPAM *error);
+
+/**
+ * Set description for nospam.
+ * Description should be utf-8 string.
+ * length should not be greater then TOX_MAX_NOSPAM_DESCRIPTION_LENGTH.
+ *
+ * @param nospam 32-bit unsigned non-zero integer.
+ * @param description utf-8 string.
+ * @param length length of the string in bytes.
+ */
+bool tox_self_set_nospam_description(Tox *tox, uint32_t nospam, const uint8_t *description, size_t length,
+                                     TOX_ERR_NOSPAM *error);
+
+/**
+ * Writes description. Length of the description can be found with
+ * tox_self_get_nospam_description_length.
+ *
+ * @param nospam 32-bit unsigned non-zero integer.
+ * @param description allocated buffer.
+ * @see tox_self_get_nospam_description_length to find the size of description buffer.
+ */
+bool tox_self_get_nospam_description(const Tox *tox, uint32_t nospam,
+                                        uint8_t *description, TOX_ERR_NOSPAM *error);
+
+/**
+ * @return length of description in bytes on success and 0 on failure.
+ */
+size_t tox_self_get_nospam_description_length(const Tox *tox, uint32_t nospam, TOX_ERR_NOSPAM *error);
+
+/**
+ * Writes nospam set to nospams.
+ * Amount of enteries can be found with tox_self_get_nospam_list_length.
+ * This call can't fail.
+ * @see tox_self_get_nospam_list_length to find the length of nospam list.
+ */
+void tox_self_get_nospam_list(const Tox *tox, uint32_t *nospams);
+
+/**
+ * This call can't fail.
+ * @return the amount of entries in nospam set.
+ */
+size_t tox_self_get_nospam_list_length(const Tox *tox);
 
 /**
  * Copy the Tox Public Key (long term public key) from the Tox object.
@@ -1326,11 +1449,12 @@ void tox_callback_friend_read_receipt(Tox *tox, tox_friend_read_receipt_cb *func
  * The function type for the `friend_request` callback.
  *
  * @param public_key The Public Key of the user who sent the friend request.
+ * @param nospam value that request used as nospam.
  * @param message The message they sent along with the request.
  * @param length The size of the message byte array.
  */
-typedef void tox_friend_request_cb(Tox *tox, const uint8_t *public_key, const uint8_t *message, size_t length,
-                                   void *user_data);
+typedef void tox_friend_request_cb(Tox *tox, const uint8_t *public_key, uint32_t nospam,
+                                       const uint8_t *message, size_t length, void *user_data);
 
 /**
  * Set the callback for the `friend_request` event. Pass NULL to unset.


### PR DESCRIPTION
I am not sure that this pull request is going to be applied because I thought about this idea myself. Later I found that similar thing is written in TODO file, but it wasn't updated for quite long time.

Having multiple nospams can be really useful for the user, helping him to understand what kind of friend request he got and block some addresses without accessing the other. 
For example, user can have one public address that is posted on the website, one address that he published to colleagues or friends and another that he give to some other people. If the address from website got spammed, user can block it without changing the address that can be used by his colleagues. Or if you want to give your address on some forum, you can instantly create new address, give it and delete the address when he will be added to friend list without changing your main address that is posted on, for example. toxme.se.

User can add new nospam values, remove nospam values, give description to nospam values and change nospam values. Each nospam value has addition description string that can help user to recall where he left that address or understand what kind of friend request he receive. 

Such change breaks API slightly and changes save file format. Upstream toxsaves can be loaded with this version. But after save, the file can't be loaded with upstream toxcore. So if you want to test it, MAKE SURE you have made a BACKUP of you toxsave.

Also at this moment 0 can't be used as nospam value because this value is used as indicator.
So by updating nospam value to 0 user can delete it and by updating 0 to nospam value, this value will be added to nospam set. But if having 0 as nospam value is really important, this behavior can be changed.

New API description can be found in tox.h. 

The most of the code is made in friend_requests.c and some changes are in Messenger.c 
It happened that I had to write additional layer of wrapping in Messenger.h because I don't know if the project allows to use in tox.c any functions that are not in Messenger.h 

The description maximum length is fixed with 128 bytes. I assumed that having a lot of nospam values is not useful, so for test simplification, up to 16 nospams can be created. If there is a need for more, the amount can be changed easily without breaking something.

Nospams can be thought as a set or dictionary, so there are no ids and access to description is made with nospam value itself. It looks like it makes API a more simple.

I don't know about internal code rules, so I tried to make the code similar to what I saw in the project.

Any questions, discussions or criticism are welcome.

P.S. This is not tested very well, so there can (will) be bugs.