### PR TITLE
API function to get last seen timestamp of friend

### DIFF
--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -198,7 +198,7 @@ typedef struct {
     uint16_t info_size; // Length of the info.
     uint32_t message_id; // a semi-unique id used in read receipts.
     uint32_t friendrequest_nospam; // The nospam number used in the friend request.
-    uint64_t ping_lastrecv;//TODO remove
+    uint64_t last_seen_time;
     uint64_t share_relays_lastsent;
     uint8_t last_connection_udp_tcp;
     struct File_Transfers file_sending[MAX_CONCURRENT_FILE_PIPES];
@@ -460,8 +460,8 @@ uint8_t m_get_userstatus(const Messenger *m, int32_t friendnumber);
 uint8_t m_get_self_userstatus(const Messenger *m);
 
 
-/* returns timestamp of last time friendnumber was seen online, or 0 if never seen.
- * returns -1 on error.
+/* returns timestamp of last time friendnumber was seen online or 0 if never seen.
+ * if friendnumber is invalid this function will return UINT64_MAX.
  */
 uint64_t m_get_last_online(const Messenger *m, int32_t friendnumber);
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -599,6 +599,20 @@ bool tox_friend_exists(const Tox *tox, uint32_t friend_number)
     return m_friend_exists(m, friend_number);
 }
 
+uint64_t tox_friend_get_last_online(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_GET_LAST_ONLINE *error)
+{
+    const Messenger *m = tox;
+    uint64_t timestamp = m_get_last_online(m, friend_number);
+
+    if (timestamp == UINT64_MAX) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_GET_LAST_ONLINE_FRIEND_NOT_FOUND)
+        return UINT64_MAX;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_GET_LAST_ONLINE_OK);
+    return timestamp;
+}
+
 size_t tox_self_get_friend_list_size(const Tox *tox)
 {
     const Messenger *m = tox;

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -996,6 +996,21 @@ bool tox_friend_get_public_key(const Tox *tox, uint32_t friend_number, uint8_t *
  */
 bool tox_friend_exists(const Tox *tox, uint32_t friend_number);
 
+typedef enum TOX_ERR_FRIEND_GET_LAST_ONLINE {
+    TOX_ERR_FRIEND_GET_LAST_ONLINE_OK,
+    /**
+     * No friend with the given number exists on the friend list.
+     */
+    TOX_ERR_FRIEND_GET_LAST_ONLINE_FRIEND_NOT_FOUND,
+} TOX_ERR_FRIEND_GET_LAST_ONLINE;
+
+/**
+ * Return a unix-time timestamp of the last time the friend associated with a given
+ * friend number was seen online. This function will return UINT64_MAX on error.
+ *
+ * @param friend_number The friend number you want to query.
+ */
+uint64_t tox_friend_get_last_online(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_GET_LAST_ONLINE *error);
 
 /**
  * Return the number of friends on the friend list.


### PR DESCRIPTION
The removal of this function broke both Toxic and ToxBot. The reason given for its removal by @irungentoo was that some systems in rare cases might not handle the timestamps properly due to timezone setting incompatibilities (correct me if I'm wrong).

My argument is that we should not deprive 99.9% of users of useful functionality to account for these very rare cases, which would still only display an incorrect time and not actually break anything. Moreover, client developers should be able to use their own discretion.