### PR TITLE
systemd service fix

### DIFF
--- a/other/bootstrap_daemon/tox-bootstrapd-tmpfile.conf
+++ b/other/bootstrap_daemon/tox-bootstrapd-tmpfile.conf
@@ -1,0 +1,1 @@
+d /var/run/tox-bootstrapd 0750 tox-bootstrapd tox-bootstrapd -

--- a/other/bootstrap_daemon/tox-bootstrapd.service
+++ b/other/bootstrap_daemon/tox-bootstrapd.service
@@ -4,9 +4,6 @@ After=network.target
 
 [Service]
 Type=forking
-PermissionsStartOnly=true
-ExecStartPre=-/bin/mkdir /var/run/tox-bootstrapd -p
-ExecStartPre=/bin/chown tox-bootstrapd:tox-bootstrapd -R /var/run/tox-bootstrapd
 WorkingDirectory=/var/lib/tox-bootstrapd
 ExecStart=/usr/local/bin/tox-bootstrapd /etc/tox-bootstrapd.conf
 User=tox-bootstrapd

--- a/other/bootstrap_daemon/tox-bootstrapd.service
+++ b/other/bootstrap_daemon/tox-bootstrapd.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=forking
 WorkingDirectory=/var/lib/tox-bootstrapd
-ExecStart=/usr/local/bin/tox-bootstrapd /etc/tox-bootstrapd.conf
+ExecStart=/usr/bin/tox-bootstrapd /etc/tox-bootstrapd.conf
 User=tox-bootstrapd
 Group=tox-bootstrapd
 PIDFile=/var/run/tox-bootstrapd/tox-bootstrapd.pid


### PR DESCRIPTION
Added systemd tmpfile (to be installed in '/usr/lib/tmpfiles.d').
Cleaned up the systemd service file to no longer include commands
handled by systemd-tmpfiles.