### PR TITLE
Updated daemon's systemd file, fixed typos in README

### DIFF
--- a/other/bootstrap_daemon/tox-bootstrapd.service
+++ b/other/bootstrap_daemon/tox-bootstrapd.service
@@ -4,16 +4,14 @@ After=network.target
 
 [Service]
 Type=forking
-PermissionsStartOnly=true
-ExecStartPre=-/bin/mkdir /var/run/tox-bootstrapd -p
-ExecStartPre=/bin/chown tox-bootstrapd:tox-bootstrapd -R /var/run/tox-bootstrapd
+RuntimeDirectory=tox-bootstrapd
+RuntimeDirectoryMode=750
+PIDFile=/var/run/tox-bootstrapd/tox-bootstrapd.pid
 WorkingDirectory=/var/lib/tox-bootstrapd
 ExecStart=/usr/local/bin/tox-bootstrapd /etc/tox-bootstrapd.conf
 User=tox-bootstrapd
 Group=tox-bootstrapd
-PIDFile=/var/run/tox-bootstrapd/tox-bootstrapd.pid
 #CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
@arthurtiteica has pointed out (https://github.com/irungentoo/toxcore/pull/1332) that systemd has more suitable facilities for creating a temporary directory for a PID file rather than calling  ExecStartPre, which requires an absolute path to coreutils executables we used for creating a directory and changing its owner, paths of which are are not universal across distributions. Systemd can take care of it for us without need to provide absolute paths, which is what we use here.
Tested on Debian Jessie -- worked for me.

@stqism you might want to check that it doesn't break the daemon package.