### PR TITLE
Make tests working with no IPv6 too

### DIFF
--- a/auto_tests/dht_test.c
+++ b/auto_tests/dht_test.c
@@ -7,6 +7,7 @@
 
 #include "../toxcore/tox.h"
 #include "../toxcore/DHT.c"
+#include "../toxcore/network.h"
 
 #include "helpers.h"
 
@@ -355,6 +356,7 @@ START_TEST(test_addto_lists_ipv4)
 }
 END_TEST
 
+#if TOX_ENABLE_IPV6_DEFAULT == 1
 START_TEST(test_addto_lists_ipv6)
 {
     IP ip;
@@ -363,13 +365,16 @@ START_TEST(test_addto_lists_ipv6)
 
 }
 END_TEST
+#endif
 
 Suite *dht_suite(void)
 {
     Suite *s = suite_create("DHT");
 
     DEFTESTCASE(addto_lists_ipv4);
+#if TOX_ENABLE_IPV6_DEFAULT == 1
     DEFTESTCASE(addto_lists_ipv6);
+#endif
     return s;
 }
 

--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -39,6 +39,7 @@ START_TEST(test_addr_resolv_localhost)
         ck_assert_msg(ip.ip4.uint32 == htonl(0x7F000001), "Expected 127.0.0.1, got %s.", inet_ntoa(ip.ip4.in_addr));
     }
 
+#if TOX_ENABLE_IPV6_DEFAULT == 1
     ip_init(&ip, 1);
     res = addr_resolve(localhost, &ip, NULL);
 
@@ -72,6 +73,7 @@ START_TEST(test_addr_resolv_localhost)
     } else {
         printf("Localhost seems to be split in two.\n");
     }
+#endif
 }
 END_TEST
 

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -13,6 +13,7 @@
 #include "../toxcore/onion_announce.h"
 #include "../toxcore/onion_client.h"
 #include "../toxcore/util.h"
+#include "../toxcore/network.h"
 
 #include "helpers.h"
 
@@ -129,8 +130,13 @@ static int handle_test_4(void *object, IP_Port source, const uint8_t *packet, ui
 START_TEST(test_basic)
 {
     IP ip;
+#if TOX_ENABLE_IPV6_DEFAULT == 1
     ip_init(&ip, 1);
     ip.ip6.uint8[15] = 1;
+#else
+    ip_init(&ip, 0);
+    ip.ip4.uint32 = htonl(0x7F000001);
+#endif
     Onion *onion1 = new_onion(new_DHT(new_networking(ip, 34567)));
     Onion *onion2 = new_onion(new_DHT(new_networking(ip, 34568)));
     ck_assert_msg((onion1 != NULL) && (onion2 != NULL), "Onion failed initializing.");
@@ -269,8 +275,13 @@ typedef struct {
 Onions *new_onions(uint16_t port)
 {
     IP ip;
+#if TOX_ENABLE_IPV6_DEFAULT == 1
     ip_init(&ip, 1);
     ip.ip6.uint8[15] = 1;
+#else
+    ip_init(&ip, 0);
+    ip.ip4.uint32 = htonl(0x7F000001);
+#endif
     Onions *on = malloc(sizeof(Onions));
     DHT *dht = new_DHT(new_networking(ip, port));
     on->onion = new_onion(dht);
@@ -371,8 +382,13 @@ START_TEST(test_announce)
     }
 
     IP ip;
+#if TOX_ENABLE_IPV6_DEFAULT == 1
     ip_init(&ip, 1);
     ip.ip6.uint8[15] = 1;
+#else
+    ip_init(&ip, 0);
+    ip.ip4.uint32 = htonl(0x7F000001);
+#endif
 
     for (i = 3; i < NUM_ONIONS; ++i) {
         IP_Port ip_port = {ip, onions[i - 1]->onion->net->port};


### PR DESCRIPTION
Original all building (check) tries are failing if the build machines
has no IPv6. This patch fixes that partly by respecting
TOX_ENABLE_IPV6_DEFAULT.