### PR TITLE
Use stdbool instead of _Bool

### DIFF
--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -3,6 +3,7 @@
 #endif
 
 #include <sys/types.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 #include <check.h>
@@ -309,7 +310,7 @@ void kill_onions(Onions *on)
 #define NUM_FIRST 7
 #define NUM_LAST 37
 
-_Bool first_ip, last_ip;
+bool first_ip, last_ip;
 void dht_ip_callback(void *object, int32_t number, IP_Port ip_port)
 {
     if (NUM_FIRST == number) {
@@ -325,7 +326,7 @@ void dht_ip_callback(void *object, int32_t number, IP_Port ip_port)
     ck_abort_msg("Error.");
 }
 
-_Bool first, last;
+bool first, last;
 uint8_t first_dht_pk[crypto_box_PUBLICKEYBYTES];
 uint8_t last_dht_pk[crypto_box_PUBLICKEYBYTES];
 

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -3,6 +3,7 @@
 #endif
 
 #include <sys/types.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
@@ -190,9 +191,9 @@ void file_print_control(Tox *tox, uint32_t friend_number, uint32_t file_number, 
 }
 
 uint64_t max_sending;
-_Bool m_send_reached;
+bool m_send_reached;
 uint8_t sending_num;
-_Bool file_sending_done;
+bool file_sending_done;
 void tox_file_chunk_request(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, size_t length,
                             void *user_data)
 {
@@ -244,7 +245,7 @@ void tox_file_chunk_request(Tox *tox, uint32_t friend_number, uint32_t file_numb
 
 
 uint8_t num;
-_Bool file_recv;
+bool file_recv;
 void write_file(Tox *tox, uint32_t friendnumber, uint32_t filenumber, uint64_t position, const uint8_t *data,
                 size_t length, void *user_data)
 {

--- a/toxav/codec.c
+++ b/toxav/codec.c
@@ -61,12 +61,12 @@ typedef struct {
     Payload **packets;
 } PayloadBuffer;
 
-static _Bool buffer_full(const PayloadBuffer *b)
+static bool buffer_full(const PayloadBuffer *b)
 {
     return (b->end + 1) % b->size == b->start;
 }
 
-static _Bool buffer_empty(const PayloadBuffer *b)
+static bool buffer_empty(const PayloadBuffer *b)
 {
     return b->end == b->start;
 }

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -86,7 +86,7 @@ typedef enum {
 #define GENERIC_HEADER(header, val_type) \
 typedef struct _MSIHeader##header { \
 val_type value; \
-_Bool exists; \
+bool exists; \
 } MSIHeader##header;
 
 

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -68,7 +68,7 @@ typedef struct _ToxAvCall {
     pthread_mutex_t mutex_do[1];
     RTPSession *crtps[2]; /** Audio is first and video is second */
     CSSession *cs;
-    _Bool active;
+    bool active;
 } ToxAvCall;
 
 struct _ToxAv {

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -228,7 +228,7 @@ static IP broadcast_ip(sa_family_t family_socket, sa_family_t family_broadcast)
 }
 
 /* Is IP a local ip or not. */
-_Bool Local_ip(IP ip)
+bool Local_ip(IP ip)
 {
     if (ip.family == AF_INET) {
         IP4 ip4 = ip.ip4;

--- a/toxcore/LAN_discovery.h
+++ b/toxcore/LAN_discovery.h
@@ -21,10 +21,10 @@
  *
  */
 
-
 #ifndef LAN_DISCOVERY_H
 #define LAN_DISCOVERY_H
 
+#include <stdbool.h>
 
 #include "DHT.h"
 
@@ -41,7 +41,7 @@ void LANdiscovery_init(DHT *dht);
 void LANdiscovery_kill(DHT *dht);
 
 /* Is IP a local ip or not. */
-_Bool Local_ip(IP ip);
+bool Local_ip(IP ip);
 
 /* checks if a given IP isn't routable
  *

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -412,7 +412,7 @@ int m_get_friend_connectionstatus(const Messenger *m, int32_t friendnumber)
         return -1;
 
     if (m->friendlist[friendnumber].status == FRIEND_ONLINE) {
-        _Bool direct_connected = 0;
+        bool direct_connected = 0;
         unsigned int num_online_relays = 0;
         crypto_connection_status(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
                                  m->friendlist[friendnumber].friendcon_id), &direct_connected, &num_online_relays);
@@ -794,7 +794,7 @@ void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, uint32_t
     m->friend_userstatuschange_userdata = userdata;
 }
 
-void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, _Bool, void *), void *userdata)
+void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, bool, void *), void *userdata)
 {
     m->friend_typingchange = function;
     m->friend_typingchange_userdata = userdata;
@@ -1987,7 +1987,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
             if (data_length != 1)
                 break;
 
-            _Bool typing = !!data[0];
+            bool typing = !!data[0];
 
             set_friend_typing(m, i, typing);
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -245,7 +245,7 @@ struct Messenger {
     void *friend_statusmessagechange_userdata;
     void (*friend_userstatuschange)(struct Messenger *m, uint32_t, unsigned int, void *);
     void *friend_userstatuschange_userdata;
-    void (*friend_typingchange)(struct Messenger *m, uint32_t, _Bool, void *);
+    void (*friend_typingchange)(struct Messenger *m, uint32_t, bool, void *);
     void *friend_typingchange_userdata;
     void (*read_receipt)(struct Messenger *m, uint32_t, uint32_t, void *);
     void *read_receipt_userdata;
@@ -506,7 +506,7 @@ void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, uint32_t
 /* Set the callback for typing changes.
  *  Function(uint32_t friendnumber, uint8_t is_typing)
  */
-void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, _Bool, void *), void *userdata);
+void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, bool, void *), void *userdata);
 
 /* Set the callback for read receipts.
  *  Function(uint32_t friendnumber, uint32_t receipt)

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -322,7 +322,7 @@ static int send_pending_data(TCP_Client_Connection *con)
 /* return 0 on failure (only if malloc fails)
  * return 1 on success
  */
-static _Bool add_priority(TCP_Client_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
+static bool add_priority(TCP_Client_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
 {
     TCP_Priority_List *p = con->priority_queue_end, *new;
     new = malloc(sizeof(TCP_Priority_List) + size);
@@ -363,12 +363,12 @@ static void wipe_priority_list(TCP_Client_Connection *con)
  * return -1 on failure (connection must be killed).
  */
 static int write_packet_TCP_secure_connection(TCP_Client_Connection *con, const uint8_t *data, uint16_t length,
-        _Bool priority)
+        bool priority)
 {
     if (length + crypto_box_MACBYTES > MAX_PACKET_SIZE)
         return -1;
 
-    _Bool sendpriority = 1;
+    bool sendpriority = 1;
 
     if (send_pending_data(con) == -1) {
         if (priority) {

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -39,7 +39,7 @@
 /* return 1 if the connections_number is not valid.
  * return 0 if the connections_number is valid.
  */
-static _Bool connections_number_not_valid(const TCP_Connections *tcp_c, int connections_number)
+static bool connections_number_not_valid(const TCP_Connections *tcp_c, int connections_number)
 {
     if ((unsigned int)connections_number >= tcp_c->connections_length)
         return 1;
@@ -56,7 +56,7 @@ static _Bool connections_number_not_valid(const TCP_Connections *tcp_c, int conn
 /* return 1 if the tcp_connections_number is not valid.
  * return 0 if the tcp_connections_number is valid.
  */
-static _Bool tcp_connections_number_not_valid(const TCP_Connections *tcp_c, int tcp_connections_number)
+static bool tcp_connections_number_not_valid(const TCP_Connections *tcp_c, int tcp_connections_number)
 {
     if ((unsigned int)tcp_connections_number >= tcp_c->tcp_connections_length)
         return 1;
@@ -213,7 +213,7 @@ int send_packet_tcp_connection(TCP_Connections *tcp_c, int connections_number, c
     unsigned int i;
     int ret = -1;
 
-    _Bool limit_reached = 0;
+    bool limit_reached = 0;
 
     for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
         uint32_t tcp_con_num = con_to->connections[i].tcp_connection;
@@ -494,7 +494,7 @@ int kill_tcp_connection_to(TCP_Connections *tcp_c, int connections_number)
  * return 0 on success.
  * return -1 on failure.
  */
-int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number, _Bool status)
+int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number, bool status)
 {
     TCP_Connection_to *con_to = get_connection(tcp_c, connections_number);
 
@@ -550,7 +550,7 @@ int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number,
     }
 }
 
-static _Bool tcp_connection_in_conn(TCP_Connection_to *con_to, unsigned int tcp_connections_number)
+static bool tcp_connection_in_conn(TCP_Connection_to *con_to, unsigned int tcp_connections_number)
 {
     unsigned int i;
 
@@ -1177,7 +1177,7 @@ unsigned int tcp_copy_connected_relays(TCP_Connections *tcp_c, Node_format *tcp_
  * return 0 on success.
  * return -1 on failure.
  */
-int set_tcp_onion_status(TCP_Connections *tcp_c, _Bool status)
+int set_tcp_onion_status(TCP_Connections *tcp_c, bool status)
 {
     if (tcp_c->onion_status == status)
         return -1;

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -24,6 +24,8 @@
 #ifndef TCP_CONNECTION_H
 #define TCP_CONNECTION_H
 
+#include <stdbool.h>
+
 #include "TCP_client.h"
 
 #define TCP_CONN_NONE 0
@@ -70,12 +72,12 @@ typedef struct {
     uint64_t connected_time;
     uint32_t lock_count;
     uint32_t sleep_count;
-    _Bool onion;
+    bool onion;
 
     /* Only used when connection is sleeping. */
     IP_Port ip_port;
     uint8_t relay_pk[crypto_box_PUBLICKEYBYTES];
-    _Bool unsleep; /* set to 1 to unsleep connection. */
+    bool unsleep; /* set to 1 to unsleep connection. */
 } TCP_con;
 
 typedef struct {
@@ -99,7 +101,7 @@ typedef struct {
 
     TCP_Proxy_Info proxy_info;
 
-    _Bool onion_status;
+    bool onion_status;
     uint16_t onion_num_conns;
 } TCP_Connections;
 
@@ -135,7 +137,7 @@ int tcp_send_onion_request(TCP_Connections *tcp_c, unsigned int tcp_connections_
  * return 0 on success.
  * return -1 on failure.
  */
-int set_tcp_onion_status(TCP_Connections *tcp_c, _Bool status);
+int set_tcp_onion_status(TCP_Connections *tcp_c, bool status);
 
 /* Send an oob packet via the TCP relay corresponding to tcp_connections_number.
  *
@@ -184,7 +186,7 @@ int kill_tcp_connection_to(TCP_Connections *tcp_c, int connections_number);
  * return 0 on success.
  * return -1 on failure.
  */
-int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number, _Bool status);
+int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number, bool status);
 
 /* return number of online tcp relays tied to the connection on success.
  * return 0 on failure.

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -357,7 +357,7 @@ static int send_pending_data(TCP_Secure_Connection *con)
 /* return 0 on failure (only if malloc fails)
  * return 1 on success
  */
-static _Bool add_priority(TCP_Secure_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
+static bool add_priority(TCP_Secure_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
 {
     TCP_Priority_List *p = con->priority_queue_end, *new;
     new = malloc(sizeof(TCP_Priority_List) + size);
@@ -386,12 +386,12 @@ static _Bool add_priority(TCP_Secure_Connection *con, const uint8_t *packet, uin
  * return -1 on failure (connection must be killed).
  */
 static int write_packet_TCP_secure_connection(TCP_Secure_Connection *con, const uint8_t *data, uint16_t length,
-        _Bool priority)
+        bool priority)
 {
     if (length + crypto_box_MACBYTES > MAX_PACKET_SIZE)
         return -1;
 
-    _Bool sendpriority = 1;
+    bool sendpriority = 1;
 
     if (send_pending_data(con) == -1) {
         if (priority) {

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -314,7 +314,7 @@ static int handle_status(void *object, int number, uint8_t status)
     if (!friend_con)
         return -1;
 
-    _Bool call_cb = 0;
+    bool call_cb = 0;
 
     if (status) {  /* Went online. */
         call_cb = 1;

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -97,7 +97,7 @@ typedef struct {
     Node_format tcp_relays[FRIEND_MAX_STORED_TCP_RELAYS];
     uint16_t tcp_relay_counter;
 
-    _Bool hosting_tcp_relay;
+    bool hosting_tcp_relay;
 } Friend_Conn;
 
 

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -404,7 +404,7 @@ static int send_packet_to(Net_Crypto *c, int crypt_connection_id, const uint8_t 
 
     //TODO: on bad networks, direct connections might not last indefinitely.
     if (conn->ip_port.ip.family != 0) {
-        _Bool direct_connected = 0;
+        bool direct_connected = 0;
         crypto_connection_status(c, crypt_connection_id, &direct_connected, NULL);
 
         if (direct_connected) {
@@ -1646,7 +1646,7 @@ int new_crypto_connection(Net_Crypto *c, const uint8_t *real_public_key, const u
  * return -1 on failure.
  * return 0 on success.
  */
-int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, _Bool connected)
+int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, bool connected)
 {
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);
 
@@ -1832,7 +1832,7 @@ static void do_tcp(Net_Crypto *c)
             return;
 
         if (conn->status == CRYPTO_CONN_ESTABLISHED) {
-            _Bool direct_connected = 0;
+            bool direct_connected = 0;
             crypto_connection_status(c, i, &direct_connected, NULL);
 
             if (direct_connected) {
@@ -2154,7 +2154,7 @@ static void send_crypto_packets(Net_Crypto *c)
 /* Return 1 if max speed was reached for this connection (no more data can be physically through the pipe).
  * Return 0 if it wasn't reached.
  */
-_Bool max_speed_reached(Net_Crypto *c, int crypt_connection_id)
+bool max_speed_reached(Net_Crypto *c, int crypt_connection_id)
 {
     return reset_max_speed_reached(c, crypt_connection_id) != 0;
 }
@@ -2330,7 +2330,7 @@ int crypto_kill(Net_Crypto *c, int crypt_connection_id)
  * sets direct_connected to 1 if connection connects directly to other, 0 if it isn't.
  * sets online_tcp_relays to the number of connected tcp relays this connection has.
  */
-unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, _Bool *direct_connected,
+unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, bool *direct_connected,
                                       unsigned int *online_tcp_relays)
 {
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -233,7 +233,7 @@ int new_crypto_connection(Net_Crypto *c, const uint8_t *real_public_key, const u
  * return -1 on failure.
  * return 0 on success.
  */
-int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, _Bool connected);
+int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, bool connected);
 
 /* Set function to be called when connection with crypt_connection_id goes connects/disconnects.
  *
@@ -293,7 +293,7 @@ uint32_t crypto_num_free_sendqueue_slots(const Net_Crypto *c, int crypt_connecti
 /* Return 1 if max speed was reached for this connection (no more data can be physically through the pipe).
  * Return 0 if it wasn't reached.
  */
-_Bool max_speed_reached(Net_Crypto *c, int crypt_connection_id);
+bool max_speed_reached(Net_Crypto *c, int crypt_connection_id);
 
 /* Sends a lossless cryptopacket.
  *
@@ -371,7 +371,7 @@ int crypto_kill(Net_Crypto *c, int crypt_connection_id);
  * sets direct_connected to 1 if connection connects directly to other, 0 if it isn't.
  * sets online_tcp_relays to the number of connected tcp relays this connection has.
  */
-unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, _Bool *direct_connected,
+unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, bool *direct_connected,
                                       unsigned int *online_tcp_relays);
 
 /* Generate our public and private keys.

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -61,7 +61,7 @@ static void ip_pack(uint8_t *data, IP source)
 }
 
 /* return 0 on success, -1 on failure. */
-static int ip_unpack(IP *target, const uint8_t *data, unsigned int data_size, _Bool disable_family_check)
+static int ip_unpack(IP *target, const uint8_t *data, unsigned int data_size, bool disable_family_check)
 {
     if (data_size < (1 + SIZE_IP6))
         return -1;
@@ -89,7 +89,7 @@ static void ipport_pack(uint8_t *data, const IP_Port *source)
 }
 
 /* return 0 on success, -1 on failure. */
-static int ipport_unpack(IP_Port *target, const uint8_t *data, unsigned int data_size, _Bool disable_family_check)
+static int ipport_unpack(IP_Port *target, const uint8_t *data, unsigned int data_size, bool disable_family_check)
 {
     if (data_size < (SIZE_IP + SIZE_PORT))
         return -1;

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -159,7 +159,7 @@ typedef struct {
     uint64_t last_packet_recv;
 
     unsigned int onion_connected;
-    _Bool UDP_connected;
+    bool UDP_connected;
 } Onion_Client;
 
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -128,7 +128,7 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
 
     Messenger_Options m_options = {0};
 
-    _Bool load_savedata_sk = 0, load_savedata_tox = 0;
+    bool load_savedata_sk = false, load_savedata_tox = false;
 
     if (options == NULL) {
         m_options.ipv6enabled = TOX_ENABLE_IPV6_DEFAULT;
@@ -259,19 +259,19 @@ bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *
 {
     if (!address || !public_key) {
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_NULL);
-        return 0;
+        return false;
     }
 
     if (port == 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_BAD_PORT);
-        return 0;
+        return false;
     }
 
     struct addrinfo *root, *info;
 
     if (getaddrinfo(address, NULL, NULL, &root) != 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_BAD_HOST);
-        return 0;
+        return false;
     }
 
     info = root;
@@ -317,12 +317,12 @@ bool tox_add_tcp_relay(Tox *tox, const char *address, uint16_t port, const uint8
 {
     if (!address || !public_key) {
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_NULL);
-        return 0;
+        return false;
     }
 
     if (port == 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_BOOTSTRAP_BAD_PORT);
-        return 0;
+        return false;
     }
 
     struct addrinfo *root, *info;


### PR DESCRIPTION
Since modern C doesn't need the _Bool macro anymore. I've changed some 0
or 1 values to true or false, but not all of them.

The function return values have all changed, as far as I know. Tox compiled fine with me. However, I'm not a very experienced C programmer, so discretion is required. 

Build succeeded, but only one check failed:

```
../auto_tests/tox_test.c:1139:F:many_group:test_many_group:0: Bad number of group peers. expected: 32 got: 9, tox 26
FAIL tox_test (exit status: 1)
```
However, I'm not sure if this failure is related to the changes to stdbool. If someone could point out the mistake I made, feel free to do so.

If there's a reason to use _Bool instead of the new stdbool.h, feel free to close the pull request.

This is not ready for merging yet, since the test fails, but I'm curious about why it failed. If the tox team approves of the change, I'll look more into the error. Or perhaps someone knows the cause already. I got no build errors, but I do when building with `make check`, not with `make`.

Edit: GCC seems to succeed while clang fails