### PR TITLE
Improve documentation about tcp_port

### DIFF
--- a/other/apidsl/tox.in.h
+++ b/other/apidsl/tox.in.h
@@ -431,7 +431,15 @@ static class options {
     uint16_t end_port;
 
     /**
-     * The port to use for the TCP server. If 0, the tcp server is disabled.
+     * The port to use for the TCP server (relay). If 0, the TCP server is
+     * disabled.
+     *
+     * Enabling it is not required for Tox to function properly.
+     *
+     * When enabled, your Tox instance can act as a TCP relay for other Tox
+     * instance. This leads to increased traffic, thus when writing a client
+     * it is recommended to enable TCP server only if the user has an option
+     * to disable it.
      */
     uint16_t tcp_port;
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -451,7 +451,15 @@ struct Tox_Options {
 
 
     /**
-     * The port to use for the TCP server. If 0, the tcp server is disabled.
+     * The port to use for the TCP server (relay). If 0, the TCP server is
+     * disabled.
+     *
+     * Enabling it is not required for Tox to function normally.
+     *
+     * When enabled, your Tox instance can act as a TCP relay for other Tox
+     * instance. This leads to increased traffic, thus when writing a client
+     * it is recommended to enable TCP server only if the user has an option
+     * to disable it.
      */
     uint16_t tcp_port;
 


### PR DESCRIPTION
Apparently it's not entirely clear that it's not needed in clients.