### PR TITLE
Update info for Fedora

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -105,7 +105,11 @@ cd ..
 
 If your default prefix is /usr/local and you happen to get an error that says "error while loading shared libraries: libtoxcore.so.0: cannot open shared object file: No such file or directory", then you can try running ```sudo ldconfig```. If that doesn't fix it, run:
 ```
-echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf // also just adding to /etc/ld.so.conf works
+echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallibs.conf 
+
+OR in the event you have  no locallibs.conf file  run:
+
+echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf 
 sudo ldconfig
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,9 +57,10 @@ sudo apt-get install build-essential libtool autotools-dev automake checkinstall
 On Fedora:
 
 ```bash
-yum groupinstall "Development Tools"
-yum install libtool autoconf automake check check-devel
+dnf groupinstall "Development Tools"
+dnf install libtool autoconf automake check check-devel
 ```
+Using  dnf install @"Development Tools"  is also valid and slightly shorter / cleaner way, also @"Rpm Development Tools"  would carry the remaining dependencies listed here.
 
 On SunOS:
 
@@ -104,7 +105,7 @@ cd ..
 
 If your default prefix is /usr/local and you happen to get an error that says "error while loading shared libraries: libtoxcore.so.0: cannot open shared object file: No such file or directory", then you can try running ```sudo ldconfig```. If that doesn't fix it, run:
 ```
-echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
+echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf // also just adding to /etc/ld.so.conf works
 sudo ldconfig
 ```
 


### PR DESCRIPTION
--Updated calls to package manager which is now  dnf by default 
--Mention of using  /etc/ld.so.conf directly which works and  in most distros *SHOULD NOT* cause  global override issues