### PR TITLE
Opus codec settings

### DIFF
--- a/toxav/codec.c
+++ b/toxav/codec.c
@@ -308,6 +308,7 @@ static int init_audio_encoder(CSSession *cs)
         return -1;
     }
     
+    /* Enable in-band forward error correction in codec */
     rc = opus_encoder_ctl(cs->audio_encoder, OPUS_SET_INBAND_FEC(1));
 
     if ( rc != OPUS_OK ) {
@@ -323,6 +324,7 @@ static int init_audio_encoder(CSSession *cs)
         return -1;
     }
 
+    /* Set algorithm to the highest complexity, maximizing compression */
     rc = opus_encoder_ctl(cs->audio_encoder, OPUS_SET_COMPLEXITY(10));
 
     if ( rc != OPUS_OK ) {

--- a/toxav/codec.c
+++ b/toxav/codec.c
@@ -294,7 +294,7 @@ static int init_audio_encoder(CSSession *cs)
 {
     int rc = OPUS_OK;
     cs->audio_encoder = opus_encoder_create(cs->audio_encoder_sample_rate,
-                                            cs->audio_encoder_channels, OPUS_APPLICATION_AUDIO, &rc);
+                                            cs->audio_encoder_channels, OPUS_APPLICATION_VOIP, &rc);
 
     if ( rc != OPUS_OK ) {
         LOGGER_ERROR("Error while starting audio encoder: %s", opus_strerror(rc));

--- a/toxav/codec.c
+++ b/toxav/codec.c
@@ -307,6 +307,13 @@ static int init_audio_encoder(CSSession *cs)
         LOGGER_ERROR("Error while setting encoder ctl: %s", opus_strerror(rc));
         return -1;
     }
+    
+    rc = opus_encoder_ctl(cs->audio_encoder, OPUS_SET_INBAND_FEC(1));
+
+    if ( rc != OPUS_OK ) {
+        LOGGER_ERROR("Error while setting encoder ctl: %s", opus_strerror(rc));
+        return -1;
+    }
 
     rc = opus_encoder_ctl(cs->audio_encoder, OPUS_SET_COMPLEXITY(10));
 

--- a/toxav/codec.c
+++ b/toxav/codec.c
@@ -315,6 +315,14 @@ static int init_audio_encoder(CSSession *cs)
         return -1;
     }
 
+    /* Make codec resistant to up to 10% packet loss */
+    rc = opus_encoder_ctl(cs->audio_encoder, OPUS_SET_PACKET_LOSS_PERC(10));
+
+    if ( rc != OPUS_OK ) {
+        LOGGER_ERROR("Error while setting encoder ctl: %s", opus_strerror(rc));
+        return -1;
+    }
+
     rc = opus_encoder_ctl(cs->audio_encoder, OPUS_SET_COMPLEXITY(10));
 
     if ( rc != OPUS_OK ) {


### PR DESCRIPTION
Currently, APPLICATION_AUDIO is used, and so audio is not robust to packet loss. Audio decoding appears to be already set up to deal with packet loss, but the encoder is not. These changes should drastically improve audio quality on lossy connections like WiFi.

Note: I am not able to test this code at the moment. I can do so after next week and update this request if necessary.