### PR TITLE
If sodium is installed, then it uses this...

### DIFF
--- a/toxencryptsave/toxencryptsave.c
+++ b/toxencryptsave/toxencryptsave.c
@@ -34,6 +34,10 @@
 #include "crypto_pwhash_scryptsalsa208sha256/crypto_pwhash_scryptsalsa208sha256.h"
 #include "crypto_pwhash_scryptsalsa208sha256/utils.h" /* sodium_memzero */
 #include <crypto_hash_sha256.h>
+#else
+#include <sodium/crypto_pwhash_scryptsalsa208sha256.h>
+#include <sodium/utils.h> /* sodium_memzero */
+#include <sodium/crypto_hash_sha256.h>
 #endif
 
 #if TOX_PASS_SALT_LENGTH != crypto_pwhash_scryptsalsa208sha256_SALTBYTES


### PR DESCRIPTION
... But if not uses the one included.

For some reason, on Fedora, compiling toxcore gives this error:

```
  CC       ../toxav/libtoxav_la-rtp.lo
../toxencryptsave/toxencryptsave.c:40:2: error: #error TOX_PASS_SALT_LENGTH is assumed to be equal to crypto_pwhash_scryptsalsa208sha256_SALTBYTES
 #error TOX_PASS_SALT_LENGTH is assumed to be equal to crypto_pwhash_scryptsalsa208sha256_SALTBYTES
  ^
../toxencryptsave/toxencryptsave.c:48:2: error: #error TOX_PASS_ENCRYPTION_EXTRA_LENGTH is assumed to be equal to (crypto_box_MACBYTES + crypto_box_NONCEBYTES + crypto_pwhash_scryptsalsa208sha256_SALTBYTES + TOX_ENC_SAVE_MAGIC_LENGTH)
 #error TOX_PASS_ENCRYPTION_EXTRA_LENGTH is assumed to be equal to (crypto_box_MACBYTES + crypto_box_NONCEBYTES + crypto_pwhash_scryptsalsa208sha256_SALTBYTES + TOX_ENC_SAVE_MAGIC_LENGT
  ^
../toxencryptsave/toxencryptsave.c: In function 'tox_get_salt':
../toxencryptsave/toxencryptsave.c:70:24: error: 'crypto_pwhash_scryptsalsa208sha256_SALTBYTES' undeclared (first use in this function)
     memcpy(salt, data, crypto_pwhash_scryptsalsa208sha256_SALTBYTES);
                        ^
../toxencryptsave/toxencryptsave.c:70:24: note: each undeclared identifier is reported only once for each function it appears in
../toxencryptsave/toxencryptsave.c: In function 'tox_derive_key_from_pass':
../toxencryptsave/toxencryptsave.c:88:18: error: 'crypto_pwhash_scryptsalsa208sha256_SALTBYTES' undeclared (first use in this function)
     uint8_t salt[crypto_pwhash_scryptsalsa208sha256_SALTBYTES];
```

This means that sodium's definitions are not included, so I added these lines and it worked fine.