### PR TITLE
Fix PACKET_ID_OFFLINE fallinthrough PACKET_ID_NICKNAME

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1930,6 +1930,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
                 break;
 
             set_friend_status(m, i, FRIEND_CONFIRMED);
+            break;
         }
 
         case PACKET_ID_NICKNAME: {


### PR DESCRIPTION
This fixes the PACKET_ID_OFFLINE handling code incorrectly falling through to the PACKET_ID_NICKNAME handling code

This bug resulted in a friend B's name being wiped on friend A's client after B removes A

Fixes tux3/qTox#1967

Fixes #1426