### PR TITLE
change fprintf -> LOGGER_ERROR

### DIFF
--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -196,7 +196,7 @@ bool chloss (const RTPSession *session, const struct RTPHeader *header)
                (session->rsequnum + 65535) - hosq :
                session->rsequnum - hosq;
 
-        fprintf (stderr, "Lost packet\n");
+        LOGGER_ERROR("Lost packet");
 
         while (lost --)
             bwc_add_lost(session->bwc , 0);


### PR DESCRIPTION
toxcore shouldn't print to std* by default, that's what logging is for

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/irungentoo/toxcore/1466)
<!-- Reviewable:end -->
