### PR TITLE
Avoiding conditional directives that split up parts of statements. 

### DIFF
--- a/toxencryptsave/crypto_pwhash_scryptsalsa208sha256/nosse/pwhash_scryptsalsa208sha256_nosse.c
+++ b/toxencryptsave/crypto_pwhash_scryptsalsa208sha256/nosse/pwhash_scryptsalsa208sha256_nosse.c
@@ -257,11 +257,11 @@ escrypt_kdf_nosse(escrypt_local_t * local,
 		errno = EINVAL;
 		return -1;
 	}
-	if ((r > SIZE_MAX / 128 / p) ||
+	int test = (r > SIZE_MAX / 128 / p) || (N > SIZE_MAX / 128 / r);
 #if SIZE_MAX / 256 <= UINT32_MAX
-	    (r > SIZE_MAX / 256) ||
+	test = test || (r > SIZE_MAX / 256);
 #endif
-	    (N > SIZE_MAX / 128 / r)) {
+	if (test) {
 		errno = ENOMEM;
 		return -1;
 	}

--- a/toxencryptsave/crypto_pwhash_scryptsalsa208sha256/scrypt_platform.c
+++ b/toxencryptsave/crypto_pwhash_scryptsalsa208sha256/scrypt_platform.c
@@ -41,13 +41,13 @@ alloc_region(escrypt_region_t * region, size_t size)
 {
 	uint8_t * base, * aligned;
 #ifdef MAP_ANON
-	if ((base = (uint8_t *) mmap(NULL, size, PROT_READ | PROT_WRITE,
+	int flags;
 #ifdef MAP_NOCORE
-	    MAP_ANON | MAP_PRIVATE | MAP_NOCORE,
+	flags = MAP_ANON | MAP_PRIVATE | MAP_NOCORE;
 #else
-	    MAP_ANON | MAP_PRIVATE,
+	flags = MAP_ANON | MAP_PRIVATE;
 #endif
-	    -1, 0)) == MAP_FAILED)
+	if ((base = (uint8_t *) mmap(NULL, size, PROT_READ | PROT_WRITE, flags, -1, 0)) == MAP_FAILED)
 		base = NULL;
 	aligned = base;
 #elif defined(HAVE_POSIX_MEMALIGN)

--- a/toxencryptsave/crypto_pwhash_scryptsalsa208sha256/sse/pwhash_scryptsalsa208sha256_sse.c
+++ b/toxencryptsave/crypto_pwhash_scryptsalsa208sha256/sse/pwhash_scryptsalsa208sha256_sse.c
@@ -345,11 +345,11 @@ escrypt_kdf_sse(escrypt_local_t * local,
 		errno = EINVAL;
 		return -1;
 	}
-	if ((r > SIZE_MAX / 128 / p) ||
+	int test = (r > SIZE_MAX / 128 / p) || (N > SIZE_MAX / 128 / r);
 #if SIZE_MAX / 256 <= UINT32_MAX
-	    (r > SIZE_MAX / 256) ||
-#endif
-	    (N > SIZE_MAX / 128 / r)) {
+	test = test || (r > SIZE_MAX / 256);
+#endif	
+	if (test) {
 		errno = ENOMEM;
 		return -1;
 	}


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.