### PR TITLE
Re-format to reduce Docker image file by ~70%

### DIFF
--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -12,9 +12,10 @@ RUN export BUILD_PACKAGES="\
       git \
       yasm \
       libsodium-dev \
+      libconfig-dev \
       python3" && \
     export RUNTIME_PACKAGES="\
-      libconfig-dev \
+      libconfig9 \
       libsodium13" && \
 # get all deps
     apt-get update && apt-get install -y $BUILD_PACKAGES $RUNTIME_PACKAGES && \
@@ -33,24 +34,21 @@ RUN export BUILD_PACKAGES="\
       --user-group tox-bootstrapd && \
     chmod 700 /var/lib/tox-bootstrapd && \
     cp other/bootstrap_daemon/tox-bootstrapd.conf /etc/tox-bootstrapd.conf && \
+# disable LAN discovery
+    sed -i 's/enable_lan_discovery = true/enable_lan_discovery = false/' /etc/tox-bootstrapd.conf && \
 # remove all the example bootstrap nodes from the config file
-    N=-1 && \
-    while grep -q "bootstrap_nodes =" /etc/tox-bootstrapd.conf; \
-    do \
-      head -n $N other/bootstrap_daemon/tox-bootstrapd.conf > /etc/tox-bootstrapd.conf; \
-      N=$((N-1)); \
-    done && \
+    sed -i '/^bootstrap_nodes = /,$d' /etc/tox-bootstrapd.conf && \
 # add bootstrap nodes from https://nodes.tox.chat/
     python3 other/bootstrap_daemon/docker/get-nodes.py >> /etc/tox-bootstrapd.conf && \
+# perform cleanup
     export AUTO_ADDED_PACKAGES="$(apt-mark showauto)" && \
     apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES && \
-    apt-get install -y $RUNTIME_PACKAGES && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     cd / && \
     rm -rf /tmp/*
 
-WORKDIR /
+WORKDIR /var/lib/tox-bootstrapd
 
 USER tox-bootstrapd
 
@@ -59,5 +57,4 @@ ENTRYPOINT /usr/local/bin/tox-bootstrapd \
              --log-backend stdout \
              --foreground
 
-EXPOSE 443 3389 33445
-EXPOSE 33445/udp
+EXPOSE 443/tcp 3389/tcp 33445/tcp 33445/udp

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -1,7 +1,10 @@
+# install toxcore and daemon
 FROM debian:jessie
 
-# get all deps
-RUN apt-get update && apt-get install -y \
+WORKDIR /tmp/tox
+
+# get all deps, build, install, remove build packages
+RUN export BUILD_PACKAGES="\
       build-essential \
       libtool \
       autotools-dev \
@@ -11,42 +14,40 @@ RUN apt-get update && apt-get install -y \
       git \
       yasm \
       libsodium-dev \
+      python3" && \
+    export RUNTIME_PACKAGES="\
       libconfig-dev \
-      python3 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# install toxcore and daemon
-WORKDIR /root/
-RUN git clone https://github.com/irungentoo/toxcore
-WORKDIR /root/toxcore/
-RUN ./autogen.sh
-RUN ./configure --enable-daemon
-RUN make -j`nproc`
-RUN make install -j`nproc`
-RUN ldconfig
-
-WORKDIR /root/toxcore/other/bootstrap_daemon/
-
-# add new user
-RUN useradd --home-dir /var/lib/tox-bootstrapd --create-home \
+      libsodium13" && \
+    apt-get update && apt-get install -y $BUILD_PACKAGES $RUNTIME_PACKAGES && \
+    git clone https://github.com/irungentoo/toxcore && \
+    cd toxcore && \
+    ./autogen.sh && \
+    ./configure --enable-daemon && \
+    make -j`nproc` && \
+    make install -j`nproc` && \
+    ldconfig && \
+    useradd --home-dir /var/lib/tox-bootstrapd --create-home \
       --system --shell /sbin/nologin \
       --comment "Account to run Tox's DHT bootstrap daemon" \
-      --user-group tox-bootstrapd
-RUN chmod 700 /var/lib/tox-bootstrapd
-
-RUN cp tox-bootstrapd.conf /etc/tox-bootstrapd.conf
-
-# remove all the example bootstrap nodes from the config file
-RUN N=-1 && \
+      --user-group tox-bootstrapd && \
+    chmod 700 /var/lib/tox-bootstrapd && \
+    cp other/bootstrap_daemon/tox-bootstrapd.conf /etc/tox-bootstrapd.conf && \
+    N=-1 && \
     while grep -q "bootstrap_nodes =" /etc/tox-bootstrapd.conf; \
     do \
       head -n $N tox-bootstrapd.conf > /etc/tox-bootstrapd.conf; \
       N=$((N-1)); \
-    done
+    done && \
+    python3 other/bootstrap_daemon/docker/get-nodes.py >> /etc/tox-bootstrapd.conf && \
+    export AUTO_ADDED_PACKAGES="$(apt-mark showauto)" && \
+    apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES && \
+    apt-get install -y $RUNTIME_PACKAGES && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    cd / && \
+    rm -rf /tmp/*
 
-# add bootstrap nodes from https://nodes.tox.chat/
-RUN python3 docker/get-nodes.py >> /etc/tox-bootstrapd.conf
+WORKDIR /
 
 USER tox-bootstrapd
 

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -38,10 +38,10 @@ RUN export BUILD_PACKAGES="\
     N=-1 && \
     while grep -q "bootstrap_nodes =" /etc/tox-bootstrapd.conf; \
     do \
-      head -n $N cp other/bootstrap_daemon/tox-bootstrapd.conf > /etc/tox-bootstrapd.conf; \
+      head -n $N other/bootstrap_daemon/tox-bootstrapd.conf > /etc/tox-bootstrapd.conf; \
       N=$((N-1)); \
     done && \
-  echo "add bootstrap nodes from https://nodes.tox.chat/" && \
+  echo " === add bootstrap nodes from https://nodes.tox.chat/ === " && \
     python3 other/bootstrap_daemon/docker/get-nodes.py >> /etc/tox-bootstrapd.conf && \
     export AUTO_ADDED_PACKAGES="$(apt-mark showauto)" && \
     apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES && \

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -2,7 +2,6 @@ FROM debian:jessie
 
 WORKDIR /tmp/tox
 
-# get all deps, build, install, remove build packages
 RUN export BUILD_PACKAGES="\
       build-essential \
       libtool \
@@ -17,9 +16,9 @@ RUN export BUILD_PACKAGES="\
     export RUNTIME_PACKAGES="\
       libconfig-dev \
       libsodium13" && \
-  echo " === get all deps === " && \
+# get all deps
     apt-get update && apt-get install -y $BUILD_PACKAGES $RUNTIME_PACKAGES && \
-  echo " === install toxcore and daemon === " && \
+# install toxcore and daemon
     git clone https://github.com/irungentoo/toxcore && \
     cd toxcore && \
     ./autogen.sh && \
@@ -27,21 +26,21 @@ RUN export BUILD_PACKAGES="\
     make -j`nproc` && \
     make install -j`nproc` && \
     ldconfig && \
-  echo " === add new user === " && \
+# add new user
     useradd --home-dir /var/lib/tox-bootstrapd --create-home \
       --system --shell /sbin/nologin \
       --comment "Account to run Tox's DHT bootstrap daemon" \
       --user-group tox-bootstrapd && \
     chmod 700 /var/lib/tox-bootstrapd && \
     cp other/bootstrap_daemon/tox-bootstrapd.conf /etc/tox-bootstrapd.conf && \
-  echo " === remove all the example bootstrap nodes from the config file === " && \
+# remove all the example bootstrap nodes from the config file
     N=-1 && \
     while grep -q "bootstrap_nodes =" /etc/tox-bootstrapd.conf; \
     do \
       head -n $N other/bootstrap_daemon/tox-bootstrapd.conf > /etc/tox-bootstrapd.conf; \
       N=$((N-1)); \
     done && \
-  echo " === add bootstrap nodes from https://nodes.tox.chat/ === " && \
+# add bootstrap nodes from https://nodes.tox.chat/
     python3 other/bootstrap_daemon/docker/get-nodes.py >> /etc/tox-bootstrapd.conf && \
     export AUTO_ADDED_PACKAGES="$(apt-mark showauto)" && \
     apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES && \

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -34,8 +34,6 @@ RUN export BUILD_PACKAGES="\
       --user-group tox-bootstrapd && \
     chmod 700 /var/lib/tox-bootstrapd && \
     cp other/bootstrap_daemon/tox-bootstrapd.conf /etc/tox-bootstrapd.conf && \
-# disable LAN discovery
-    sed -i 's/enable_lan_discovery = true/enable_lan_discovery = false/' /etc/tox-bootstrapd.conf && \
 # remove all the example bootstrap nodes from the config file
     sed -i '/^bootstrap_nodes = /,$d' /etc/tox-bootstrapd.conf && \
 # add bootstrap nodes from https://nodes.tox.chat/

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -1,4 +1,3 @@
-# install toxcore and daemon
 FROM debian:jessie
 
 WORKDIR /tmp/tox
@@ -18,7 +17,9 @@ RUN export BUILD_PACKAGES="\
     export RUNTIME_PACKAGES="\
       libconfig-dev \
       libsodium13" && \
+  echo " === get all deps === " && \
     apt-get update && apt-get install -y $BUILD_PACKAGES $RUNTIME_PACKAGES && \
+  echo " === install toxcore and daemon === " && \
     git clone https://github.com/irungentoo/toxcore && \
     cd toxcore && \
     ./autogen.sh && \
@@ -26,18 +27,21 @@ RUN export BUILD_PACKAGES="\
     make -j`nproc` && \
     make install -j`nproc` && \
     ldconfig && \
+  echo " === add new user === " && \
     useradd --home-dir /var/lib/tox-bootstrapd --create-home \
       --system --shell /sbin/nologin \
       --comment "Account to run Tox's DHT bootstrap daemon" \
       --user-group tox-bootstrapd && \
     chmod 700 /var/lib/tox-bootstrapd && \
     cp other/bootstrap_daemon/tox-bootstrapd.conf /etc/tox-bootstrapd.conf && \
+  echo " === remove all the example bootstrap nodes from the config file === " && \
     N=-1 && \
     while grep -q "bootstrap_nodes =" /etc/tox-bootstrapd.conf; \
     do \
       head -n $N cp other/bootstrap_daemon/tox-bootstrapd.conf > /etc/tox-bootstrapd.conf; \
       N=$((N-1)); \
     done && \
+  echo "add bootstrap nodes from https://nodes.tox.chat/" && \
     python3 other/bootstrap_daemon/docker/get-nodes.py >> /etc/tox-bootstrapd.conf && \
     export AUTO_ADDED_PACKAGES="$(apt-mark showauto)" && \
     apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES && \

--- a/other/bootstrap_daemon/docker/Dockerfile
+++ b/other/bootstrap_daemon/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN export BUILD_PACKAGES="\
     N=-1 && \
     while grep -q "bootstrap_nodes =" /etc/tox-bootstrapd.conf; \
     do \
-      head -n $N tox-bootstrapd.conf > /etc/tox-bootstrapd.conf; \
+      head -n $N cp other/bootstrap_daemon/tox-bootstrapd.conf > /etc/tox-bootstrapd.conf; \
       N=$((N-1)); \
     done && \
     python3 other/bootstrap_daemon/docker/get-nodes.py >> /etc/tox-bootstrapd.conf && \


### PR DESCRIPTION
Dockerfile has been re-formatted and image being built to reduce its' size from ~442.2MB to ~188.3MB. Idea is in leaving only one RUN statement, and inside it to perform build, install and cleanup. Change also cleans up build dependencies.