### PR TITLE
Add missing files so that archive for make dist is complete

### DIFF
--- a/other/bootstrap_daemon/src/Makefile.inc
+++ b/other/bootstrap_daemon/src/Makefile.inc
@@ -11,6 +11,7 @@ tox_bootstrapd_SOURCES = \
                         ../other/bootstrap_daemon/src/log.c \
                         ../other/bootstrap_daemon/src/log.h \
                         ../other/bootstrap_daemon/src/tox-bootstrapd.c \
+                        ../other/bootstrap_daemon/src/global.h \
                         ../other/bootstrap_node_packets.c \
                         ../other/bootstrap_node_packets.h
 

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -50,7 +50,8 @@ libtoxcore_la_SOURCES = ../toxcore/DHT.h \
                         ../toxcore/TCP_connection.c \
                         ../toxcore/list.c \
                         ../toxcore/list.h \
-                        ../toxcore/misc_tools.h
+                        ../toxcore/misc_tools.h \
+                        ../toxcore/tox_old_code.h
 
 libtoxcore_la_CFLAGS =  -I$(top_srcdir) \
                         -I$(top_srcdir)/toxcore \

--- a/toxencryptsave/Makefile.inc
+++ b/toxencryptsave/Makefile.inc
@@ -6,7 +6,8 @@ libtoxencryptsave_la_include_HEADERS = \
 libtoxencryptsave_la_includedir = $(includedir)/tox
 
 libtoxencryptsave_la_SOURCES = ../toxencryptsave/toxencryptsave.h \
-                        ../toxencryptsave/toxencryptsave.c
+                        ../toxencryptsave/toxencryptsave.c \
+                        ../toxencryptsave/defines.h
 
 
 if WITH_NACL


### PR DESCRIPTION
Currently archive created by `make dist` is incomplete.

Test to be run inside a repository clone:
```bash
#!/bin/sh

set -e -x

DIST=tox-0.0.0.tar.gz

./autogen.sh
./configure --prefix=/usr --enable-daemon
make dist

UNPACK_DIR=$(mktemp -d)
trap "rm -rf '$UNPACK_DIR'" EXIT

tar xf $DIST -C"$UNPACK_DIR/"
pushd "$UNPACK_DIR/$(basename $DIST .tar.gz)"
./configure --prefix=/usr --enable-daemon
make
popd

echo "OK"
```