### PR TITLE
Remove addr_resolve magic numbers

### DIFF
--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -28,7 +28,7 @@ START_TEST(test_addr_resolv_localhost)
     int localhost_split = 0;
 
     IP ip;
-    ip_init(&ip, /* ipv6? */ 0);
+    ip_init(&ip, 0); // ipv6enabled = 0
 
     int res = addr_resolve(localhost, &ip, NULL);
 
@@ -39,7 +39,7 @@ START_TEST(test_addr_resolv_localhost)
         ck_assert_msg(ip.ip4.uint32 == htonl(0x7F000001), "Expected 127.0.0.1, got %s.", inet_ntoa(ip.ip4.in_addr));
     }
 
-    ip_init(&ip, /* ipv6? */ 1);
+    ip_init(&ip, 1); // ipv6enabled = 1
     res = addr_resolve(localhost, &ip, NULL);
 
     if (!(res & TOX_ADDR_RESOLVE_INET6)) {
@@ -55,7 +55,7 @@ START_TEST(test_addr_resolv_localhost)
     }
 
     if (!localhost_split) {
-        ip_init(&ip, /* ipv6? */ 1);
+        ip_init(&ip, 1); // ipv6enabled = 1
         ip.family = AF_UNSPEC;
         IP extra;
         ip_reset(&extra);

--- a/auto_tests/network_test.c
+++ b/auto_tests/network_test.c
@@ -144,7 +144,7 @@ Suite *network_suite(void)
     return s;
 }
 
-int main(int argc, char *argv[])
+int main()
 {
     srand((unsigned int) time(NULL));
 

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -970,9 +970,9 @@ int addr_resolve(const char *address, IP *to, IP *extra)
     }
 
     IP ip4;
-    ip_init(&ip4, /* ipv6? */ false);
+    ip_init(&ip4, 0); // ipv6enabled = 0
     IP ip6;
-    ip_init(&ip6, /* ipv6? */ true);
+    ip_init(&ip6, 1); // ipv6enabled = 1
 
     for (walker = server; (walker != NULL) && !done; walker = walker->ai_next) {
         switch (walker->ai_family) {

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -939,7 +939,7 @@ int addr_parse_ip(const char *address, IP *to)
  * returns in *to a valid IPAny (v4/v6),
  *     prefers v6 if ip.family was AF_UNSPEC and both available
  * returns in *extra an IPv4 address, if family was AF_UNSPEC and *to is AF_INET6
- * returns 0 on failure
+ * returns 0 on failure, TOX_ADDR_RESOLVE_* on success.
  */
 int addr_resolve(const char *address, IP *to, IP *extra)
 {
@@ -951,7 +951,9 @@ int addr_resolve(const char *address, IP *to, IP *extra)
     struct addrinfo *server = NULL;
     struct addrinfo *walker = NULL;
     struct addrinfo  hints;
-    int              rc;
+    int rc;
+    int result = 0;
+    int done = 0;
 
     memset(&hints, 0, sizeof(hints));
     hints.ai_family   = family;
@@ -972,17 +974,18 @@ int addr_resolve(const char *address, IP *to, IP *extra)
     IP ip6;
     ip_init(&ip6, /* ipv6? */ true);
 
-    for (walker = server; (walker != NULL) && (rc != 3); walker = walker->ai_next) {
+    for (walker = server; (walker != NULL) && !done; walker = walker->ai_next) {
         switch (walker->ai_family) {
             case AF_INET:
                 if (walker->ai_family == family) { /* AF_INET requested, done */
                     struct sockaddr_in *addr = (struct sockaddr_in *)walker->ai_addr;
                     to->ip4.in_addr = addr->sin_addr;
-                    rc = 3; // TODO do we really have to reuse variable instead of creating a new one?
-                } else if (!(rc & 1)) { /* AF_UNSPEC requested, store away */
+                    result = TOX_ADDR_RESOLVE_INET;
+                    done = 1;
+                } else if (!(result & TOX_ADDR_RESOLVE_INET)) { /* AF_UNSPEC requested, store away */
                     struct sockaddr_in *addr = (struct sockaddr_in *)walker->ai_addr;
                     ip4.ip4.in_addr = addr->sin_addr;
-                    rc |= 1; // FIXME magic number
+                    result |= TOX_ADDR_RESOLVE_INET;
                 }
 
                 break; /* switch */
@@ -992,13 +995,14 @@ int addr_resolve(const char *address, IP *to, IP *extra)
                     if (walker->ai_addrlen == sizeof(struct sockaddr_in6)) {
                         struct sockaddr_in6 *addr = (struct sockaddr_in6 *)walker->ai_addr;
                         to->ip6.in6_addr = addr->sin6_addr;
-                        rc = 3;
+                        result = TOX_ADDR_RESOLVE_INET6;
+                        done = 1;
                     }
-                } else if (!(rc & 2)) { /* AF_UNSPEC requested, store away */
+                } else if (!(result & TOX_ADDR_RESOLVE_INET6)) { /* AF_UNSPEC requested, store away */
                     if (walker->ai_addrlen == sizeof(struct sockaddr_in6)) {
                         struct sockaddr_in6 *addr = (struct sockaddr_in6 *)walker->ai_addr;
                         ip6.ip6.in6_addr = addr->sin6_addr;
-                        rc |= 2;
+                        result |= TOX_ADDR_RESOLVE_INET6;
                     }
                 }
 
@@ -1006,21 +1010,22 @@ int addr_resolve(const char *address, IP *to, IP *extra)
         }
     }
 
-    if (to->family == AF_UNSPEC) {
-        if (rc & 2) { // FIXME magic number
+    if (family == AF_UNSPEC) {
+        if (result & TOX_ADDR_RESOLVE_INET6) {
             ip_copy(to, &ip6);
 
-            if ((rc & 1) && (extra != NULL)) {
+            if ((result & TOX_ADDR_RESOLVE_INET) && (extra != NULL)) {
                 ip_copy(extra, &ip4);
             }
-        } else if (rc & 1) {
+        } else if (result & TOX_ADDR_RESOLVE_INET) {
             ip_copy(to, &ip4);
-        } else
-            rc = 0;
+        } else {
+            result = 0;
+        }
     }
 
     freeaddrinfo(server);
-    return rc;
+    return result;
 }
 
 /*

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -176,6 +176,10 @@ IP_Port;
 
 #define TOX_ENABLE_IPV6_DEFAULT 1
 
+/* addr_resolve return values */
+#define TOX_ADDR_RESOLVE_INET  1
+#define TOX_ADDR_RESOLVE_INET6 2
+
 /* ip_ntoa
  *   converts ip into a string
  *   uses a static buffer, so mustn't used multiple times in the same output


### PR DESCRIPTION
As I was figuring the reason `network_test` failed on my Fedora box (TL;DR: [#496300](https://bugzilla.redhat.com/show_bug.cgi?id=496300), Fedora does not ship `::1 localhost` in `/etc/hosts`), I stumbled upon `addr_resolve` code, which was reusing the `rc` from `getaddrinfo` and assigning values 1, 2, and 3 for AF_INET result, AF_INET6 result, and a flag that exact match was found respectively. It took me a while to understand what's going on, so I decided to introduce the following replacements for magic numbers:
```
/* addr_resolve return values */
#define TOX_ADDR_RESOLVE_INET  1
#define TOX_ADDR_RESOLVE_INET6 2
```

`3` was removed, since the return value is only checked in the test, and the latter does not care about the `3` case. `3` will be returned when the address resolved to both AF_INET and AF_INET6.

Also updated the `network_test.c` which is still broken on Fedora in default configuration (and result may depend on upstream resolver configuration).