### PR TITLE
Add support for proxy username/password authentication

### DIFF
--- a/other/apidsl/tox.in.h
+++ b/other/apidsl/tox.in.h
@@ -277,6 +277,11 @@ const FILE_ID_LENGTH              = 32;
  */
 const MAX_FILENAME_LENGTH         = 255;
 
+/**
+ * Maximum username/password length for proxy authentication.
+ */
+const MAX_PROXY_USER_PASS_LENGTH  = 255;
+
 
 /*******************************************************************************
  *
@@ -417,6 +422,30 @@ static class options {
        * proxy_type is TOX_PROXY_TYPE_NONE.
        */
       uint16_t port;
+
+      /**
+       * The username to be used to authenticate.
+       *
+       * If used, this must be non-NULL. The name must not
+       * exceed MAX_PROXY_USER_PASS_LENGTH characters, and be in a NUL-terminated C string format
+       * (MAX_PROXY_USER_PASS_LENGTH chars + 1 NUL byte).
+       *
+       * This member and password must be non-NULL in order to use username/password authentication.
+       * If either of these members are NULL, they are ignored and connecting to the proxy will be attempted without authentication.
+       */
+      string username;
+
+      /**
+       * The password to be used to authenticate.
+       *
+       * If used, this must be non-NULL. The name must not
+       * exceed MAX_PROXY_USER_PASS_LENGTH characters, and be in a NUL-terminated C string format
+       * (MAX_PROXY_USER_PASS_LENGTH chars + 1 NUL byte).
+       *
+       * This member and username must be non-NULL in order to use username/password authentication.
+       * If either of these members are NULL, they are ignored and connecting to the proxy will be attempted without authentication.
+       */
+      string password;
     }
 
     /**
@@ -563,6 +592,14 @@ static this new(const options_t *options) {
      * proxy_type was valid, but the proxy_port was invalid.
      */
     BAD_PORT,
+    /**
+     * The username passed exceeded the maximum length of MAX_PROXY_USER_PASS_LENGTH characters.
+     */
+    BAD_USERNAME,
+    /**
+     * The password passed exceeded the maximum length of MAX_PROXY_USER_PASS_LENGTH characters.
+     */
+    BAD_PASSWORD,
     /**
      * The proxy address passed could not be resolved.
      */

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -128,12 +128,22 @@ static int proxy_http_read_connection_response(TCP_Client_Connection *TCP_conn)
 
     return -1;
 }
-
 static void proxy_socks5_generate_handshake(TCP_Client_Connection *TCP_conn)
 {
     TCP_conn->last_packet[0] = 5; /* SOCKSv5 */
     TCP_conn->last_packet[1] = 1; /* number of authentication methods supported */
-    TCP_conn->last_packet[2] = 0; /* No authentication */
+
+    /*
+      if the client specified a username and password, we should only try to auth with that
+
+      this can be important because tor (for example) makes sure circuits aren't shared 
+      between streams for which different credentials were provided 
+    */
+    if (TCP_conn->proxy_info.username != NULL && TCP_conn->proxy_info.password != NULL) {
+        TCP_conn->last_packet[2] = 2; /* Username/password authentication */
+    } else {
+        TCP_conn->last_packet[2] = 0; /* No authentication */
+    }
 
     TCP_conn->last_packet_length = 3;
     TCP_conn->last_packet_sent = 0;
@@ -151,7 +161,7 @@ static int socks5_read_handshake_response(TCP_Client_Connection *TCP_conn)
     if (ret == -1)
         return 0;
 
-    if (data[0] == 5 && data[1] == 0) // FIXME magic numbers
+    if (data[0] == 5 && (data[1] == 0 || data[1] == 2)) // FIXME magic numbers
         return 1;
 
     return -1;
@@ -183,6 +193,28 @@ static void proxy_socks5_generate_connection_request(TCP_Client_Connection *TCP_
     TCP_conn->last_packet_sent = 0;
 }
 
+static void proxy_socks5_generate_auth_request(TCP_Client_Connection *TCP_conn)
+{
+    uint8_t username_len = strlen(TCP_conn->proxy_info.username);
+    uint8_t password_len = strlen(TCP_conn->proxy_info.password);
+
+    TCP_conn->last_packet[0] = 1; //version of the subnegotiation
+    TCP_conn->last_packet[1] = username_len;
+    uint16_t length = 2;
+
+    memcpy(TCP_conn->last_packet + length, TCP_conn->proxy_info.username, username_len);
+    length += username_len;
+
+    TCP_conn->last_packet[length] = password_len;
+    length++;
+
+    memcpy(TCP_conn->last_packet + length, TCP_conn->proxy_info.password, password_len);
+    length += password_len;
+
+    TCP_conn->last_packet_length = length;
+    TCP_conn->last_packet_sent = 0;
+}
+
 /* return 1 on success.
  * return 0 if no data received.
  * return -1 on failure (connection refused).
@@ -209,6 +241,24 @@ static int proxy_socks5_read_connection_response(TCP_Client_Connection *TCP_conn
         if (data[0] == 5 && data[1] == 0)
             return 1;
     }
+
+    return -1;
+}
+
+/* return 1 on success.
+ * return 0 if no data received.
+ * return -1 on failure (connection refused).
+ */
+static int proxy_socks5_read_auth_response(TCP_Client_Connection *TCP_conn)
+{
+    uint8_t data[2];
+    int ret = read_TCP_packet(TCP_conn->sock, data, sizeof(data));
+
+    if (ret == -1)
+        return 0;
+
+    if (data[0] == 1 && data[1] == 0)
+        return 1;
 
     return -1;
 }
@@ -901,8 +951,13 @@ void do_TCP_connection(TCP_Client_Connection *TCP_connection)
             }
 
             if (ret == 1) {
-                proxy_socks5_generate_connection_request(TCP_connection);
-                TCP_connection->status = TCP_CLIENT_PROXY_SOCKS5_UNCONFIRMED;
+                if (TCP_connection->proxy_info.username != NULL && TCP_connection->proxy_info.password != NULL) {
+                    proxy_socks5_generate_auth_request(TCP_connection);
+                    TCP_connection->status = TCP_CLIENT_PROXY_SOCKS5_AUTH;
+                } else {
+                    proxy_socks5_generate_connection_request(TCP_connection);
+                    TCP_connection->status = TCP_CLIENT_PROXY_SOCKS5_UNCONFIRMED; 
+                }
             }
         }
     }
@@ -919,6 +974,22 @@ void do_TCP_connection(TCP_Client_Connection *TCP_connection)
             if (ret == 1) {
                 generate_handshake(TCP_connection);
                 TCP_connection->status = TCP_CLIENT_CONNECTING;
+            }
+        }
+    }
+
+    if (TCP_connection->status == TCP_CLIENT_PROXY_SOCKS5_AUTH) {
+        if (send_pending_data(TCP_connection) ==0) {
+            int ret = proxy_socks5_read_auth_response(TCP_connection);
+
+            if (ret == -1) {
+                TCP_connection->kill_at = 0;
+                TCP_connection->status = TCP_CLIENT_DISCONNECTED;
+            }
+
+            if (ret == 1) {
+                proxy_socks5_generate_connection_request(TCP_connection);
+                TCP_connection->status = TCP_CLIENT_PROXY_SOCKS5_UNCONFIRMED;
             }
         }
     }

--- a/toxcore/TCP_client.h
+++ b/toxcore/TCP_client.h
@@ -38,6 +38,8 @@ typedef enum {
 typedef struct {
     IP_Port ip_port;
     uint8_t proxy_type; // a value from TCP_PROXY_TYPE
+    const char *username;
+    const char *password;
 } TCP_Proxy_Info;
 
 enum {
@@ -45,6 +47,7 @@ enum {
     TCP_CLIENT_PROXY_HTTP_CONNECTING,
     TCP_CLIENT_PROXY_SOCKS5_CONNECTING,
     TCP_CLIENT_PROXY_SOCKS5_UNCONFIRMED,
+    TCP_CLIENT_PROXY_SOCKS5_AUTH,
     TCP_CLIENT_CONNECTING,
     TCP_CLIENT_UNCONFIRMED,
     TCP_CLIENT_CONFIRMED,

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -194,6 +194,18 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
                 return NULL;
             }
 
+            if (options->proxy_username != NULL && options->proxy_password != NULL) {
+                if (strlen(options->proxy_username) > TOX_MAX_PROXY_USER_PASS_LENGTH) {
+                    SET_ERROR_PARAMETER(error, TOX_ERR_NEW_PROXY_BAD_USERNAME);
+                    return NULL;
+                }
+
+                if (strlen(options->proxy_password) > TOX_MAX_PROXY_USER_PASS_LENGTH) {
+                    SET_ERROR_PARAMETER(error, TOX_ERR_NEW_PROXY_BAD_PASSWORD);
+                    return NULL;
+                }
+            }
+
             ip_init(&m_options.proxy_info.ip_port.ip, m_options.ipv6enabled);
 
             if (m_options.ipv6enabled)
@@ -206,6 +218,8 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
             }
 
             m_options.proxy_info.ip_port.port = htons(options->proxy_port);
+            m_options.proxy_info.username = options->proxy_username;
+            m_options.proxy_info.password = options->proxy_password;
         }
     }
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -274,6 +274,11 @@ bool tox_version_is_compatible(uint32_t major, uint32_t minor, uint32_t patch);
  */
 #define TOX_MAX_FILENAME_LENGTH        255
 
+/**
+ * Maximum username/password length for proxy authentication.
+ */
+#define TOX_MAX_PROXY_USER_PASS_LENGTH 255
+
 
 /*******************************************************************************
  *
@@ -439,6 +444,32 @@ struct Tox_Options {
 
 
     /**
+     * The username to be used to authenticate.
+     *
+     * If used, this must be non-NULL. The name must not
+     * exceed MAX_PROXY_USER_PASS_LENGTH characters, and be in a NUL-terminated C string format
+     * (MAX_PROXY_USER_PASS_LENGTH chars + 1 NUL byte).
+     *
+     * This member and password must be non-NULL in order to use username/password authentication.
+     * If either of these members are NULL, they are ignored and connecting to the proxy will be attempted without authentication.
+     */
+    const char *proxy_username;
+
+
+    /**
+     * The password to be used to authenticate.
+     *
+     * If used, this must be non-NULL. The name must not
+     * exceed MAX_PROXY_USER_PASS_LENGTH characters, and be in a NUL-terminated C string format
+     * (MAX_PROXY_USER_PASS_LENGTH chars + 1 NUL byte).
+     *
+     * This member and username must be non-NULL in order to use username/password authentication.
+     * If either of these members are NULL, they are ignored and connecting to the proxy will be attempted without authentication.
+     */
+    const char *proxy_password;
+
+
+    /**
      * The start port of the inclusive port range to attempt to use.
      *
      * If both start_port and end_port are 0, the default port range will be
@@ -590,6 +621,16 @@ typedef enum TOX_ERR_NEW {
      * proxy_type was valid, but the proxy_port was invalid.
      */
     TOX_ERR_NEW_PROXY_BAD_PORT,
+
+    /**
+     * The username passed exceeded the maximum length of MAX_PROXY_USER_PASS_LENGTH characters.
+     */
+    TOX_ERR_NEW_PROXY_BAD_USERNAME,
+
+    /**
+     * The password passed exceeded the maximum length of MAX_PROXY_USER_PASS_LENGTH characters.
+     */
+    TOX_ERR_NEW_PROXY_BAD_PASSWORD,
 
     /**
      * The proxy address passed could not be resolved.


### PR DESCRIPTION
Progress:
- [x] SOCKS5
- [ ] HTTP

Figured I'd submit this in advance so you guys can take a look and scrutinize my horrid C skills if needed.