### PR TITLE
add missing header to dist tarball

### DIFF
--- a/auto_tests/Makefile.inc
+++ b/auto_tests/Makefile.inc
@@ -107,4 +107,5 @@ encryptsave_test_CFLAGS = $(AUTOTEST_CFLAGS)
 encryptsave_test_LDADD = $(AUTOTEST_LDADD)
 
 
-EXTRA_DIST += $(top_srcdir)/auto_tests/friends_test.c
+EXTRA_DIST += $(top_srcdir)/auto_tests/friends_test.c \
+              $(top_srcdir)/auto_tests/helpers.h


### PR DESCRIPTION
tried to `make distcheck`. ran into this.